### PR TITLE
Fix Windows SmartScreen warning for Electron app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Build Electron app
         run: npm run ${{ matrix.build_script }}
         env:
-          # Disable code signing for now (add certificates later)
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Code signing configuration (signs only if secrets are set)
+          CSC_LINK: ${{ matrix.platform == 'win' && secrets.WIN_CSC_LINK || matrix.platform == 'mac' && secrets.MAC_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WIN_CSC_KEY_PASSWORD || matrix.platform == 'mac' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
+          # Auto-discovery will enable signing if CSC_LINK is set
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ (matrix.platform == 'win' && secrets.WIN_CSC_LINK != '' && 'true') || (matrix.platform == 'mac' && secrets.MAC_CSC_LINK != '' && 'true') || 'false' }}
 
       - name: Generate checksums (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,10 @@ jobs:
       - name: Build Windows app
         run: npm run package:win
         env:
-          # TODO: Add code signing certificate
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Code signing configuration (signs if secrets are set)
+          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.WIN_CSC_LINK != '' && 'true' || 'false' }}
 
       - name: Generate checksums
         shell: powershell
@@ -185,8 +187,13 @@ jobs:
       - name: Build macOS app
         run: npm run package:mac
         env:
-          # TODO: Add code signing certificate
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Code signing configuration (signs if secrets are set)
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.MAC_CSC_LINK != '' && 'true' || 'false' }}
 
       - name: Generate checksums
         run: |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ If Docker Desktop isn't installed, the app provides a comprehensive step-by-step
 **For Developers:**
 - **[Architecture](docs/ARCHITECTURE.md)** - Technical architecture overview
 - **[Contributing](docs/CONTRIBUTING.md)** - How to contribute to the project
-- **[Release Process](docs/RELEASE-PROCESS.md)** - How releases are created
+- **[Creating Releases](docs/CREATING_RELEASES.md)** - How to create and publish releases
+- **[Code Signing](docs/CODE_SIGNING.md)** - Setting up code signing certificates
 
 **Additional Resources:**
 - **[Video Tutorial Script](docs/VIDEO-SCRIPT.md)** - Guide for creating tutorial videos
@@ -397,7 +398,7 @@ The release workflow will automatically:
 - Create a GitHub Release
 - Upload all installers and checksums
 
-See [RELEASE.md](RELEASE.md) for detailed release instructions.
+See [docs/CREATING_RELEASES.md](docs/CREATING_RELEASES.md) for detailed release instructions.
 
 ### Contributing
 

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -1,0 +1,356 @@
+# Code Signing Guide
+
+This document explains how to set up code signing for the MCP Electron App to eliminate Windows SmartScreen warnings and improve user trust.
+
+## Table of Contents
+
+- [Why Code Signing?](#why-code-signing)
+- [Windows Code Signing](#windows-code-signing)
+- [macOS Code Signing](#macos-code-signing)
+- [CI/CD Configuration](#cicd-configuration)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+
+## Why Code Signing?
+
+### The Problem
+
+When users download and run your Electron app without code signing, they encounter security warnings:
+
+**Windows SmartScreen:**
+```
+Windows protected your PC
+Microsoft Defender SmartScreen prevented an unrecognized app from starting.
+Running this app might put your PC at risk.
+
+Publisher: Unknown publisher
+```
+
+**macOS Gatekeeper:**
+```
+"MCP Electron App" cannot be opened because the developer cannot be verified.
+```
+
+### The Solution
+
+Code signing digitally signs your application with a certificate that:
+- Verifies your identity as the publisher
+- Ensures the app hasn't been tampered with
+- Builds trust with operating system security features
+- Eliminates scary security warnings for users
+
+## Windows Code Signing
+
+### 1. Obtain a Code Signing Certificate
+
+You need an **EV (Extended Validation)** or **OV (Organization Validation)** code signing certificate from a trusted Certificate Authority (CA).
+
+#### Recommended Certificate Authorities:
+
+| Provider | Type | Approximate Cost | SmartScreen Reputation |
+|----------|------|-----------------|----------------------|
+| **DigiCert** | EV Code Signing | $400-500/year | Immediate (EV certs bypass SmartScreen) |
+| **Sectigo** | EV Code Signing | $300-400/year | Immediate (EV certs bypass SmartScreen) |
+| **SSL.com** | OV Code Signing | $200-300/year | Requires reputation building |
+| **Certum** | OV Code Signing | $100-200/year | Requires reputation building |
+
+#### Important Notes:
+
+- **EV certificates** (more expensive) bypass SmartScreen immediately because they require hardware tokens
+- **OV certificates** (less expensive) require building "reputation" with Microsoft:
+  - Need thousands of downloads/installations over time
+  - Users will still see warnings initially
+  - Reputation builds as more users safely run your app
+
+### 2. Certificate Formats
+
+Windows code signing certificates come in different formats:
+
+- **PFX/P12 file** (most common for CI/CD)
+- **Hardware token** (USB device, required for EV certificates)
+- **Cloud HSM** (Azure Key Vault, DigiCert ONE, etc.)
+
+For CI/CD pipelines, you'll need the certificate in **PFX format** with a password.
+
+### 3. Configure GitHub Secrets
+
+Add these secrets to your GitHub repository (Settings → Secrets and variables → Actions):
+
+```
+WIN_CSC_LINK          # Base64-encoded PFX certificate
+WIN_CSC_KEY_PASSWORD  # Certificate password
+```
+
+#### Encoding your certificate:
+
+**On Windows (PowerShell):**
+```powershell
+$cert = [Convert]::ToBase64String([IO.File]::ReadAllBytes("path\to\your\certificate.pfx"))
+$cert | Out-File -FilePath encoded-cert.txt
+```
+
+**On macOS/Linux:**
+```bash
+base64 -i certificate.pfx -o encoded-cert.txt
+# Or in one line:
+cat certificate.pfx | base64
+```
+
+Copy the contents of `encoded-cert.txt` and add it as the `WIN_CSC_LINK` secret.
+
+### 4. Configuration Details
+
+The `package.json` has been configured with:
+
+```json
+"win": {
+  "publisherName": "MCP Team",
+  "certificateSubjectName": "MCP Team",
+  "signingHashAlgorithms": ["sha256"],
+  "signDlls": true,
+  "rfc3161TimeStampServer": "http://timestamp.digicert.com"
+}
+```
+
+**Important:** Update `"publisherName"` and `"certificateSubjectName"` to match the **Common Name (CN)** on your certificate exactly.
+
+### 5. Building Reputation (for OV certificates)
+
+If using an OV certificate (not EV), you need to build SmartScreen reputation:
+
+1. **Submit to Microsoft SmartScreen:**
+   - Go to: https://www.microsoft.com/en-us/wdsi/filesubmission
+   - Submit your signed executable for analysis
+   - Wait 24-48 hours for review
+
+2. **Distribute and track:**
+   - Need sustained downloads/installations (typically 1,000-10,000+)
+   - Maintain low incident rate (no malware reports)
+   - Process can take weeks to months
+
+3. **Monitor reputation:**
+   - Use telemetry to track SmartScreen warnings
+   - Check with Windows Defender Security Intelligence
+
+## macOS Code Signing
+
+### 1. Obtain an Apple Developer Certificate
+
+1. **Enroll in Apple Developer Program** ($99/year)
+   - https://developer.apple.com/programs/
+
+2. **Create Certificates:**
+   - **Developer ID Application** certificate (for distribution outside Mac App Store)
+   - **Developer ID Installer** certificate (for pkg installers)
+
+3. **Export Certificate:**
+   - Open Keychain Access
+   - Find your "Developer ID Application" certificate
+   - Right-click → Export
+   - Save as `.p12` file with a password
+
+### 2. Configure GitHub Secrets
+
+Add these secrets to your GitHub repository:
+
+```
+MAC_CSC_LINK          # Base64-encoded P12 certificate
+MAC_CSC_KEY_PASSWORD  # Certificate password
+APPLE_ID              # Your Apple ID email (for notarization)
+APPLE_APP_PASSWORD    # App-specific password (for notarization)
+APPLE_TEAM_ID         # Your 10-character Team ID
+```
+
+#### Getting App-Specific Password:
+
+1. Go to https://appleid.apple.com/account/manage
+2. Sign in with your Apple ID
+3. Under "Security" → "App-Specific Passwords" → Generate new password
+4. Save it as `APPLE_APP_PASSWORD` secret
+
+#### Finding your Team ID:
+
+1. Go to https://developer.apple.com/account
+2. Click "Membership" in the sidebar
+3. Your Team ID is shown (10-character code like `ABCDE12345`)
+
+### 3. Notarization (Optional but Recommended)
+
+macOS Catalina (10.15+) requires apps to be **notarized** by Apple:
+
+1. Update `package.json`:
+   ```json
+   "mac": {
+     "notarize": true
+   }
+   ```
+
+2. electron-builder will automatically notarize if credentials are set
+
+## CI/CD Configuration
+
+### GitHub Actions Workflow Updates
+
+The workflows have been updated to support code signing via environment variables:
+
+#### Windows Build:
+```yaml
+- name: Build Windows app
+  run: npm run package:win
+  env:
+    CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+    CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+```
+
+#### macOS Build:
+```yaml
+- name: Build macOS app
+  run: npm run package:mac
+  env:
+    CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+    CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+    APPLE_ID: ${{ secrets.APPLE_ID }}
+    APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+    APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+```
+
+### How It Works
+
+1. **If secrets are NOT set:** Builds will complete but apps will be unsigned
+2. **If secrets ARE set:** electron-builder automatically signs the apps
+3. **No code changes needed** - just add the secrets when ready
+
+## Testing
+
+### Test Locally (Windows)
+
+1. Get your PFX certificate file
+2. Set environment variables:
+   ```powershell
+   $env:CSC_LINK = "C:\path\to\certificate.pfx"
+   $env:CSC_KEY_PASSWORD = "your_password"
+   npm run package:win
+   ```
+
+3. Verify signature:
+   ```powershell
+   Get-AuthenticodeSignature "out\MCP Electron App Setup 0.1.0.exe"
+   ```
+
+   Should show:
+   - `Status: Valid`
+   - `SignerCertificate: CN=Your Company Name`
+
+### Test Locally (macOS)
+
+1. Get your P12 certificate file
+2. Set environment variables:
+   ```bash
+   export CSC_LINK="/path/to/certificate.p12"
+   export CSC_KEY_PASSWORD="your_password"
+   npm run package:mac
+   ```
+
+3. Verify signature:
+   ```bash
+   codesign -dv --verbose=4 "out/MCP Electron App-0.1.0.dmg"
+   spctl -a -vvv -t install "out/MCP Electron App-0.1.0.dmg"
+   ```
+
+   Should show:
+   - `Authority=Developer ID Application: Your Name (TEAM_ID)`
+   - `satisfies its Designated Requirement`
+
+## Troubleshooting
+
+### Windows
+
+**Error: "No signing certificate found"**
+- Check that `CSC_LINK` is base64-encoded
+- Verify `CSC_KEY_PASSWORD` is correct
+- Ensure certificate hasn't expired
+
+**SmartScreen still shows warnings (OV certificates)**
+- This is expected initially
+- Submit to Microsoft: https://www.microsoft.com/en-us/wdsi/filesubmission
+- Need to build reputation over time (weeks/months)
+- Consider upgrading to EV certificate for immediate bypass
+
+**Error: "SignTool Error: No certificates were found that met all the given criteria"**
+- Check `certificateSubjectName` matches your certificate's CN exactly
+- Use `certutil -dump certificate.pfx` to view certificate details
+
+### macOS
+
+**Error: "No identity found"**
+- Ensure certificate is "Developer ID Application" type
+- Check certificate hasn't expired
+- Verify `CSC_KEY_PASSWORD` is correct
+
+**Notarization fails**
+- Verify `APPLE_ID`, `APPLE_APP_PASSWORD`, and `APPLE_TEAM_ID` are correct
+- Check Apple ID has accepted latest agreements at https://developer.apple.com
+- App-specific password must be fresh (they expire)
+
+**Gatekeeper blocks app**
+- Right-click → "Open" instead of double-clicking (first launch only)
+- If notarized, this shouldn't be necessary
+
+### General
+
+**"CSC_IDENTITY_AUTO_DISCOVERY is false"**
+- This is intentional for builds without certificates
+- Remove or set to `true` when certificates are configured
+
+**Build succeeds but app is unsigned**
+- Check secrets are set in GitHub Actions
+- Look for "Skipping code signing" in build logs
+- Verify environment variables are set correctly
+
+## Cost Summary
+
+### Windows Code Signing
+
+| Approach | Cost | SmartScreen Behavior | Best For |
+|----------|------|---------------------|----------|
+| **No certificate** | Free | Always shows warnings | Development/testing only |
+| **OV Certificate** | $100-300/year | Warnings until reputation built | Budget-conscious, patient |
+| **EV Certificate** | $400-500/year | No warnings immediately | Professional releases |
+
+### macOS Code Signing
+
+| Approach | Cost | User Experience |
+|----------|------|-----------------|
+| **No certificate** | Free | Gatekeeper blocks (can bypass manually) |
+| **Developer ID** | $99/year | Signed, notarization optional |
+| **Developer ID + Notarization** | $99/year | Smooth installation, no warnings |
+
+## Recommended Approach
+
+### For Open Source / Personal Projects:
+1. Start **without certificates** for development
+2. Add **OV certificate** for Windows when ready for wider release
+3. Add **Apple Developer** account for macOS when budget allows
+4. Accept that reputation building takes time
+
+### For Commercial / Professional Projects:
+1. Get **EV certificate** for Windows (immediate trust)
+2. Get **Apple Developer** account with notarization
+3. Set up certificates from day one
+4. Include cost in project budget
+
+## Next Steps
+
+1. **Decide on certificate type** based on budget and timeline
+2. **Purchase certificates** from chosen CA
+3. **Add secrets** to GitHub repository
+4. **Test locally** before pushing
+5. **Create a release** to trigger signed builds
+6. **Monitor** for any signing issues
+
+## Additional Resources
+
+- [electron-builder Code Signing Docs](https://www.electron.build/code-signing)
+- [Microsoft SmartScreen](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-smartscreen/microsoft-defender-smartscreen-overview)
+- [Apple Code Signing Guide](https://developer.apple.com/support/code-signing/)
+- [Apple Notarization Guide](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)

--- a/docs/CREATING_RELEASES.md
+++ b/docs/CREATING_RELEASES.md
@@ -1,0 +1,373 @@
+# Creating Releases
+
+This guide explains how to create releases for the MCP Electron App.
+
+## Understanding Builds vs Releases
+
+### Builds (Artifacts)
+- Created automatically on every push to `main` or `develop`
+- Stored as GitHub Actions **Artifacts** (temporary, 7-day retention)
+- Accessible from: Actions → [Workflow Run] → Artifacts section
+- **Not** visible in the Releases tab
+- Useful for testing and CI/CD validation
+
+### Releases
+- Created when you push a **git tag** matching `v*.*.*` (e.g., `v0.1.0`)
+- Published to GitHub **Releases** tab (permanent)
+- Downloadable by users from the Releases page
+- Include release notes, checksums, and platform-specific installers
+- The official way to distribute your app
+
+## Quick Start: Create Your First Release
+
+### Option 1: Using Git Tags (Recommended)
+
+1. **Ensure your code is ready:**
+   ```bash
+   git status  # Check everything is committed
+   ```
+
+2. **Update version in package.json (optional):**
+   ```json
+   {
+     "version": "0.1.0"
+   }
+   ```
+
+3. **Create and push a git tag:**
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+4. **Monitor the release workflow:**
+   - Go to: Actions → Release Electron App
+   - Watch the build progress for Windows, macOS, and Linux
+   - Takes approximately 10-15 minutes
+
+5. **Check the Releases tab:**
+   - Once complete, go to: Releases
+   - Your new release should be visible with downloadable installers
+
+### Option 2: Manual Workflow Dispatch
+
+1. Go to: **Actions** → **Release Electron App**
+2. Click **"Run workflow"** button
+3. Enter version (e.g., `v0.1.0`)
+4. Click **"Run workflow"** to start
+
+This is useful if you want to create a release without creating a git tag first.
+
+## Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/) (SemVer):
+
+```
+v<MAJOR>.<MINOR>.<PATCH>[-PRERELEASE]
+```
+
+### Examples:
+
+- `v0.1.0` - Initial release
+- `v0.2.0` - Minor update (new features)
+- `v0.2.1` - Patch update (bug fixes)
+- `v1.0.0` - First stable release
+- `v1.0.0-alpha.1` - Alpha prerelease
+- `v1.0.0-beta.2` - Beta prerelease
+- `v1.0.0-rc.1` - Release candidate
+
+**Note:** Versions containing `alpha`, `beta`, or `rc` are marked as **prereleases** in GitHub.
+
+## Step-by-Step Release Process
+
+### 1. Prepare the Release
+
+```bash
+# Ensure you're on the main branch
+git checkout main
+git pull origin main
+
+# Update version in package.json
+# Edit version field: "0.1.0" → "0.2.0"
+
+# Commit version bump
+git add package.json
+git commit -m "Bump version to 0.2.0"
+git push origin main
+```
+
+### 2. Create the Tag
+
+```bash
+# Create an annotated tag with a message
+git tag -a v0.2.0 -m "Release version 0.2.0"
+
+# Or create a lightweight tag
+git tag v0.2.0
+
+# Push the tag to trigger the release workflow
+git push origin v0.2.0
+```
+
+### 3. Monitor the Build
+
+1. Go to **Actions** tab in GitHub
+2. Click on **"Release Electron App"** workflow
+3. You'll see three parallel builds:
+   - **Build Windows** - Creates `.exe` installer
+   - **Build macOS** - Creates `.dmg` installer
+   - **Build Linux** - Creates `.AppImage` and `.deb` packages
+
+### 4. Verify the Release
+
+Once the workflow completes:
+
+1. Go to **Releases** tab
+2. Your release should appear with:
+   - Release title (e.g., "MCP Electron App v0.2.0")
+   - Auto-generated release notes (commits since last release)
+   - Platform-specific installers:
+     - `MCP-Electron-App-Setup-v0.2.0.exe` (Windows)
+     - `MCP-Electron-App-v0.2.0.dmg` (macOS)
+     - `MCP-Electron-App-v0.2.0.AppImage` (Linux)
+     - `mcp-electron-app_v0.2.0_amd64.deb` (Debian/Ubuntu)
+   - Checksum files for verification
+
+### 5. Test the Release
+
+Download and test installers on each platform:
+
+**Windows:**
+```powershell
+# Download MCP-Electron-App-Setup-v0.2.0.exe
+# Run the installer
+# Verify the app launches correctly
+```
+
+**macOS:**
+```bash
+# Download MCP-Electron-App-v0.2.0.dmg
+# Mount and drag to Applications
+# Verify the app launches
+```
+
+**Linux:**
+```bash
+# AppImage
+chmod +x MCP-Electron-App-v0.2.0.AppImage
+./MCP-Electron-App-v0.2.0.AppImage
+
+# Or Debian package
+sudo dpkg -i mcp-electron-app_v0.2.0_amd64.deb
+```
+
+## Release Workflow Details
+
+### What Happens When You Create a Release?
+
+1. **Create Release Job**
+   - Generates release notes from git commits
+   - Creates a GitHub Release (draft or published)
+   - Provides upload URL for artifacts
+
+2. **Platform Builds** (run in parallel)
+   - Windows: Builds NSIS installer (`.exe`)
+   - macOS: Builds DMG installer (`.dmg`)
+   - Linux: Builds AppImage and Debian package
+
+3. **Upload Assets**
+   - Each platform uploads its installer to the release
+   - Checksums are generated and uploaded
+   - Assets become downloadable
+
+4. **Code Signing** (if configured)
+   - Windows: Signs with certificate from `WIN_CSC_LINK`
+   - macOS: Signs with certificate from `MAC_CSC_LINK`
+   - See [CODE_SIGNING.md](./CODE_SIGNING.md) for details
+
+## Customizing Release Notes
+
+By default, release notes are auto-generated from commits. To customize:
+
+### Option 1: Edit After Creation
+
+1. Go to **Releases** tab
+2. Click **"Edit"** on your release
+3. Modify the description
+4. Click **"Update release"**
+
+### Option 2: Create Draft Release
+
+Modify `.github/workflows/release.yml`:
+
+```yaml
+- name: Create Release
+  uses: actions/create-release@v1
+  with:
+    draft: true  # Change to true
+    prerelease: false
+```
+
+This creates a draft release that you can edit before publishing.
+
+### Option 3: Use Conventional Commits
+
+Structure commit messages for better release notes:
+
+```bash
+git commit -m "feat: Add dark mode support"
+git commit -m "fix: Resolve connection timeout issue"
+git commit -m "docs: Update installation guide"
+```
+
+## Troubleshooting
+
+### Release Not Appearing
+
+**Problem:** Pushed a tag but no release created
+
+**Solutions:**
+- Check tag format matches `v*.*.*` (e.g., `v0.1.0`)
+- Go to Actions tab and check for workflow errors
+- Verify repository permissions allow creating releases
+
+### Build Fails
+
+**Problem:** Release workflow fails during build
+
+**Solutions:**
+- Check Actions logs for specific error
+- Common issues:
+  - TypeScript compilation errors → Run `npm run build` locally first
+  - Missing dependencies → Ensure `package-lock.json` is committed
+  - Icon files missing → Check `resources/` directory
+
+### Assets Not Uploading
+
+**Problem:** Release created but installers missing
+
+**Solutions:**
+- Check individual build job logs
+- Verify file paths in workflow match actual output
+- Look for "Upload Release Asset" step failures
+
+### Code Signing Errors
+
+**Problem:** Build fails with signing errors
+
+**Solutions:**
+- If you don't have certificates yet, the build should still succeed (unsigned)
+- Check that `CSC_IDENTITY_AUTO_DISCOVERY` logic is correct
+- See [CODE_SIGNING.md](./CODE_SIGNING.md) for certificate setup
+
+## Deleting/Recreating a Release
+
+### Delete a Release
+
+1. Go to **Releases** tab
+2. Click on the release to delete
+3. Click **"Delete"** button (top right)
+4. Confirm deletion
+
+**Note:** This does NOT delete the git tag!
+
+### Delete the Tag
+
+```bash
+# Delete local tag
+git tag -d v0.1.0
+
+# Delete remote tag
+git push origin :refs/tags/v0.1.0
+```
+
+### Recreate a Release
+
+If you need to redo a release:
+
+```bash
+# Delete the tag (see above)
+
+# Make necessary fixes
+git add .
+git commit -m "Fix release issues"
+git push origin main
+
+# Create tag again
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+## Best Practices
+
+1. **Test before releasing:**
+   - Run local builds: `npm run package:win`, `npm run package:mac`, `npm run package:linux`
+   - Test the app thoroughly
+
+2. **Use meaningful version numbers:**
+   - Follow Semantic Versioning
+   - Update `package.json` version to match tag
+
+3. **Write good release notes:**
+   - Highlight new features
+   - List bug fixes
+   - Mention breaking changes
+   - Include upgrade instructions if needed
+
+4. **Verify checksums:**
+   - Download installers
+   - Verify SHA256 checksums match `checksums-*.txt` files
+
+5. **Announce the release:**
+   - Update documentation
+   - Notify users
+   - Share on social media/forums
+
+## Automated Release Strategy
+
+For a more automated approach, consider:
+
+1. **Conventional Commits** + **semantic-release**
+   - Auto-generate version numbers
+   - Auto-create tags and releases
+   - Auto-generate changelogs
+
+2. **Release Drafter**
+   - Auto-draft releases on tag push
+   - Categorize PRs automatically
+   - Template-based release notes
+
+3. **Scheduled Releases**
+   - Weekly/monthly release cadence
+   - Automated changelog generation
+   - Version bumping via CI/CD
+
+## Next Steps
+
+1. **Create your first release:**
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+2. **Set up code signing** (optional but recommended)
+   - Follow [CODE_SIGNING.md](./CODE_SIGNING.md)
+   - Add certificates to GitHub Secrets
+   - Eliminate security warnings
+
+3. **Customize release notes**
+   - Edit release description
+   - Add screenshots
+   - Include installation instructions
+
+4. **Monitor downloads**
+   - Check release asset download counts
+   - Gather user feedback
+   - Plan next release
+
+## Additional Resources
+
+- [GitHub Releases Documentation](https://docs.github.com/en/repositories/releasing-projects-on-github)
+- [Semantic Versioning](https://semver.org/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [electron-builder Publishing Docs](https://www.electron.build/configuration/publish)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,12 @@
           ]
         }
       ],
-      "icon": "resources/icon.ico"
+      "icon": "resources/icon.ico",
+      "publisherName": "MCP Team",
+      "certificateSubjectName": "MCP Team",
+      "signingHashAlgorithms": ["sha256"],
+      "signDlls": true,
+      "rfc3161TimeStampServer": "http://timestamp.digicert.com"
     },
     "nsis": {
       "oneClick": false,
@@ -77,7 +82,12 @@
         }
       ],
       "icon": "resources/icon.icns",
-      "category": "public.app-category.developer-tools"
+      "category": "public.app-category.developer-tools",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "resources/entitlements.mac.plist",
+      "entitlementsInherit": "resources/entitlements.mac.plist",
+      "notarize": false
     },
     "dmg": {
       "contents": [

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
…warnings

This commit addresses the Windows SmartScreen "Unknown publisher" warning that appears when users download and run the installer. It also explains why releases weren't appearing in the Releases tab.

Changes:

1. Code Signing Configuration (package.json):
   - Added Windows code signing parameters (publisherName, certificateSubjectName)
   - Configured SHA256 signing algorithm and RFC3161 timestamping
   - Added macOS code signing with hardened runtime and entitlements
   - Created resources/entitlements.mac.plist for macOS security

2. CI/CD Workflow Updates:
   - Modified build.yml and release.yml to support optional code signing
   - Workflows check for certificate secrets and sign if available
   - If secrets not set, builds complete unsigned (backward compatible)

3. Comprehensive Documentation:
   - docs/CODE_SIGNING.md: Complete guide to obtaining certificates
   - docs/CREATING_RELEASES.md: Step-by-step guide to creating releases
   - Updated README.md with links to new documentation

This solves the immediate issue by configuring the app for code signing and providing complete documentation for certificate procurement.