### PR TITLE
Run installer and troubleshoot setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ dist/
 out/
 build/
 
-# Compiled TypeScript
+# Compiled TypeScript (but keep build scripts)
 *.js
+!scripts/*.js
 *.js.map
 *.d.ts
 *.d.ts.map

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   "private": true,
   "scripts": {
     "dev": "npm run build && electron .",
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-assets.js",
     "build:watch": "tsc --watch",
     "start": "electron .",
     "export-docker-images": "bash scripts/export-docker-images.sh",
+    "copy-assets": "node scripts/copy-assets.js",
     "package": "npm run build && electron-builder build --publish never",
     "package:win": "npm run build && electron-builder build --win --publish never",
     "package:mac": "npm run build && electron-builder build --mac --publish never",

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,59 @@
+/**
+ * Copy static assets (HTML, CSS, etc.) from src to dist
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function ensureDirSync(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function copyAssets() {
+  const srcRenderer = path.join(__dirname, '..', 'src', 'renderer');
+  const distRenderer = path.join(__dirname, '..', 'dist', 'renderer');
+
+  try {
+    console.log('Copying renderer assets...');
+
+    // Ensure dist/renderer directory exists
+    ensureDirSync(distRenderer);
+
+    // Copy HTML and CSS files
+    const files = fs.readdirSync(srcRenderer);
+    for (const file of files) {
+      if (file.endsWith('.html') || file.endsWith('.css')) {
+        const srcPath = path.join(srcRenderer, file);
+        const destPath = path.join(distRenderer, file);
+        fs.copyFileSync(srcPath, destPath);
+        console.log(`  ✓ Copied ${file}`);
+      }
+    }
+
+    // Also copy preload assets if they exist
+    const srcPreload = path.join(__dirname, '..', 'src', 'preload');
+    const distPreload = path.join(__dirname, '..', 'dist', 'preload');
+
+    if (fs.existsSync(srcPreload)) {
+      ensureDirSync(distPreload);
+      const preloadFiles = fs.readdirSync(srcPreload);
+      for (const file of preloadFiles) {
+        if (file.endsWith('.html') || file.endsWith('.css')) {
+          const srcPath = path.join(srcPreload, file);
+          const destPath = path.join(distPreload, file);
+          fs.copyFileSync(srcPath, destPath);
+          console.log(`  ✓ Copied preload/${file}`);
+        }
+      }
+    }
+
+    console.log('✓ Asset copying complete!');
+  } catch (error) {
+    console.error('Error copying assets:', error);
+    process.exit(1);
+  }
+}
+
+copyAssets();


### PR DESCRIPTION
The packaged installer was showing a blank window with a "Not allowed to load local resource" error because HTML and CSS files from src/renderer were not being copied to dist/renderer during the build process.

Changes:
- Added scripts/copy-assets.js to copy HTML and CSS files from src to dist
- Updated package.json build script to run copy-assets after TypeScript compilation
- Updated .gitignore to allow build scripts in the scripts/ directory

This ensures that when the app is packaged with electron-builder, all necessary static assets are included in the app.asar bundle.

Fixes the blank window issue on installer launch.