### PR TITLE
Add version tracking to wizard state

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -881,6 +881,26 @@ function setupIPC(): void {
     return await setupWizard.canProceedToNextStep(step);
   });
 
+  ipcMain.handle('setup-wizard:get-installation-version', async () => {
+    logWithCategory('info', LogCategory.SYSTEM, 'IPC: Getting installation version...');
+    return await setupWizard.getInstallationVersion();
+  });
+
+  ipcMain.handle('setup-wizard:is-installation-outdated', async () => {
+    logWithCategory('info', LogCategory.SYSTEM, 'IPC: Checking if installation is outdated...');
+    return await setupWizard.isInstallationOutdated();
+  });
+
+  ipcMain.handle('setup-wizard:get-migration-history', async () => {
+    logWithCategory('info', LogCategory.SYSTEM, 'IPC: Getting migration history...');
+    return await setupWizard.getMigrationHistory();
+  });
+
+  ipcMain.handle('setup-wizard:add-migration-record', async (_, record: setupWizard.MigrationRecord) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: Adding migration record for version ${record.version}...`);
+    return await setupWizard.addMigrationRecord(record);
+  });
+
   // GitHub Credentials IPC handlers
   ipcMain.handle('github-credentials:set-token', async (_, token: string) => {
     logWithCategory('info', LogCategory.SYSTEM, 'IPC: Setting GitHub token...');

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -486,6 +486,16 @@ interface WizardStepData {
 }
 
 /**
+ * Migration record
+ */
+interface MigrationRecord {
+  version: string;
+  appliedAt: string;  // ISO timestamp
+  stepsRerun: WizardStep[];
+  success: boolean;
+}
+
+/**
  * Wizard state
  */
 interface WizardState {
@@ -496,6 +506,9 @@ interface WizardState {
   startedAt?: string;
   completedAt?: string;
   version?: string;
+  installationVersion?: string;     // Version when wizard was completed
+  lastMigrationVersion?: string;    // Last migration that was applied
+  migrationHistory?: MigrationRecord[];  // History of applied migrations
 }
 
 /**
@@ -1424,6 +1437,34 @@ contextBridge.exposeInMainWorld('electronAPI', {
      */
     canProceed: (step: WizardStep): Promise<CanProceedResult> => {
       return ipcRenderer.invoke('setup-wizard:can-proceed', step);
+    },
+
+    /**
+     * Get the installation version from wizard state
+     */
+    getInstallationVersion: (): Promise<string | null> => {
+      return ipcRenderer.invoke('setup-wizard:get-installation-version');
+    },
+
+    /**
+     * Check if installation version is outdated
+     */
+    isInstallationOutdated: (): Promise<boolean> => {
+      return ipcRenderer.invoke('setup-wizard:is-installation-outdated');
+    },
+
+    /**
+     * Get migration history from wizard state
+     */
+    getMigrationHistory: (): Promise<MigrationRecord[]> => {
+      return ipcRenderer.invoke('setup-wizard:get-migration-history');
+    },
+
+    /**
+     * Add a migration record to the migration history
+     */
+    addMigrationRecord: (record: MigrationRecord): Promise<WizardOperationResult> => {
+      return ipcRenderer.invoke('setup-wizard:add-migration-record', record);
     },
 
     /**


### PR DESCRIPTION
- Add MigrationRecord interface to track applied migrations
- Extend WizardState with installationVersion, lastMigrationVersion, and migrationHistory fields
- Capture app version when wizard is completed via markWizardComplete()
- Implement getter functions:
  - getInstallationVersion(): Get the version from wizard state
  - isInstallationOutdated(): Check if installation is outdated
  - getMigrationHistory(): Retrieve migration history
  - addMigrationRecord(): Add new migration records to history
- Add IPC handlers for version tracking methods
- Expose version methods to renderer via preload
- Foundation for future migration capabilities when users upgrade

Closes #47