### PR TITLE
Create migration registry and definition system

### DIFF
--- a/src/main/migrations.ts
+++ b/src/main/migrations.ts
@@ -1,0 +1,211 @@
+/**
+ * Migration Registry
+ * Centralized registry of all version-specific migrations
+ */
+
+import { Migration } from '../types/migration';
+import { WizardStep } from '../types/wizard';
+import { logWithCategory, LogCategory } from './logger';
+
+/**
+ * Migration registry
+ * Add new migrations here when setup logic changes
+ */
+const migrations: Migration[] = [
+  // Example migration (to be replaced with actual migrations as needed):
+  // {
+  //   version: '1.1.0',
+  //   description: 'Update Docker configurations for new MCP services',
+  //   steps: [WizardStep.DOWNLOAD_SETUP, WizardStep.SYSTEM_STARTUP],
+  //   skipIfFresh: true,
+  //   critical: true
+  // }
+];
+
+/**
+ * Get all registered migrations
+ */
+export function getAllMigrations(): Migration[] {
+  return [...migrations];
+}
+
+/**
+ * Get a specific migration by version
+ */
+export function getMigrationByVersion(version: string): Migration | undefined {
+  return migrations.find(m => m.version === version);
+}
+
+/**
+ * Get migrations that need to be applied when upgrading from one version to another
+ * @param fromVersion - Current installed version
+ * @param toVersion - Target upgrade version
+ * @returns Array of migrations to apply, sorted by version
+ */
+export function getMigrationsForUpgrade(fromVersion: string, toVersion: string): Migration[] {
+  try {
+    const applicable = migrations.filter(migration => {
+      // Check if migration version is between from and to versions
+      const migrationInRange =
+        compareVersions(migration.version, fromVersion) > 0 &&
+        compareVersions(migration.version, toVersion) <= 0;
+
+      if (!migrationInRange) {
+        return false;
+      }
+
+      // If migration has a specific fromVersion requirement, check it
+      if (migration.fromVersion) {
+        return compareVersions(fromVersion, migration.fromVersion) === 0;
+      }
+
+      return true;
+    });
+
+    // Sort by version (oldest to newest)
+    return applicable.sort((a, b) => compareVersions(a.version, b.version));
+  } catch (error) {
+    logWithCategory('error', LogCategory.SYSTEM, 'Error getting migrations for upgrade', error);
+    return [];
+  }
+}
+
+/**
+ * Compare two semantic version strings
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b
+ */
+export function compareVersions(a: string, b: string): number {
+  try {
+    // Remove 'v' prefix if present
+    const cleanA = a.replace(/^v/, '');
+    const cleanB = b.replace(/^v/, '');
+
+    const partsA = cleanA.split('.').map(Number);
+    const partsB = cleanB.split('.').map(Number);
+
+    // Compare major, minor, patch
+    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+      const numA = partsA[i] || 0;
+      const numB = partsB[i] || 0;
+
+      if (numA > numB) return 1;
+      if (numA < numB) return -1;
+    }
+
+    return 0;
+  } catch (error) {
+    logWithCategory('error', LogCategory.SYSTEM, `Error comparing versions ${a} and ${b}`, error);
+    return 0;
+  }
+}
+
+/**
+ * Check if any migrations in the list are marked as critical
+ */
+export function hasCriticalMigrations(migrations: Migration[]): boolean {
+  return migrations.some(m => m.critical === true);
+}
+
+/**
+ * Extract unique wizard steps from a list of migrations
+ * @returns Sorted array of unique wizard steps
+ */
+export function getStepsFromMigrations(migrations: Migration[]): WizardStep[] {
+  const stepSet = new Set<WizardStep>();
+
+  migrations.forEach(migration => {
+    migration.steps.forEach(step => stepSet.add(step));
+  });
+
+  // Convert to array and sort
+  return Array.from(stepSet).sort((a, b) => a - b);
+}
+
+/**
+ * Validate migrations for common errors
+ * @returns Object with validation results
+ */
+export function validateMigrations(): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  try {
+    // Check for duplicate versions
+    const versions = new Set<string>();
+    migrations.forEach(migration => {
+      if (versions.has(migration.version)) {
+        errors.push(`Duplicate migration version: ${migration.version}`);
+      }
+      versions.add(migration.version);
+    });
+
+    // Validate each migration
+    migrations.forEach(migration => {
+      // Check required fields
+      if (!migration.version) {
+        errors.push('Migration missing version');
+      }
+      if (!migration.description) {
+        errors.push(`Migration ${migration.version} missing description`);
+      }
+      if (!migration.steps || migration.steps.length === 0) {
+        errors.push(`Migration ${migration.version} has no steps`);
+      }
+
+      // Validate version format (basic semver check)
+      if (migration.version && !migration.version.match(/^\d+\.\d+\.\d+/)) {
+        errors.push(`Migration ${migration.version} has invalid version format (expected semver)`);
+      }
+
+      // Validate fromVersion if present
+      if (migration.fromVersion && !migration.fromVersion.match(/^\d+\.\d+\.\d+/)) {
+        errors.push(`Migration ${migration.version} has invalid fromVersion format`);
+      }
+
+      // Validate steps are valid WizardStep values
+      migration.steps?.forEach(step => {
+        if (!Object.values(WizardStep).includes(step)) {
+          errors.push(`Migration ${migration.version} contains invalid step: ${step}`);
+        }
+      });
+    });
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  } catch (error) {
+    logWithCategory('error', LogCategory.SYSTEM, 'Error validating migrations', error);
+    errors.push(`Validation error: ${error instanceof Error ? error.message : String(error)}`);
+    return {
+      valid: false,
+      errors
+    };
+  }
+}
+
+/**
+ * Get migrations that should be applied for a fresh installation
+ * (Filters out migrations with skipIfFresh: true)
+ */
+export function getMigrationsForFreshInstall(): Migration[] {
+  return migrations.filter(m => !m.skipIfFresh);
+}
+
+/**
+ * Log migration registry information
+ */
+export function logMigrationRegistry(): void {
+  logWithCategory('info', LogCategory.SYSTEM, `Migration registry: ${migrations.length} migrations registered`);
+
+  const validation = validateMigrations();
+  if (!validation.valid) {
+    logWithCategory('warn', LogCategory.SYSTEM, 'Migration validation errors:', validation.errors);
+  }
+
+  migrations.forEach(migration => {
+    logWithCategory('debug', LogCategory.SYSTEM,
+      `  - ${migration.version}: ${migration.description} ` +
+      `(${migration.steps.length} steps, critical: ${migration.critical || false})`
+    );
+  });
+}

--- a/src/main/setup-wizard.ts
+++ b/src/main/setup-wizard.ts
@@ -7,85 +7,20 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { app } from 'electron';
 import { logWithCategory, LogCategory } from './logger';
+import {
+  WizardStep,
+  WizardStepData,
+  MigrationRecord,
+  WizardState
+} from '../types/wizard';
 
-/**
- * Wizard step enum
- */
-export enum WizardStep {
-  WELCOME = 1,
-  PREREQUISITES = 2,
-  ENVIRONMENT = 3,
-  CLIENT_SELECTION = 4,
-  DOWNLOAD_SETUP = 5,
-  SYSTEM_STARTUP = 6,
-  COMPLETE = 7
-}
-
-/**
- * Wizard step data interface
- */
-export interface WizardStepData {
-  // Step 2: Prerequisites
-  prerequisites?: {
-    docker: boolean;
-    git: boolean;
-    wsl?: boolean;
-  };
-
-  // Step 3: Environment configuration
-  environment?: {
-    saved: boolean;
-    configPath?: string;
-  };
-
-  // Step 4: Client selection
-  clients?: string[];
-
-  // Step 5: Download & setup
-  buildPipeline?: {
-    completed: boolean;
-    clonedRepositories?: string[];
-    builtRepositories?: string[];
-    dockerImages?: string[];
-    verifiedArtifacts?: string[];
-  };
-  downloads?: {
-    typingMindCompleted: boolean;
-    dockerImagesCompleted: boolean;
-  };
-
-  // Step 6: System startup
-  systemStartup?: {
-    started: boolean;
-    healthy: boolean;
-  };
-}
-
-/**
- * Migration record interface for tracking applied migrations
- */
-export interface MigrationRecord {
-  version: string;
-  appliedAt: string;  // ISO timestamp
-  stepsRerun: WizardStep[];
-  success: boolean;
-}
-
-/**
- * Wizard state interface
- */
-export interface WizardState {
-  completed: boolean;
-  currentStep: WizardStep;
-  stepsCompleted: WizardStep[];
-  data: WizardStepData;
-  startedAt?: string;
-  completedAt?: string;
-  version?: string;
-  installationVersion?: string;     // Version when wizard was completed
-  lastMigrationVersion?: string;    // Last migration that was applied
-  migrationHistory?: MigrationRecord[];  // History of applied migrations
-}
+// Re-export wizard types for backward compatibility
+export {
+  WizardStep,
+  WizardStepData,
+  MigrationRecord,
+  WizardState
+} from '../types/wizard';
 
 /**
  * Get the path to the wizard state file

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -1,0 +1,49 @@
+/**
+ * Migration Types
+ * Type definitions for the migration system
+ */
+
+import { WizardStep } from './wizard';
+
+/**
+ * Migration definition interface
+ * Defines a version-specific migration that re-runs certain wizard steps
+ */
+export interface Migration {
+  version: string;
+  description: string;
+  steps: WizardStep[];
+  skipIfFresh?: boolean;        // Skip this migration for fresh installations
+  critical?: boolean;           // If true, migration must be run immediately
+  fromVersion?: string;         // Only apply if upgrading from this specific version
+  validator?: MigrationValidator;
+}
+
+/**
+ * Migration validator function type
+ * Returns true if migration should be applied, false otherwise
+ */
+export type MigrationValidator = () => Promise<boolean>;
+
+/**
+ * Migration result interface
+ * Records the outcome of a migration execution
+ */
+export interface MigrationResult {
+  version: string;
+  success: boolean;
+  appliedAt: string;            // ISO timestamp
+  stepsRerun: WizardStep[];
+  error?: string;
+}
+
+/**
+ * Pending migrations status
+ * Information about migrations that need to be applied
+ */
+export interface PendingMigrationsStatus {
+  hasPending: boolean;
+  migrations: Migration[];
+  criticalCount: number;
+  optionalCount: number;
+}

--- a/src/types/wizard.ts
+++ b/src/types/wizard.ts
@@ -1,0 +1,83 @@
+/**
+ * Wizard Types
+ * Type definitions for the setup wizard system
+ */
+
+/**
+ * Wizard step enum
+ */
+export enum WizardStep {
+  WELCOME = 1,
+  PREREQUISITES = 2,
+  ENVIRONMENT = 3,
+  CLIENT_SELECTION = 4,
+  DOWNLOAD_SETUP = 5,
+  SYSTEM_STARTUP = 6,
+  COMPLETE = 7
+}
+
+/**
+ * Wizard step data interface
+ */
+export interface WizardStepData {
+  // Step 2: Prerequisites
+  prerequisites?: {
+    docker: boolean;
+    git: boolean;
+    wsl?: boolean;
+  };
+
+  // Step 3: Environment configuration
+  environment?: {
+    saved: boolean;
+    configPath?: string;
+  };
+
+  // Step 4: Client selection
+  clients?: string[];
+
+  // Step 5: Download & setup
+  buildPipeline?: {
+    completed: boolean;
+    clonedRepositories?: string[];
+    builtRepositories?: string[];
+    dockerImages?: string[];
+    verifiedArtifacts?: string[];
+  };
+  downloads?: {
+    typingMindCompleted: boolean;
+    dockerImagesCompleted: boolean;
+  };
+
+  // Step 6: System startup
+  systemStartup?: {
+    started: boolean;
+    healthy: boolean;
+  };
+}
+
+/**
+ * Migration record interface for tracking applied migrations
+ */
+export interface MigrationRecord {
+  version: string;
+  appliedAt: string;  // ISO timestamp
+  stepsRerun: WizardStep[];
+  success: boolean;
+}
+
+/**
+ * Wizard state interface
+ */
+export interface WizardState {
+  completed: boolean;
+  currentStep: WizardStep;
+  stepsCompleted: WizardStep[];
+  data: WizardStepData;
+  startedAt?: string;
+  completedAt?: string;
+  version?: string;
+  installationVersion?: string;     // Version when wizard was completed
+  lastMigrationVersion?: string;    // Last migration that was applied
+  migrationHistory?: MigrationRecord[];  // History of applied migrations
+}


### PR DESCRIPTION
Implements Issue #48 - Create a centralized migration registry system that defines which installation steps need to be re-run when users upgrade from one version to another.

Changes:
- Created src/types/wizard.ts with wizard type definitions (WizardStep, WizardStepData, MigrationRecord, WizardState)
- Created src/types/migration.ts with migration type definitions (Migration, MigrationValidator, MigrationResult, PendingMigrationsStatus)
- Created src/main/migrations.ts with migration registry and helper functions:
  - getAllMigrations() - Get all registered migrations
  - getMigrationByVersion() - Get specific migration by version
  - getMigrationsForUpgrade() - Get migrations for version upgrade
  - compareVersions() - Semver comparison utility
  - hasCriticalMigrations() - Check for critical migrations
  - getStepsFromMigrations() - Extract unique wizard steps
  - validateMigrations() - Validate migration definitions
  - getMigrationsForFreshInstall() - Get migrations for fresh installs
  - logMigrationRegistry() - Log migration info
- Updated src/main/setup-wizard.ts to import and re-export types from new types files for backward compatibility

All functions tested and validated. Ready for integration with migration detection and execution logic.

Resolves #48