### PR TITLE
Fix missing MCP-Writing-Servers repository error

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1481,12 +1481,20 @@ function setupIPC(): void {
         logWithCategory('info', LogCategory.GENERAL, 'Resolved config path', { resolvedConfigPath });
         await currentPipelineOrchestrator.loadConfig(resolvedConfigPath);
 
+        // Ensure workingDirectory is set to userData if not provided
+        // This ensures repositories are cloned to the same location where the system expects to find them
+        const options = request.options || {};
+        if (!options.workingDirectory) {
+          options.workingDirectory = app.getPath('userData');
+          logWithCategory('info', LogCategory.GENERAL, 'Using userData as working directory', { workingDirectory: options.workingDirectory });
+        }
+
         // Create progress throttler
         const progressThrottler = new ProgressThrottler(10);
 
         // Execute pipeline with progress tracking
         const result = await currentPipelineOrchestrator.executePipeline(
-          request.options || {},
+          options,
           (progress) => {
             progressThrottler.emit(progress, (throttledProgress) => {
               if (mainWindow) {


### PR DESCRIPTION
…allation

Fixed a critical installer bug where repositories were being cloned to the project directory instead of the app's userData directory, causing a "repository not found" error at startup.

The issue occurred because the build pipeline executor was using the current directory (.) as the default working directory when cloning repositories, but the system expected to find them in app.getPath('userData')/repositories/mcp-writing-servers at startup.

Changes:
- Modified the pipeline executor in src/main/index.ts to automatically set workingDirectory to app.getPath('userData') if not explicitly provided
- Added logging to track the working directory being used
- This ensures repositories are always cloned to the correct location during installation

Impact:
- Fixes the "MCP-Writing-Servers repository not found" startup error
- Ensures consistent repository location between installation and runtime
- No changes required to the installer UI or user experience