### PR TITLE
Update outdated documentation for app

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ A: The app will detect this and show you a step-by-step guide to install Docker 
 
 **Q: How much does this cost?**
 A: The MCP Electron App is free and open-source. However, you may need:
-- A free Docker Hub account (for Docker Desktop)
+- Docker Desktop (free for personal use; a Docker Hub account is optional)
 - API credits for AI services (Claude, ChatGPT, etc.) depending on your chosen client
 
 **Q: Can I uninstall it later?**

--- a/docs/DOCKER-IMAGE-PRELOADING.md
+++ b/docs/DOCKER-IMAGE-PRELOADING.md
@@ -1,6 +1,16 @@
 # Docker Image Pre-loading System
 
-This document describes the Docker image pre-loading system implemented for the MCP Electron App. This feature allows bundling pre-built Docker images with the application to provide a faster, more reliable installation experience.
+> **⚠️ FUTURE ENHANCEMENT - NOT CURRENTLY IMPLEMENTED**
+>
+> This document describes a planned future feature for pre-loading bundled Docker images with the application installer.
+>
+> **Current Behavior:** The app currently pulls the PostgreSQL image from Docker Hub and builds MCP server images from source code during setup.
+>
+> **Future Enhancement:** This document outlines the design for bundling pre-built Docker images as tar.gz files with the application to provide faster, offline installation.
+
+---
+
+This document describes the Docker image pre-loading system planned for the MCP Electron App. This feature will allow bundling pre-built Docker images with the application to provide a faster, more reliable installation experience.
 
 ## Overview
 
@@ -36,19 +46,21 @@ The Docker image pre-loading system enables the application to:
 5. **Export Script** - Generates image files for bundling
    - `/scripts/export-docker-images.sh`
 
-## Bundled Images
+## Bundled Images (Planned)
 
-### postgres:15
-- **File**: `postgres-15.tar.gz`
+### postgres:15 (or postgres:16-alpine)
+- **File**: `postgres-15.tar.gz` (or `postgres-16-alpine.tar.gz`)
 - **Size**: ~150MB compressed
 - **Purpose**: PostgreSQL database for MCP servers
-- **Source**: Official PostgreSQL 15 image from Docker Hub
+- **Current**: Pulled from Docker Hub during setup
+- **Future**: Pre-bundled in application installer
 
 ### mcp-servers:latest
 - **File**: `mcp-servers.tar.gz`
 - **Size**: ~200MB compressed
 - **Purpose**: Custom MCP servers container
-- **Source**: Built from local Dockerfile
+- **Current**: Built from cloned source code during setup
+- **Future**: Pre-built and bundled in application installer
 
 ## Usage
 
@@ -91,9 +103,9 @@ window.electronAPI.dockerImages.onProgress((progress) => {
    npm run package
    ```
 
-#### Manual Image Export
+#### Manual Image Export (For Future Implementation)
 
-If you prefer manual control:
+If you prefer manual control when implementing this feature:
 
 ```bash
 # Export PostgreSQL image
@@ -101,6 +113,7 @@ docker pull postgres:15
 docker save postgres:15 | gzip > resources/docker-images/postgres-15.tar.gz
 
 # Build and export MCP servers
+# Note: Current implementation builds from source, not from local Dockerfile
 docker build -t mcp-servers:latest .
 docker save mcp-servers:latest | gzip > resources/docker-images/mcp-servers.tar.gz
 ```
@@ -434,7 +447,19 @@ docker save test-image:latest | gzip > resources/docker-images/test-image.tar.gz
 2. Check network if pulling images
 3. Monitor system resources during load
 
-## Future Enhancements
+## Implementation Status
+
+**Current Status:** Planning/Design Phase
+
+This entire document describes a future enhancement. The current application:
+- ✅ Pulls PostgreSQL from Docker Hub automatically
+- ✅ Clones MCP server repositories and builds images from source
+- ❌ Does NOT bundle pre-built images with the installer
+- ❌ Does NOT include tar.gz image files in the application package
+
+## Future Enhancements (After Base Feature Implementation)
+
+Once the base pre-loading feature is implemented, these additional enhancements could be added:
 
 1. **Delta updates** - Only download image changes
 2. **Parallel loading** - Load independent images simultaneously

--- a/docs/DOCKER-IMAGE-USAGE-EXAMPLE.md
+++ b/docs/DOCKER-IMAGE-USAGE-EXAMPLE.md
@@ -1,6 +1,16 @@
 # Docker Image Pre-loading - Usage Examples
 
-This document provides practical examples of using the Docker image pre-loading system in the MCP Electron App.
+> **⚠️ FUTURE ENHANCEMENT - NOT CURRENTLY IMPLEMENTED**
+>
+> This document describes usage examples for a planned future feature.
+>
+> **Current Behavior:** The app currently pulls the PostgreSQL image from Docker Hub and builds MCP server images from source code during setup.
+>
+> **Future Enhancement:** This document provides examples for when pre-loading bundled Docker images is implemented.
+
+---
+
+This document provides practical examples of using the Docker image pre-loading system planned for the MCP Electron App.
 
 ## Basic Usage
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -90,7 +90,7 @@ That's it! The app helps you install both if needed.
 **First-time setup:** 15-30 minutes
 - Docker Desktop installation: 10-15 minutes
 - MCP App setup wizard: 5-10 minutes
-- Downloading Docker images: 5-10 minutes
+- Preparing Docker images: 5-10 minutes (pulling Postgres, building MCP servers)
 
 **Subsequent starts:** 30-60 seconds
 - Services start much faster after initial setup!
@@ -346,7 +346,8 @@ All ports can be changed in Environment Configuration if there are conflicts.
 **What's transmitted:**
 - AI client to AI service communication (OpenAI, Claude, etc.)
 - Update checks to GitHub
-- Docker image downloads
+- Docker image pulls (Postgres from Docker Hub)
+- Repository cloning for MCP servers (via Git)
 
 **The MCP Electron App never sends your data anywhere!**
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -180,14 +180,16 @@ Choose which AI client(s) you want to use.
 - Check the box next to your preferred client(s)
 - Click "Save Selection"
 
-### Step 5: Download Docker Images
+### Step 5: Prepare Docker Images
 
-The app will download necessary Docker images (PostgreSQL, MCP Servers).
+The app will prepare necessary Docker images (PostgreSQL is pulled from Docker Hub, MCP Servers are built from source).
 
 **What happens:**
-- Progress bar shows download status
+- Progress bar shows preparation status
+- PostgreSQL image is pulled from Docker Hub
+- MCP Server code is downloaded and image is built locally
 - This may take 5-15 minutes depending on your internet speed
-- You can see which image is currently downloading
+- You can see which image is currently being prepared
 
 **Note:** This only happens once! The images are saved on your computer for future use.
 
@@ -473,7 +475,7 @@ No! This app is designed for non-technical users. Everything is done through but
 
 Yes, the MCP Electron App is free and open-source. However, you may need:
 - API credits for AI services (Claude, ChatGPT, etc.) depending on your client
-- A free Docker Hub account for Docker Desktop
+- Docker Desktop (free for personal use; a Docker Hub account is optional)
 
 ### What is Docker and why do I need it?
 

--- a/docs/VIDEO-SCRIPT.md
+++ b/docs/VIDEO-SCRIPT.md
@@ -165,18 +165,18 @@
 - Show selection summary: "1 client selected"
 - Click "Save Selection"
 
-#### Step 5: Docker Images Download (45 seconds)
+#### Step 5: Prepare Docker Images (45 seconds)
 
-**[Screen: Docker Images download screen]**
+**[Screen: Docker Images preparation screen]**
 
 **Narration:**
-> "The app now downloads necessary Docker images - these are the database and server components. This only happens once and takes about 5 to 15 minutes depending on your internet speed. I'll speed this up for the video."
+> "The app now prepares the necessary Docker images. It pulls the PostgreSQL database from Docker Hub and downloads the MCP server code to build locally. This only happens once and takes about 5 to 15 minutes depending on your internet speed. I'll speed this up for the video."
 
 **Actions:**
 - Show progress bar
-- Show which image is being downloaded
+- Show which image is being prepared (pulled or built)
 - [Fast-forward in editing to completion]
-- Show "All images loaded successfully" message
+- Show "All images prepared successfully" message
 
 #### Step 6: Typing Mind Installation (30 seconds)
 

--- a/resources/docker-images/README.md
+++ b/resources/docker-images/README.md
@@ -1,24 +1,35 @@
 # Docker Images Directory
 
-This directory contains pre-built Docker images that are bundled with the application to avoid building on the user's machine.
+> **⚠️ FUTURE ENHANCEMENT - NOT CURRENTLY USED**
+>
+> This directory is reserved for a planned future feature to bundle pre-built Docker images with the application.
+>
+> **Current Behavior:** The app currently pulls the PostgreSQL image from Docker Hub and builds MCP server images from source code during setup. This directory is not currently used by the application.
 
-## Expected Files
+---
 
-The following Docker images should be placed in this directory before packaging the application:
+This directory will contain pre-built Docker images that will be bundled with the application to provide faster, offline installation (planned future enhancement).
 
-1. **postgres-15.tar.gz** (~150MB)
-   - PostgreSQL 15 database image
-   - Source: `postgres:15`
+## Expected Files (For Future Implementation)
+
+When this feature is implemented, the following Docker images should be placed in this directory before packaging the application:
+
+1. **postgres-15.tar.gz** (or **postgres-16-alpine.tar.gz**) (~150MB)
+   - PostgreSQL database image
+   - **Current**: Pulled from Docker Hub during setup
+   - **Future**: Pre-bundled with installer
 
 2. **mcp-servers.tar.gz** (~200MB)
    - MCP servers custom image
-   - Source: `mcp-servers:latest`
+   - **Current**: Built from cloned source code during setup
+   - **Future**: Pre-built and bundled with installer
 
-## How to Export Docker Images
+## How to Export Docker Images (For Future Implementation)
 
-To create these image files for bundling, run the export script:
+When implementing this feature, these image files can be created using:
 
 ```bash
+# This script is prepared for the future feature
 npm run export-docker-images
 ```
 
@@ -29,45 +40,42 @@ Or manually export using Docker:
 docker pull postgres:15
 docker save postgres:15 | gzip > postgres-15.tar.gz
 
-# Export MCP servers image (after building)
+# Export MCP servers image
+# Note: Current implementation builds from cloned source, not local Dockerfile
 docker build -t mcp-servers:latest .
 docker save mcp-servers:latest | gzip > mcp-servers.tar.gz
 ```
 
-## Build Process
+## Build Process (Future Implementation)
 
-During the application packaging process (`npm run package`), these images will be:
+When this feature is implemented, during the application packaging process (`npm run package`), these images will be:
 
 1. Verified for existence (warning if missing)
 2. Included in the app's resources directory
 3. Loaded on first run or when requested by the user
 
-## File Sizes
+**Current Process:**
+- Images are NOT bundled with the installer
+- PostgreSQL is pulled from Docker Hub during setup
+- MCP servers are built from source during setup
+
+## File Sizes (Future)
 
 The bundled images will add approximately 350MB to the application package size. Users will benefit from:
 
 - Faster installation (no image building required)
 - Offline installation support
 - Consistent versions across all deployments
-- No need for Docker Hub access
+- Reduced dependency on external services
 
-## Development
+## Current Behavior
 
-During development, if these files are not present:
+Currently, this directory is not used. The application:
 
-- The application will still run
-- Image loading will fail gracefully
-- Users will need to pull/build images manually
-- Warnings will be logged
-
-## Production
-
-For production builds:
-
-1. Ensure both image files exist in this directory
-2. Verify file sizes are reasonable
-3. Test image loading after packaging
-4. Consider hosting images separately for very large deployments
+- ✅ Pulls PostgreSQL from Docker Hub automatically
+- ✅ Clones MCP server repositories and builds images
+- ✅ Works without any pre-bundled images
+- ✅ Provides progress feedback during image preparation
 
 ## Notes
 


### PR DESCRIPTION
Clarified that:
- PostgreSQL images are pulled from Docker Hub (not bundled)
- MCP server images are built from source code (not pre-bundled)
- Docker Hub account is optional (not required)
- Image pre-loading feature is a future enhancement, not current behavior

Updated files:
- README.md: Fixed Docker Hub account requirement text
- docs/USER-GUIDE.md: Updated FAQ and Step 5 to reflect actual behavior
- docs/FAQ.md: Changed "downloading" to "preparing" Docker images
- docs/VIDEO-SCRIPT.md: Updated Step 5 narration
- docs/DOCKER-IMAGE-PRELOADING.md: Marked as future enhancement
- docs/DOCKER-IMAGE-USAGE-EXAMPLE.md: Marked as future enhancement
- resources/docker-images/README.md: Clarified current vs future behavior