### PR TITLE
Fix Docker error and troubleshoot

### DIFF
--- a/scripts/README-CLEANUP.md
+++ b/scripts/README-CLEANUP.md
@@ -1,0 +1,81 @@
+# Docker Cleanup Scripts
+
+## Purpose
+
+These scripts help resolve Docker port conflicts (EADDRINUSE errors) by safely cleaning up MCP-related containers.
+
+## Safety
+
+**IMPORTANT:** These scripts are designed to ONLY affect MCP-related containers:
+- Containers with names starting with `mcp-`
+- Containers with names starting with `typing-mind-`
+
+**Your other Docker containers will NOT be affected.**
+
+## Usage
+
+### Linux/macOS
+
+```bash
+./scripts/cleanup-docker.sh
+```
+
+### Windows
+
+```cmd
+scripts\cleanup-docker.bat
+```
+
+## When to Use
+
+Use these scripts when:
+1. You encounter a `EADDRINUSE` error when starting the MCP system
+2. The application fails to start with port conflict messages
+3. You need to completely reset the MCP Docker containers
+
+## What the Scripts Do
+
+1. Check if Docker is running
+2. Find all MCP-related containers
+3. Stop those containers
+4. Remove those containers
+5. Leave volumes intact (unless you uncomment the volume cleanup section)
+
+## Automatic Cleanup
+
+The MCP system now includes automatic cleanup:
+- Before starting services, old containers are automatically stopped and removed
+- If port conflicts are detected, the system attempts automatic recovery
+- These scripts are only needed if automatic cleanup fails
+
+## Manual Docker Commands
+
+If you prefer to run Docker commands directly:
+
+```bash
+# View MCP containers
+docker ps -a --filter "name=mcp-" --filter "name=typing-mind-"
+
+# Stop MCP containers only
+docker stop $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q)
+
+# Remove MCP containers only
+docker rm $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q)
+```
+
+## Troubleshooting
+
+If you still encounter port conflicts after running the cleanup:
+
+1. Check if another application is using the port:
+   ```bash
+   # Linux/macOS
+   lsof -i :50880
+
+   # Windows (PowerShell)
+   Get-NetTCPConnection -LocalPort 50880
+   ```
+
+2. Change the port in the MCP Electron App environment configuration
+
+3. Restart Docker Desktop

--- a/scripts/cleanup-docker.bat
+++ b/scripts/cleanup-docker.bat
@@ -1,0 +1,52 @@
+@echo off
+REM MCP Docker Cleanup Script (Windows)
+REM This script helps resolve Docker port conflicts by stopping and removing ONLY MCP-related containers
+REM
+REM IMPORTANT: This script ONLY affects containers with names starting with:
+REM   - mcp-
+REM   - typing-mind-
+REM
+REM Other Docker containers on your system will NOT be affected.
+
+echo MCP Docker Cleanup Script
+echo =========================
+echo.
+echo WARNING: This will stop and remove MCP-related containers only.
+echo          Other Docker containers will NOT be affected.
+echo.
+
+REM Check if Docker is running
+docker info >nul 2>&1
+if errorlevel 1 (
+    echo Error: Docker is not running. Please start Docker Desktop first.
+    exit /b 1
+)
+
+echo Finding MCP-related containers...
+docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" --format "{{.Names}}" > temp_containers.txt
+
+REM Check if file is empty
+for %%A in (temp_containers.txt) do if %%~zA==0 (
+    echo No MCP containers found. System is clean.
+    del temp_containers.txt
+    exit /b 0
+)
+
+echo Found containers:
+type temp_containers.txt
+echo.
+
+REM Stop containers
+echo Stopping containers...
+for /f %%i in ('docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q') do docker stop %%i
+echo Containers stopped
+
+REM Remove containers
+echo Removing containers...
+for /f %%i in ('docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q') do docker rm %%i
+echo Containers removed
+
+del temp_containers.txt
+
+echo.
+echo Cleanup complete! You can now restart the MCP system.

--- a/scripts/cleanup-docker.sh
+++ b/scripts/cleanup-docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# MCP Docker Cleanup Script
+# This script helps resolve Docker port conflicts by stopping and removing ONLY MCP-related containers
+#
+# IMPORTANT: This script ONLY affects containers with names starting with:
+#   - mcp-
+#   - typing-mind-
+#
+# Other Docker containers on your system will NOT be affected.
+
+echo "MCP Docker Cleanup Script"
+echo "========================="
+echo ""
+echo "⚠️  WARNING: This will stop and remove MCP-related containers only."
+echo "    Other Docker containers will NOT be affected."
+echo ""
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "❌ Error: Docker is not running. Please start Docker Desktop first."
+    exit 1
+fi
+
+echo "🔍 Finding MCP-related containers..."
+CONTAINERS=$(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" --format "{{.Names}}")
+
+if [ -z "$CONTAINERS" ]; then
+    echo "✅ No MCP containers found. System is clean."
+    exit 0
+fi
+
+echo "Found containers:"
+echo "$CONTAINERS"
+echo ""
+
+# Stop containers
+echo "🛑 Stopping containers..."
+docker stop $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q) 2>/dev/null
+echo "✅ Containers stopped"
+
+# Remove containers
+echo "🗑️  Removing containers..."
+docker rm $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q) 2>/dev/null
+echo "✅ Containers removed"
+
+# Optional: Clean up volumes (uncomment if needed)
+# echo "🗑️  Removing volumes..."
+# docker volume rm $(docker volume ls -q --filter "name=mcp-" --filter "name=postgres-data") 2>/dev/null
+# echo "✅ Volumes removed"
+
+echo ""
+echo "✅ Cleanup complete! You can now restart the MCP system."


### PR DESCRIPTION
Resolves the "address already in use" error that occurs when starting the MCP connector service.

Changes:
- Add automatic container cleanup before starting services using docker-compose down
- Implement EADDRINUSE error detection with automatic retry logic
- Add force cleanup with orphan removal when port conflicts persist
- Create cleanup-docker.sh and cleanup-docker.bat scripts (ONLY affect MCP containers)
- Add comprehensive documentation explaining safety and usage
- Improve error messages with specific, safe troubleshooting instructions

Safety:
- docker-compose down only affects containers in the compose file
- Cleanup scripts filter by name (mcp-*, typing-mind-*) to protect other containers
- Clear warnings added to prevent accidental removal of non-MCP containers
- Volumes are preserved unless explicitly removed

The fix ensures:
1. Old MCP containers are properly stopped before new ones start
2. Port conflicts are detected and handled with automatic retry
3. Users have clear, safe instructions and tools for manual cleanup
4. Other Docker containers on the system are never affected