### PR TITLE
Enhance Docker port conflict resolution with aggressive cleanup and d…

### DIFF
--- a/scripts/README-CLEANUP.md
+++ b/scripts/README-CLEANUP.md
@@ -1,8 +1,8 @@
-# Docker Cleanup Scripts
+# Docker Cleanup and Diagnostic Scripts
 
 ## Purpose
 
-These scripts help resolve Docker port conflicts (EADDRINUSE errors) by safely cleaning up MCP-related containers.
+These scripts help resolve Docker port conflicts (EADDRINUSE errors) by diagnosing and safely cleaning up MCP-related containers.
 
 ## Safety
 
@@ -12,15 +12,42 @@ These scripts help resolve Docker port conflicts (EADDRINUSE errors) by safely c
 
 **Your other Docker containers will NOT be affected.**
 
-## Usage
+## Available Scripts
 
-### Linux/macOS
+### 1. Diagnostic Tool (Recommended First Step)
+
+Run this first to identify what's causing the port conflict:
+
+#### Linux/macOS
+
+```bash
+./scripts/debug-docker-ports.sh
+```
+
+#### Windows
+
+```cmd
+scripts\debug-docker-ports.bat
+```
+
+**What it does:**
+- Checks Docker status
+- Lists all MCP containers and their status
+- Checks port usage for ports 5432, 50880, and 3000
+- Identifies Docker networks
+- Offers interactive cleanup with verification
+
+### 2. Cleanup Scripts (Quick Fix)
+
+Use these for a quick cleanup without diagnostics:
+
+#### Linux/macOS
 
 ```bash
 ./scripts/cleanup-docker.sh
 ```
 
-### Windows
+#### Windows
 
 ```cmd
 scripts\cleanup-docker.bat
@@ -63,6 +90,26 @@ docker stop $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q)
 docker rm $(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q)
 ```
 
+## Recommended Workflow for Port Conflicts
+
+1. **First, try the diagnostic tool:**
+   ```bash
+   ./scripts/debug-docker-ports.sh  # or .bat on Windows
+   ```
+   This will help you understand what's causing the issue.
+
+2. **If the diagnostic tool offers cleanup, accept it** - it will safely remove only MCP containers.
+
+3. **If issues persist**, try the quick cleanup script:
+   ```bash
+   ./scripts/cleanup-docker.sh  # or .bat on Windows
+   ```
+
+4. **Still having issues?** Try these additional steps:
+   - Restart Docker Desktop
+   - Run the diagnostic tool again
+   - Check the application logs for more details
+
 ## Troubleshooting
 
 If you still encounter port conflicts after running the cleanup:
@@ -76,6 +123,10 @@ If you still encounter port conflicts after running the cleanup:
    Get-NetTCPConnection -LocalPort 50880
    ```
 
-2. Change the port in the MCP Electron App environment configuration
+2. Use the diagnostic tool to identify which process is using the port
 
-3. Restart Docker Desktop
+3. Change the port in the MCP Electron App environment configuration
+
+4. Restart Docker Desktop
+
+5. As a last resort, restart your computer to clear all port bindings

--- a/scripts/debug-docker-ports.bat
+++ b/scripts/debug-docker-ports.bat
@@ -1,0 +1,117 @@
+@echo off
+REM Debug Docker Port Conflicts
+REM This script helps diagnose and fix Docker port conflicts for the MCP system
+
+echo ================================================
+echo Docker Port Conflict Diagnostic Tool
+echo ================================================
+echo.
+
+REM Check if Docker is running
+echo 1. Checking Docker status...
+docker info >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] Docker is not running
+    echo         Please start Docker Desktop and try again
+    exit /b 1
+)
+echo [OK] Docker is running
+echo.
+
+REM Check for MCP containers
+echo 2. Checking for MCP containers...
+docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" --format "{{.ID}} {{.Names}} {{.Status}}" > temp_containers.txt
+if %errorlevel% neq 0 (
+    echo [ERROR] Failed to check containers
+    del temp_containers.txt 2>nul
+    exit /b 1
+)
+
+set FOUND_CONTAINERS=0
+for /f "tokens=*" %%a in (temp_containers.txt) do (
+    set FOUND_CONTAINERS=1
+    echo    %%a
+)
+
+if %FOUND_CONTAINERS%==0 (
+    echo [OK] No MCP containers found
+) else (
+    echo [WARNING] Found MCP containers ^(listed above^)
+)
+del temp_containers.txt
+echo.
+
+REM Check ports
+echo 3. Checking port usage...
+echo    Note: Windows port checking requires additional tools
+echo    Checking Docker containers on common MCP ports...
+
+docker ps --format "{{.Names}} {{.Ports}}" | findstr /C:"5432" /C:"50880" /C:"3000" > temp_ports.txt
+if %errorlevel% neq 0 (
+    echo [OK] No containers found using MCP ports
+) else (
+    echo [WARNING] Containers using MCP ports:
+    type temp_ports.txt
+)
+del temp_ports.txt 2>nul
+echo.
+
+REM Check Docker networks
+echo 4. Checking Docker networks...
+docker network ls --filter "name=mcp" --format "{{.ID}} {{.Name}}" > temp_networks.txt
+set FOUND_NETWORKS=0
+for /f "tokens=*" %%a in (temp_networks.txt) do (
+    set FOUND_NETWORKS=1
+    echo    %%a
+)
+
+if %FOUND_NETWORKS%==0 (
+    echo [OK] No MCP networks found
+) else (
+    echo [WARNING] Found MCP networks ^(listed above^)
+)
+del temp_networks.txt
+echo.
+
+REM Offer cleanup
+echo 5. Cleanup Options
+echo ==================
+echo.
+
+docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q > temp_cleanup.txt
+set NEED_CLEANUP=0
+for /f %%a in (temp_cleanup.txt) do set NEED_CLEANUP=1
+del temp_cleanup.txt
+
+if %NEED_CLEANUP%==1 (
+    set /p CLEANUP="Would you like to clean up MCP containers? (y/n): "
+    if /i "%CLEANUP%"=="y" (
+        echo Stopping MCP containers...
+        for /f %%i in ('docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q') do docker stop %%i
+
+        echo Removing MCP containers...
+        for /f %%i in ('docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q') do docker rm -f %%i
+
+        echo [OK] Cleanup complete
+
+        echo Waiting 3 seconds for ports to be released...
+        timeout /t 3 /nobreak >nul
+
+        echo.
+        echo 6. Cleanup successful!
+        echo    You can now try starting the MCP system again.
+    )
+) else (
+    echo [OK] No cleanup needed - no MCP containers found
+)
+
+echo.
+echo ================================================
+echo Diagnostic complete!
+echo.
+echo If you're still experiencing port conflicts:
+echo 1. Restart Docker Desktop
+echo 2. Run this script again
+echo 3. Check for other applications using ports 5432, 50880, or 3000
+echo.
+pause

--- a/scripts/debug-docker-ports.sh
+++ b/scripts/debug-docker-ports.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Debug Docker Port Conflicts
+# This script helps diagnose and fix Docker port conflicts for the MCP system
+
+set -e
+
+echo "🔍 Docker Port Conflict Diagnostic Tool"
+echo "========================================"
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if Docker is running
+echo "1. Checking Docker status..."
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${RED}❌ Docker is not running${NC}"
+    echo "   Please start Docker Desktop and try again"
+    exit 1
+fi
+echo -e "${GREEN}✓ Docker is running${NC}"
+echo ""
+
+# Check for MCP containers
+echo "2. Checking for MCP containers..."
+MCP_CONTAINERS=$(docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" --format "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}")
+if [ -z "$MCP_CONTAINERS" ]; then
+    echo -e "${GREEN}✓ No MCP containers found${NC}"
+else
+    echo -e "${YELLOW}Found MCP containers:${NC}"
+    echo "$MCP_CONTAINERS" | while IFS=$'\t' read -r id name status ports; do
+        echo "   Container: $name"
+        echo "   ID: $id"
+        echo "   Status: $status"
+        echo "   Ports: ${ports:-none}"
+        echo ""
+    done
+fi
+echo ""
+
+# Check port usage
+echo "3. Checking port usage..."
+PORTS=(5432 50880 3000)
+PORT_NAMES=("PostgreSQL" "MCP Connector" "HTTP/SSE Server")
+
+for i in "${!PORTS[@]}"; do
+    PORT="${PORTS[$i]}"
+    NAME="${PORT_NAMES[$i]}"
+
+    echo "   Checking port $PORT ($NAME)..."
+
+    # Check host port
+    if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+        PROCESS=$(lsof -Pi :$PORT -sTCP:LISTEN | tail -n 1)
+        echo -e "   ${RED}⚠ Port $PORT is in use on host:${NC}"
+        echo "   $PROCESS"
+    else
+        echo -e "   ${GREEN}✓ Port $PORT is available on host${NC}"
+    fi
+
+    # Check Docker containers using this port
+    CONTAINERS_ON_PORT=$(docker ps --format "{{.ID}}\t{{.Names}}\t{{.Ports}}" | grep ":$PORT->" || true)
+    if [ ! -z "$CONTAINERS_ON_PORT" ]; then
+        echo -e "   ${YELLOW}Docker containers using port $PORT:${NC}"
+        echo "$CONTAINERS_ON_PORT" | while IFS=$'\t' read -r id name ports; do
+            echo "      $name (ID: $id)"
+        done
+    fi
+    echo ""
+done
+echo ""
+
+# Check Docker networks
+echo "4. Checking Docker networks..."
+DOCKER_NETWORKS=$(docker network ls --filter "name=mcp" --format "{{.ID}}\t{{.Name}}")
+if [ -z "$DOCKER_NETWORKS" ]; then
+    echo -e "${GREEN}✓ No MCP networks found${NC}"
+else
+    echo -e "${YELLOW}Found MCP networks:${NC}"
+    echo "$DOCKER_NETWORKS"
+fi
+echo ""
+
+# Offer cleanup options
+echo "5. Cleanup Options"
+echo "=================="
+echo ""
+if [ ! -z "$MCP_CONTAINERS" ]; then
+    echo -e "${YELLOW}Would you like to clean up MCP containers? (y/n)${NC}"
+    read -r CLEANUP
+    if [ "$CLEANUP" = "y" ] || [ "$CLEANUP" = "Y" ]; then
+        echo "Stopping MCP containers..."
+        docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q | xargs -r docker stop
+        echo "Removing MCP containers..."
+        docker ps -a --filter "name=mcp-" --filter "name=typing-mind-" -q | xargs -r docker rm -f
+        echo -e "${GREEN}✓ Cleanup complete${NC}"
+
+        # Wait for ports to be released
+        echo "Waiting 3 seconds for ports to be released..."
+        sleep 3
+
+        echo ""
+        echo "6. Re-checking port status..."
+        for i in "${!PORTS[@]}"; do
+            PORT="${PORTS[$i]}"
+            NAME="${PORT_NAMES[$i]}"
+
+            if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+                echo -e "   ${RED}⚠ Port $PORT ($NAME) is still in use${NC}"
+            else
+                echo -e "   ${GREEN}✓ Port $PORT ($NAME) is now available${NC}"
+            fi
+        done
+    fi
+else
+    echo -e "${GREEN}No cleanup needed - no MCP containers found${NC}"
+fi
+
+echo ""
+echo "=========================================="
+echo "Diagnostic complete!"
+echo ""
+echo "If you're still experiencing port conflicts:"
+echo "1. Restart Docker Desktop"
+echo "2. Run this script again"
+echo "3. Check for other applications using ports 5432, 50880, or 3000"
+echo ""


### PR DESCRIPTION
…iagnostics

Addresses persistent EADDRINUSE errors on port 50880 by implementing more robust container cleanup and retry logic, plus new diagnostic tools.

Root Cause Analysis:
- Error occurs inside Docker container at 172.21.0.2:50880 (internal Docker IP)
- Previous cleanup was too brief, allowing port conflicts to persist
- Container processes weren't fully terminated before restart attempts

Key Improvements:

1. Enhanced Cleanup Process (src/main/mcp-system.ts):
   - Added graceful container stop before removal
   - Increased wait time from 1s to 3s for port release
   - Added --volumes flag to docker-compose down for complete cleanup
   - Force remove lingering containers using docker rm -f
   - Multi-stage cleanup: stop → down → force remove → wait

2. Improved Retry Logic:
   - Increased from 1 retry to 3 retries
   - Progressive wait times: 3s, 5s, 7s between attempts
   - Each retry includes full cleanup cycle
   - Better error messages with troubleshooting steps
   - Graceful handling when all retries exhausted

3. New Diagnostic Tools:
   - debug-docker-ports.sh (Linux/macOS)
   - debug-docker-ports.bat (Windows)
   - Features:
     * Check Docker status
     * List all MCP containers with status * Check port usage on 5432, 50880, 3000 * Identify Docker networks * Interactive cleanup with verification * Post-cleanup port status verification

4. Documentation Updates (scripts/README-CLEANUP.md):
   - Added recommended workflow for port conflicts
   - Documented diagnostic tool usage
   - Clear troubleshooting steps
   - Safety information emphasized

Technical Details:
- Wait times increased to allow Docker networking to fully release ports
- Added volume cleanup to prevent stale data from causing issues
- Force removal catches edge cases where graceful stop fails
- Diagnostic tools help users understand what's blocking ports

Testing:
- Cleanup process now handles:
  * Running containers
  * Stopped containers
  * Orphaned containers
  * Lingering Docker networks
  * Port bindings that persist after container stop

Future Considerations:
- Monitor for issues with Docker Desktop restarts
- Consider adding automatic Docker Desktop restart if persistent failures
- May need to investigate container startup scripts if issue persists

Fixes: EADDRINUSE error on Docker container port 50880
Related: Previous fix in commit f8f9837