### PR TITLE
Fix MCP server connection errors in Cursor

### DIFF
--- a/src/main/typingmind-auto-config.ts
+++ b/src/main/typingmind-auto-config.ts
@@ -25,8 +25,8 @@ export interface TypingMindMCPConfig {
  * MCP Server configuration for a single server
  */
 export interface MCPServerConfig {
-  command: string;
-  args: string[];
+  command?: string;
+  args?: string[];
   env?: {
     [key: string]: string;
   };
@@ -120,10 +120,9 @@ export async function buildMCPServersConfig(): Promise<MCPServersConfig> {
 
   // Build URL-based configuration for each server
   // These URLs point to the HTTP/SSE server running inside the Docker container
+  // For HTTP/SSE mode, only the URL is needed (no command/args)
   for (const serverName of servers) {
     config.mcpServers[serverName] = {
-      command: 'url',
-      args: [`http://localhost:${envConf.HTTP_SSE_PORT}/${serverName}`],
       url: `http://localhost:${envConf.HTTP_SSE_PORT}/${serverName}`
     };
 
@@ -132,8 +131,6 @@ export async function buildMCPServersConfig(): Promise<MCPServersConfig> {
 
   // Include author-server (uses author-server endpoint)
   config.mcpServers['author-server'] = {
-    command: 'url',
-    args: [`http://localhost:${envConf.HTTP_SSE_PORT}/author-server`],
     url: `http://localhost:${envConf.HTTP_SSE_PORT}/author-server`
   };
   logWithCategory('info', LogCategory.SYSTEM, `Configured MCP server: author-server -> http://localhost:${envConf.HTTP_SSE_PORT}/author-server`);


### PR DESCRIPTION
The MCP servers were failing to initialize with "spawn url ENOENT" errors because the configuration was incorrectly trying to execute a command called "url". For HTTP/SSE-based MCP servers, only the URL field is needed.

Changes:
- Made command and args optional in MCPServerConfig interface
- Removed invalid command:'url' and args from server configurations
- Servers now use only the url field for HTTP/SSE connections

Fixes the "Unable to connect to MCP servers" error in TypingMind UI.