### PR TITLE
Set up Docker Compose for services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./init-db:/docker-entrypoint-initdb.d
+      - ./repositories/mcp-writing-servers:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -28,7 +28,7 @@ services:
     container_name: mcp-connector
     working_dir: /app
     command: >
-      sh -c "npm install -g @typingmind/mcp@latest && 
+      sh -c "npm install -g @typingmind/mcp@latest &&
              npx @typingmind/mcp@latest $${MCP_AUTH_TOKEN}"
     environment:
       PORT: 50880
@@ -36,7 +36,7 @@ services:
     ports:
       - "50880:50880"
     volumes:
-      - ./mcp-config:/config
+      - ./repositories/mcp-writing-servers/mcp-config:/config
       - mcp_workspace:/workspace
     depends_on:
       postgres:
@@ -51,7 +51,7 @@ services:
   # Each MCP server runs on its own port for isolation
   mcp-writing-servers:
     build:
-      context: ./mcp-writing-servers
+      context: ./repositories/mcp-writing-servers
       dockerfile: Dockerfile
     container_name: mcp-writing-servers
     environment:
@@ -71,7 +71,7 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ./mcp-writing-servers:/app
+      - ./repositories/mcp-writing-servers:/app
       - /app/node_modules
     networks:
       - writing-network
@@ -84,7 +84,7 @@ services:
     ports:
       - "8080:80"
     volumes:
-      - ./typingmind:/usr/share/nginx/html:ro
+      - ./repositories/typingmind:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       postgres:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression for better performance
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Main location block - serve static files
+    location / {
+        try_files $uri $uri/ /index.html;
+
+        # Cache static assets
+        location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+    }
+
+    # Disable cache for HTML files to ensure updates are served
+    location ~* \.html$ {
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+
+    # Error pages
+    error_page 404 /index.html;
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
- Update all volume mounts and build contexts to use ./repositories/ directory
- PostgreSQL now loads init.sql from ./repositories/mcp-writing-servers
- MCP connector uses mcp-config from ./repositories/mcp-writing-servers/mcp-config
- MCP writing servers build from ./repositories/mcp-writing-servers/Dockerfile
- TypingMind serves from ./repositories/typingmind
- Add nginx.conf with SPA routing, caching, compression, and security headers

This aligns with the Electron app's structure where it clones repositories into a dedicated ./repositories/ directory during installation.