### PR TITLE
Fix Docker container creation with four services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./repositories/mcp-writing-servers:/docker-entrypoint-initdb.d:ro
+      - ${MCP_WRITING_SERVERS_DIR}:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -36,7 +36,7 @@ services:
     ports:
       - "50880:50880"
     volumes:
-      - ./repositories/mcp-writing-servers/mcp-config:/config
+      - ${MCP_WRITING_SERVERS_DIR}/mcp-config:/config
       - mcp_workspace:/workspace
     depends_on:
       postgres:
@@ -51,7 +51,7 @@ services:
   # Each MCP server runs on its own port for isolation
   mcp-writing-servers:
     build:
-      context: ./repositories/mcp-writing-servers
+      context: ${MCP_WRITING_SERVERS_DIR}
       dockerfile: Dockerfile
     container_name: mcp-writing-servers
     environment:
@@ -71,7 +71,7 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ./repositories/mcp-writing-servers:/app
+      - ${MCP_WRITING_SERVERS_DIR}:/app
       - /app/node_modules
     networks:
       - writing-network
@@ -84,8 +84,8 @@ services:
     ports:
       - "8080:80"
     volumes:
-      - ./repositories/typingmind:/usr/share/nginx/html:ro
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${TYPING_MIND_DIR}:/usr/share/nginx/html:ro
+      - ${NGINX_CONF_PATH}:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "docker-compose.yml",
+        "to": "docker-compose.yml"
+      },
+      {
+        "from": "nginx.conf",
+        "to": "nginx.conf"
       }
     ],
     "win": {

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -337,6 +337,10 @@ async function execDockerCompose(
         TYPING_MIND_DIR: typingMindDownloader.getTypingMindDirectory(),
         // Path to MCP config file for Docker volume mounting
         MCP_CONFIG_FILE_PATH: mcpConfigPath,
+        // Repository paths for Docker volume mounting
+        MCP_WRITING_SERVERS_DIR: getMCPRepositoryDirectory(),
+        // nginx.conf path for TypingMind container
+        NGINX_CONF_PATH: path.join(workingDir, 'nginx.conf'),
       }
     });
     return result;


### PR DESCRIPTION
This commit resolves the issue where the packaged Electron app couldn't find docker-compose.yml and failed to create Docker containers with 4 services.

Changes:
1. Updated package.json to include docker-compose.yml and nginx.conf in extraResources
   - These files are now bundled with the packaged app in the resources directory

2. Updated docker-compose.yml to use environment variables for all paths
   - Changed ./repositories/mcp-writing-servers to ${MCP_WRITING_SERVERS_DIR}
   - Changed ./repositories/typingmind to ${TYPING_MIND_DIR}
   - Changed ./nginx.conf to ${NGINX_CONF_PATH}
   - This ensures paths work correctly in both development and packaged modes

3. Updated src/main/mcp-system.ts to pass repository path environment variables
   - Added MCP_WRITING_SERVERS_DIR environment variable
   - Added NGINX_CONF_PATH environment variable
   - These resolve to absolute paths that work in packaged apps

The app will now correctly:
- Find docker-compose.yml in the packaged app resources directory
- Resolve repository paths to the user data directory
- Create and start all 4 Docker services (postgres, mcp-connector, mcp-writing-servers, typingmind)