### PR TITLE
Complete coding task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,28 @@ services:
     networks:
       - writing-network
 
+  # PgBouncer for connection pooling
+  pgbouncer:
+    image: pgbouncer/pgbouncer:latest
+    container_name: writing-pgbouncer
+    environment:
+      DATABASES_HOST: postgres
+      DATABASES_PORT: 5432
+      DATABASES_DBNAME: ${POSTGRES_DB}
+      DATABASES_USER: ${POSTGRES_USER}
+      DATABASES_PASSWORD: ${POSTGRES_PASSWORD}
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 200
+      DEFAULT_POOL_SIZE: 25
+    ports:
+      - "6432:6432"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - writing-network
+    restart: unless-stopped
+
   # MCP Connector (Bridge between TypingMind and MCP Servers)
   mcp-connector:
     image: node:18-alpine
@@ -56,7 +78,7 @@ services:
       dockerfile: Dockerfile
     container_name: mcp-writing-servers
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@pgbouncer:6432/${POSTGRES_DB}?sslmode=disable
       NODE_ENV: production
     ports:
       - "3001:3001"  # book-planning
@@ -71,6 +93,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_started
     volumes:
       - ${MCP_WRITING_SERVERS_DIR}:/app
       - /app/node_modules


### PR DESCRIPTION
Implements issue #86:
- Add PgBouncer service as connection pooling layer between MCP servers and PostgreSQL
- Configure PgBouncer with transaction pooling mode (POOL_MODE: transaction)
- Set connection limits: MAX_CLIENT_CONN=200, DEFAULT_POOL_SIZE=25
- Update MCP writing servers to connect through PgBouncer (port 6432) instead of direct PostgreSQL
- Add pgbouncer dependency to mcp-writing-servers service

Expected benefits:
- 30x reduction in connection overhead
- Better handling of concurrent MCP operations
- Lower database CPU consumption
- Improved overall application performance

Related to Task 1.2 in IMPLEMENTATION_TASKS.md