### PR TITLE
Add health check to MCP Connector service (Issue #90)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       PORT: 50880
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN}
+      NODE_ENV: production
     ports:
       - "50880:50880"
     volumes:
@@ -69,6 +70,12 @@ services:
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:50880/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   # MCP Writing Servers (Custom servers from your repo)
   # Each MCP server runs on its own port for isolation


### PR DESCRIPTION
- Add NODE_ENV: production to mcp-connector environment
- Add health check configuration with wget ping endpoint
- Health check runs every 30s with 10s timeout and 3 retries
- 40s start period to allow service initialization

This enables automatic detection of connector failures and improves overall system reliability and monitoring capabilities.

Implements Task 3.1 from IMPLEMENTATION_TASKS.md
Resolves #90