### PR TITLE
Fix pgBouncer not loading after Docker changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     network_mode: host
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ${MCP_WRITING_SERVERS_DIR}/init-db.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - ${MCP_WRITING_SERVERS_DIR}/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 10s


### PR DESCRIPTION
The volume mount was referencing init-db.sql but the actual file in MCP-Writing-Servers repo is init.sql. This was preventing postgres from properly initializing and blocking pgBouncer startup.