### PR TITLE
Fix Typing Mind and MCP connector cloning

### DIFF
--- a/config/setup-config.json
+++ b/config/setup-config.json
@@ -19,8 +19,8 @@
       "url": "https://github.com/TypingMind/typingmind-mcp.git",
       "clonePath": "typingmind-mcp",
       "branch": "main",
-      "optional": false,
-      "description": "MCP connector for Typing Mind integration"
+      "optional": true,
+      "description": "MCP connector for Typing Mind integration (deprecated - using npm package instead)"
     },
     {
       "id": "typing-mind",
@@ -35,12 +35,10 @@
   "buildOrder": {
     "order": [
       "mcp-writing-servers",
-      "typingmind-mcp",
       "typing-mind"
     ],
     "dependencies": {
       "mcp-writing-servers": [],
-      "typingmind-mcp": ["mcp-writing-servers"],
       "typing-mind": []
     },
     "allowParallel": false
@@ -86,11 +84,10 @@
     {
       "id": "core-system",
       "name": "Core System",
-      "description": "Core MCP system including Writing Servers and MCP Connector",
+      "description": "Core MCP system including Writing Servers",
       "enabled": true,
       "repositoryIds": [
-        "mcp-writing-servers",
-        "typingmind-mcp"
+        "mcp-writing-servers"
       ]
     },
     {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1699,13 +1699,13 @@ function setupIPC(): void {
         logWithCategory('info', LogCategory.GENERAL, 'Resolved config path', { resolvedConfigPath });
         await currentPipelineOrchestrator.loadConfig(resolvedConfigPath);
 
-        // Ensure workingDirectory is set to project root if not provided
-        // This ensures repositories are cloned to ./repositories/ relative to project root
-        // where Docker Compose can find them for volume mounts
+        // Ensure workingDirectory is set to userData if not provided
+        // This ensures repositories are cloned to {userData}/repositories/
+        // where Docker Compose expects them for volume mounts (via environment variables)
         const options = request.options || {};
         if (!options.workingDirectory) {
-          options.workingDirectory = mcpSystem.getProjectRootDirectory();
-          logWithCategory('info', LogCategory.GENERAL, 'Using project root as working directory', { workingDirectory: options.workingDirectory });
+          options.workingDirectory = mcpSystem.getMCPWorkingDirectory();
+          logWithCategory('info', LogCategory.GENERAL, 'Using userData as working directory', { workingDirectory: options.workingDirectory });
         }
 
         // Create progress throttler


### PR DESCRIPTION
After the FictionLab rebranding, repositories were not cloning to the correct location, causing only MCP-Writing-Servers to appear.

Root cause:
- Docker expects repositories in {userData}/repositories/ (via env vars)
- Build pipeline was cloning to {projectRoot}/repositories/
- This path mismatch meant repositories weren't found by Docker

Changes:
1. Updated build pipeline to use getMCPWorkingDirectory() (userData) instead of getProjectRootDirectory() in src/main/index.ts:1707

2. Removed typingmind-mcp from core-system component since Docker uses the npm package @typingmind/mcp@latest instead of a cloned repo

3. Marked typingmind-mcp repository as optional and deprecated in config/setup-config.json

Now all repositories (mcp-writing-servers and typing-mind) will clone to the correct {userData}/repositories/ directory where Docker expects them for volume mounts.

Fixes repository discovery issues after FictionLab rebranding.