### PR TITLE
Fix setup process after app rebranding

### DIFF
--- a/src/main/typingmind-downloader.ts
+++ b/src/main/typingmind-downloader.ts
@@ -76,7 +76,7 @@ export function getTypingMindDirectory(): string {
  */
 function getTempCloneDirectory(): string {
   const userDataPath = app.getPath('userData');
-  return path.join(userDataPath, 'mcp-writing-system', TEMP_CLONE_DIR);
+  return path.join(userDataPath, TEMP_CLONE_DIR);
 }
 
 /**
@@ -84,7 +84,7 @@ function getTempCloneDirectory(): string {
  */
 export function getMetadataPath(): string {
   const userDataPath = app.getPath('userData');
-  return path.join(userDataPath, 'mcp-writing-system', '.metadata.json');
+  return path.join(userDataPath, '.metadata.json');
 }
 
 /**

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1282,7 +1282,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
      * Get service logs
      */
     getLogs: (
-      serviceName: 'postgres' | 'mcp-writing-system' | 'mcp-connector' | 'typing-mind',
+      serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector' | 'typing-mind',
       tail?: number
     ): Promise<ServiceLogsResult> => {
       return ipcRenderer.invoke('mcp-system:logs', serviceName, tail);

--- a/src/renderer/dashboard-handlers.ts
+++ b/src/renderer/dashboard-handlers.ts
@@ -311,7 +311,7 @@ function updateStatusIndicator(status: MCPSystemStatus): void {
     // Typing Mind and MCP Connector are optional and don't affect overall health
     const coreContainers = status.containers.filter(c =>
       c.name.includes('postgres') ||
-      c.name.includes('mcp-writing-system') ||
+      c.name.includes('mcp-writing-servers') ||
       c.name.includes('mcp-connector')
     );
 
@@ -397,10 +397,10 @@ function updatePostgreSQLCard(status: MCPSystemStatus, config: EnvConfig): void 
 
 /**
  * Update MCP Servers service card
- * Note: Looks for 'mcp-writing-system' (from core.yml) or 'mcp-connector' (from main compose file)
+ * Note: Looks for 'mcp-writing-servers' or 'mcp-connector'
  */
 function updateMCPServersCard(status: MCPSystemStatus): void {
-  const container = status.containers.find(c => c.name.includes('mcp-writing-system') || c.name.includes('mcp-connector'));
+  const container = status.containers.find(c => c.name.includes('mcp-writing-servers') || c.name.includes('mcp-connector'));
 
   const statusIcon = document.getElementById('mcp-servers-status-icon');
   const statusText = document.getElementById('mcp-servers-status-text');
@@ -755,9 +755,9 @@ async function handleConfigureClaudeDesktop(): Promise<void> {
 async function handleViewLogs(serviceName: string): Promise<void> {
   try {
     // Map UI service names to actual service names
-    const serviceMap: { [key: string]: 'postgres' | 'mcp-writing-system' | 'mcp-connector' | 'typing-mind' } = {
+    const serviceMap: { [key: string]: 'postgres' | 'mcp-writing-servers' | 'mcp-connector' | 'typing-mind' } = {
       'postgres': 'postgres',
-      'mcp-servers': 'mcp-writing-system',
+      'mcp-servers': 'mcp-writing-servers',
       'mcp-connector': 'mcp-connector',
       'typing-mind': 'typing-mind',
     };

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -299,7 +299,7 @@ interface ElectronAPI {
     restart: () => Promise<MCPSystemOperationResult>;
     getStatus: () => Promise<MCPSystemStatus>;
     getUrls: () => Promise<ServiceUrls>;
-    getLogs: (serviceName: 'postgres' | 'mcp-writing-system' | 'mcp-connector' | 'typing-mind', tail?: number) => Promise<ServiceLogsResult>;
+    getLogs: (serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector' | 'typing-mind', tail?: number) => Promise<ServiceLogsResult>;
     checkPorts: () => Promise<PortConflictResult>;
     getWorkingDirectory: () => Promise<string>;
     onProgress: (callback: (progress: MCPSystemProgress) => void) => void;


### PR DESCRIPTION
After rebranding from MCP-Electron-App to FictionLab, the TypingMind service was no longer being created in Docker. This was caused by hardcoded references to 'mcp-writing-system' directory paths and incorrect container names.

Changes:
1. Removed hardcoded 'mcp-writing-system' subdirectory from:
   - getTempCloneDirectory() in typingmind-downloader.ts
   - getMetadataPath() in typingmind-downloader.ts

   These now correctly use the app's userData directory directly,
   which adapts to the new app name automatically.

2. Fixed container name references from 'mcp-writing-system' to 'mcp-writing-servers' to match the actual Docker container name:
   - Updated dashboard-handlers.ts health checks
   - Updated dashboard-handlers.ts log viewer
   - Updated preload.ts type definitions
   - Updated renderer.ts type definitions

The metadata can now be found correctly, allowing isInstalled() to return the proper status and enabling TypingMind Docker service creation.

Fixes critical setup functionality after rebranding.