### PR TITLE
Fix logo icon display issue

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1444,7 +1444,7 @@
 </head>
 <body>
     <header>
-        <h1><img src="../resources/icon.png" alt="FictionLab Logo" class="header-icon">FictionLab</h1>
+        <h1><img src="icon.png" alt="FictionLab Logo" class="header-icon">FictionLab</h1>
         <p class="subtitle">Your AI-Powered Writing Laboratory</p>
     </header>
 


### PR DESCRIPTION
The icon.png file is copied to dist/renderer/ by the build script, so the HTML reference should use 'icon.png' (same directory) rather than '../resources/icon.png' which doesn't exist in the packaged app.

This matches the correct path already used in setup-wizard.html.