### PR TITLE
Fix Typing Mind Docker service setup

### DIFF
--- a/config/setup-config.json
+++ b/config/setup-config.json
@@ -26,7 +26,7 @@
       "id": "typing-mind",
       "name": "Typing Mind UI",
       "url": "https://github.com/TypingMind/typingmind.git",
-      "clonePath": "typingmind",
+      "clonePath": "typing-mind",
       "branch": "main",
       "optional": true,
       "description": "Typing Mind web-based UI component"
@@ -94,7 +94,7 @@
       "id": "typing-mind-component",
       "name": "Typing Mind Integration",
       "description": "Optional Typing Mind UI component",
-      "enabled": false,
+      "enabled": true,
       "repositoryIds": [
         "typing-mind"
       ]


### PR DESCRIPTION
The Typing Mind Docker service was not being created during setup after the FictionLab rebranding. The root cause was in the build pipeline configuration.

Root Cause:
1. The "typing-mind-component" was disabled in setup-config.json
2. The repository clonePath was "typingmind" (no hyphen) but getTypingMindDirectory() expects "typing-mind" (with hyphen)

This caused:
- Build pipeline to skip cloning Typing Mind repository
- Even if manually cloned, the path mismatch would cause isInstalled() to return false
- determineServicesToStart() to set typingMind=false
- Docker service to never be created

Solution:
1. Enabled the typing-mind-component in setup-config.json Changed: "enabled": false → "enabled": true

2. Fixed the clonePath to match expected directory structure Changed: "clonePath": "typingmind" → "clonePath": "typing-mind"

Now when the setup wizard runs the build pipeline with Typing Mind selected:
- typing-mind repository will be cloned to repositories/typing-mind/
- isInstalled() will find repositories/typing-mind/src/index.html
- Docker service will be created and started correctly

Related issue: This was triggered by the rebranding but the actual bug was a pre-existing configuration error that went unnoticed.