### PR TITLE
Fix missing database service file error

### DIFF
--- a/src/renderer/components/DatabaseAdmin/Backup/BackupManager.ts
+++ b/src/renderer/components/DatabaseAdmin/Backup/BackupManager.ts
@@ -10,8 +10,8 @@
  * - Integrity validation
  */
 
-import { BackupList, BackupMetadata } from './BackupList';
-import { BackupWizard, BackupOptions } from './BackupWizard';
+import { BackupList, BackupMetadata } from './BackupList.js';
+import { BackupWizard, BackupOptions } from './BackupWizard.js';
 
 export interface RestoreOptions {
   backupPath: string;

--- a/src/renderer/components/DatabaseTab.ts
+++ b/src/renderer/components/DatabaseTab.ts
@@ -11,8 +11,8 @@
  * - Database backup and restore management
  */
 
-import { databaseService } from '../services/databaseService';
-import { BackupManager } from './DatabaseAdmin/Backup/BackupManager';
+import { databaseService } from '../services/databaseService.js';
+import { BackupManager } from './DatabaseAdmin/Backup/BackupManager.js';
 
 export interface DatabaseEvent {
   timestamp: Date;


### PR DESCRIPTION
Fixes module resolution errors in packaged Electron app where imports were failing to load databaseService and BackupManager. The renderer process uses ES2020 modules which require explicit .js extensions in import statements when the code is bundled and loaded via file:// URLs.

Changes:
- Add .js extension to databaseService import
- Add .js extension to BackupManager import
- Add .js extensions to BackupList and BackupWizard imports in BackupManager

Resolves: ERR_FILE_NOT_FOUND errors for module imports