### PR TITLE
Add table data and CRUD operations to list

### DIFF
--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -497,3 +497,67 @@
 .activity-item {
   animation: slideInLeft 0.3s ease-out;
 }
+
+/* Database Table Details Tabs */
+.table-details-container {
+  width: 100%;
+  height: 100%;
+}
+
+.table-details-tabs {
+  display: flex;
+  gap: 5px;
+  margin-bottom: 20px;
+  border-bottom: 2px solid rgba(0, 212, 170, 0.2);
+}
+
+.table-details-tabs .tab-button {
+  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.03);
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  min-width: auto;
+}
+
+.table-details-tabs .tab-button:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  border-bottom-color: rgba(0, 212, 170, 0.5);
+}
+
+.table-details-tabs .tab-button.active {
+  color: #00D4AA;
+  border-bottom-color: #00D4AA;
+  background: rgba(0, 212, 170, 0.08);
+}
+
+.table-details-content {
+  width: 100%;
+  min-height: 400px;
+}
+
+.table-details-content .tab-content {
+  display: none;
+  opacity: 0;
+  animation: fadeOut 0.2s ease-out;
+}
+
+.table-details-content .tab-content.active {
+  display: block;
+  opacity: 1;
+  animation: fadeIn 0.3s ease-in;
+}
+
+/* CRUD Panel Container */
+#crud-panel-container {
+  width: 100%;
+  min-height: 400px;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}


### PR DESCRIPTION
- Integrated CRUDPanel into DatabaseTab component for full CRUD operations
- Added tabbed interface to table details with "Schema" and "Data & CRUD" tabs
- Updated table click handler to support both schema view and data grid view
- Added styles for table details tabs with smooth transitions
- Enhanced table browser to show actual table data with insert, update, delete capabilities
- Implemented lazy loading of CRUD panel when Data tab is selected

Features added:
- Visual query builder with filters and sorting
- Data grid with inline editing and pagination
- Insert, update, delete operations for table records
- Export to CSV/JSON functionality
- Batch operations support

This addresses the issue where only table definitions were shown, now users can view and manipulate actual table data.