### PR TITLE
Fix missing TableSelector component file

### DIFF
--- a/src/renderer/components/DatabaseAdmin/CRUD/CRUDPanel.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/CRUDPanel.ts
@@ -3,10 +3,10 @@
  * Main container for CRUD operations, coordinates TableSelector, QueryBuilder, and DataGrid
  */
 
-import { TableSelector } from './TableSelector';
-import { QueryBuilder } from './QueryBuilder';
-import { DataGrid } from './DataGrid';
-import { QueryParams } from '../../../services/databaseService';
+import { TableSelector } from './TableSelector.js';
+import { QueryBuilder } from './QueryBuilder.js';
+import { DataGrid } from './DataGrid.js';
+import { QueryParams } from '../../../services/databaseService.js';
 
 export interface CRUDPanelEvents {
   onStatusChange?: (message: string, type: 'info' | 'success' | 'error') => void;

--- a/src/renderer/components/DatabaseAdmin/CRUD/DataGrid.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/DataGrid.ts
@@ -3,7 +3,7 @@
  * Displays query results with sorting, inline editing, pagination, and export capabilities
  */
 
-import { databaseService, QueryParams } from '../../../services/databaseService';
+import { databaseService, QueryParams } from '../../../services/databaseService.js';
 
 export interface DataGridColumn {
   name: string;

--- a/src/renderer/components/DatabaseAdmin/CRUD/QueryBuilder.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/QueryBuilder.ts
@@ -3,7 +3,7 @@
  * Visual interface for building database queries with WHERE clauses, ORDER BY, and pagination
  */
 
-import { databaseService, QueryParams } from '../../../services/databaseService';
+import { databaseService, QueryParams } from '../../../services/databaseService.js';
 
 export interface WhereClause {
   id: string;

--- a/src/renderer/components/DatabaseAdmin/CRUD/TableSelector.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/TableSelector.ts
@@ -3,7 +3,7 @@
  * Provides table selection interface with search and record count display
  */
 
-import { databaseService } from '../../../services/databaseService';
+import { databaseService } from '../../../services/databaseService.js';
 
 export interface TableInfo {
   name: string;


### PR DESCRIPTION
The CRUD components (TableSelector, QueryBuilder, DataGrid) were missing from the built application because their imports in CRUDPanel.ts and their own internal imports lacked the required .js extension.

When using ES2020 modules (as configured in tsconfig.renderer.json), TypeScript doesn't automatically add file extensions to imports. Electron requires these extensions to properly resolve modules when loading from the asar package.

Changes:
- Added .js extension to imports in CRUDPanel.ts
- Added .js extension to databaseService imports in:
  - TableSelector.ts
  - QueryBuilder.ts
  - DataGrid.ts

This fixes the ERR_FILE_NOT_FOUND errors when loading these components in the packaged application.