### PR TITLE
fix: Extract table names from objects in TableSelector

### DIFF
--- a/src/renderer/components/DatabaseAdmin/CRUD/TableSelector.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/TableSelector.ts
@@ -45,9 +45,12 @@ export class TableSelector {
       const result = await databaseService.listTables();
 
       if (result.success && result.data) {
-        const tableNames = result.data.tables || result.data;
-        this.tables = Array.isArray(tableNames)
-          ? tableNames.map(name => ({ name }))
+        const tablesData = result.data.tables || result.data;
+        // Extract table names from table objects
+        this.tables = Array.isArray(tablesData)
+          ? tablesData.map((t: any) => ({
+              name: typeof t === 'string' ? t : t.name
+            }))
           : [];
 
         this.filteredTables = [...this.tables];


### PR DESCRIPTION
- Apply same fix as DatabaseTab.ts (commit 44ab569)
- Handle response format where tables are objects with name property
- Extract name property when building table list
- Fixes "0 tables" bug in CRUD TableSelector component