### PR TITLE
Fix null reference error in environment config

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1738,6 +1738,20 @@
                     </div>
 
                     <div class="form-group">
+                        <label for="db-admin-port">
+                            DB Admin Port
+                            <span class="tooltip" title="Port for Database Admin service (default: 3010)">ⓘ</span>
+                        </label>
+                        <div class="input-with-indicator">
+                            <input type="number" id="db-admin-port" name="DB_ADMIN_PORT" min="1024" max="65535" required>
+                            <span class="port-indicator" id="db-admin-port-indicator">
+                                <span class="loading">⏳</span>
+                            </span>
+                        </div>
+                        <span class="validation-error" id="db-admin-port-error"></span>
+                    </div>
+
+                    <div class="form-group">
                         <label for="typing-mind-port">
                             Typing Mind Port
                             <span class="tooltip" title="Port for Typing Mind service (default: 8080)">ⓘ</span>


### PR DESCRIPTION
Adds the DB_ADMIN_PORT form field to index.html to fix the error: "Cannot set properties of null (setting 'value')" when loadEnvConfig tries to set the value of a non-existent element.

The field is added between HTTP_SSE_PORT and TYPING_MIND_PORT, following the same pattern as other port fields with:
- Label with tooltip describing "Port for Database Admin service (default: 3010)"
- Number input with id="db-admin-port" and name="DB_ADMIN_PORT"
- Port indicator span for status display
- Validation error span for error messages