### PR TITLE
fix: Ensure DataGrid.data is always an array to prevent map error

### DIFF
--- a/src/renderer/components/DatabaseAdmin/CRUD/DataGrid.ts
+++ b/src/renderer/components/DatabaseAdmin/CRUD/DataGrid.ts
@@ -57,7 +57,8 @@ export class DataGrid {
         // Handle different response formats
         // MCP server returns: { records: [...], total_count: N }
         // Or sometimes: { data: [...], totalCount: N }
-        this.data = result.data.records || result.data.data || result.data || [];
+        const responseData = result.data.records || result.data.data || result.data;
+        this.data = Array.isArray(responseData) ? responseData : [];
         this.totalRecords = result.data.total_count || result.data.totalCount || result.data.count || this.data.length;
 
         console.log('[DataGrid] Loaded records:', this.data.length, 'Total:', this.totalRecords);


### PR DESCRIPTION
Fixes the "TypeError: this.data.map is not a function" error that occurred when
clicking on the CRUD tab. The issue was that the data extraction logic could
assign a non-array object to this.data, causing map() to fail.

Changes:
- Add Array.isArray() check before assigning responseData to this.data
- Fall back to empty array if responseData is not an array
- This ensures this.data is always an array, preventing the map error

Resolves the error at DataGrid.ts:165 when rendering the table.