### PR TITLE
fix: wire TopBar workflow actions, remove dead workflows:* preload API (#160)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2467,62 +2467,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getInstalledOutputStyles: (): Promise<string[]> => {
       return ipcRenderer.invoke('workflow:get-installed-output-styles');
     },
-
-    /**
-     * List all workflows
-     */
-    list: (): Promise<any[]> => {
-      return ipcRenderer.invoke('workflows:list');
-    },
-
-    /**
-     * Get a specific workflow by ID
-     */
-    get: (workflowId: string): Promise<any> => {
-      return ipcRenderer.invoke('workflows:get', workflowId);
-    },
-
-    /**
-     * Execute a workflow
-     */
-    execute: (workflowId: string, initialContext?: any): Promise<any> => {
-      return ipcRenderer.invoke('workflows:execute', workflowId, initialContext);
-    },
-
-    /**
-     * Cancel a running workflow
-     */
-    cancel: (runId: string): Promise<any> => {
-      return ipcRenderer.invoke('workflows:cancel', runId);
-    },
-
-    /**
-     * Get workflow execution history
-     */
-    getRuns: (workflowId: string, limit?: number): Promise<any[]> => {
-      return ipcRenderer.invoke('workflows:get-runs', workflowId, limit);
-    },
-
-    /**
-     * Delete a workflow
-     */
-    delete: (workflowId: string): Promise<any> => {
-      return ipcRenderer.invoke('workflows:delete', workflowId);
-    },
-
-    /**
-     * Create a new workflow
-     */
-    create: (workflow: any): Promise<any> => {
-      return ipcRenderer.invoke('workflows:create', workflow);
-    },
-
-    /**
-     * Update an existing workflow
-     */
-    update: (workflowId: string, updates: any): Promise<any> => {
-      return ipcRenderer.invoke('workflows:update', workflowId, updates);
-    },
   },
 
   /**

--- a/src/renderer/views/WorkflowsViewReact.tsx
+++ b/src/renderer/views/WorkflowsViewReact.tsx
@@ -28,6 +28,13 @@ import type { Project } from '../../types/project.js';
 // Plugin IPC channel prefix for workflow plugin
 const WORKFLOW_PLUGIN = 'plugin:fictionlab-workflow:';
 
+// Bridge between the class-based View.handleAction() (called from the TopBar's
+// 'action-clicked' event via ViewRouter, see renderer.ts) and the WorkflowsApp
+// function component's internal state/handlers. Only one WorkflowsApp instance
+// is ever mounted at a time (ViewRouter is a singleton view host), so a module
+// level ref is sufficient.
+let activeAppActions: { openImportDialog: () => void; refresh: () => void } | null = null;
+
 // Temporary stub - series management is now in MCP-Writing-Servers
 interface Series {
   id: number;
@@ -94,6 +101,19 @@ const WorkflowsApp: React.FC = () => {
       setWorkflows([]);
     }
   }, []);
+
+  // Register this instance's actions so the TopBar (handled by the class-based
+  // View.handleAction()) can drive the same Import/Refresh behavior as the
+  // in-view toolbar buttons.
+  useEffect(() => {
+    activeAppActions = {
+      openImportDialog: () => setShowImportDialog(true),
+      refresh: () => loadWorkflows(true),
+    };
+    return () => {
+      activeAppActions = null;
+    };
+  }, [loadWorkflows]);
 
   // Load workflows on mount and setup event listeners with proper cleanup
   useEffect(() => {
@@ -859,7 +879,19 @@ export class WorkflowsViewReact implements View {
 
   handleAction(actionId: string): void {
     console.log('[WorkflowsViewReact] Action:', actionId);
-    // Actions are handled by the React component directly via toolbar buttons
-    // This is for top bar integration if needed
+    if (!activeAppActions) {
+      console.warn('[WorkflowsViewReact] Action dispatched but no mounted app instance to handle it:', actionId);
+      return;
+    }
+    switch (actionId) {
+      case 'import':
+        activeAppActions.openImportDialog();
+        break;
+      case 'refresh':
+        activeAppActions.refresh();
+        break;
+      default:
+        console.warn('[WorkflowsViewReact] Unknown action:', actionId);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Wired the TopBar Import/Refresh actions in `WorkflowsViewReact.tsx` — `handleAction()` previously only did `console.log` and no-op'd. It now dispatches `'import'` → `setShowImportDialog(true)` and `'refresh'` → `loadWorkflows(true)`, the same handlers the working in-view toolbar buttons already call (lines 658/678). Since `handleAction` lives on the class-based `View` wrapper and those setters/handlers live inside the `WorkflowsApp` function component, added a small module-level bridge (`activeAppActions`) set/cleared by a `useEffect` in the component — safe because only one `WorkflowsApp` instance is ever mounted at a time (ViewRouter is a singleton view host).
- Removed the dead `electronAPI.workflows.{list,get,execute,cancel,getRuns,delete,create,update}` preload surface (`src/preload/preload.ts`), which invoked plural `workflows:*` IPC channels with **zero** `ipcMain.handle` registrations anywhere in the app. Grepped the renderer first and confirmed no call sites for any of these methods.
- Left `electronAPI.workflows.getInstalledAgents/getInstalledSkills/getInstalledOutputStyles` alone — these use the singular, live `workflow:*` channels and are actively called from `NodeConfigDialog.tsx`.
- Did **not** touch `workflow:*` (singular) channels, and did not touch the `fictionlab-workflow` plugin repo. Filed a companion note as a comment on #160 re: the plugin's duplicate IPC registrations (`ipc-handlers.ts:139-186` + `broadcastWorkflowUpdate:18`), which remain as a follow-up cleanup in that repo.

## Results
- `npm run build` passes (renderer typecheck via `tsc -p tsconfig.renderer.json`, main typecheck via `tsc -p tsconfig.main.json`, asset copy) — no errors.
- Confirmed `WorkflowManagerPanel.tsx`'s pause/resume/cancel/jump-to-node paths reference only singular `workflow:*` channels (`workflow:list-active`, `workflow:pause`, `workflow:resume`, `workflow:cancel`, `workflow:jump-to-node`, `workflow:instance-updated`) — untouched by this change.
- Grep for `electronAPI\.workflows\.(list|get|execute|cancel|getRuns|delete|create|update)\(` across `src/` returns zero matches, confirming the deleted methods had no call sites.

## Test plan
- [x] `npm run build` passes
- [ ] Manual: click TopBar Import on the Workflows view → import dialog opens
- [ ] Manual: click TopBar Refresh on the Workflows view → workflow list reloads
- [ ] Manual: Pause/Resume/Cancel/Jump on an active workflow card still work

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)