### PR TITLE
fix: rebuild app menu from base template instead of live MenuItem instances (#158)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -81,10 +81,17 @@ function getIconPath(): string {
 }
 
 /**
- * Create the application menu
+ * Build the base application menu template.
+ *
+ * Returns a fresh `MenuItemConstructorOptions[]` array (plain options, not live
+ * `MenuItem` instances) every time it's called. Other modules (e.g.
+ * plugin-manager's `updatePluginMenu()`) should build the full menu by
+ * splicing into a fresh copy of this template rather than reading back
+ * `Menu.getApplicationMenu().items` — round-tripping live MenuItem instances
+ * through `Menu.buildFromTemplate()` silently drops their `click` handlers.
  */
-function createMenu(): void {
-  const template: Electron.MenuItemConstructorOptions[] = [
+export function getBaseMenuTemplate(): Electron.MenuItemConstructorOptions[] {
+  return [
     {
       label: 'File',
       submenu: [
@@ -245,8 +252,13 @@ function createMenu(): void {
       ],
     },
   ];
+}
 
-  const menu = Menu.buildFromTemplate(template);
+/**
+ * Create the application menu
+ */
+function createMenu(): void {
+  const menu = Menu.buildFromTemplate(getBaseMenuTemplate());
   Menu.setApplicationMenu(menu);
 }
 

--- a/src/main/plugin-manager.ts
+++ b/src/main/plugin-manager.ts
@@ -9,6 +9,7 @@ import { app, BrowserWindow, Menu, MenuItem as ElectronMenuItem, dialog } from '
 import { logWithCategory, LogCategory } from './logger';
 import { PluginRegistry } from './plugin-registry';
 import { getDatabasePool, initializeDatabasePool } from './database-connection';
+import { getBaseMenuTemplate } from './index';
 import {
   PluginState,
   PluginNotification,
@@ -181,15 +182,6 @@ class PluginManager {
       return;
     }
 
-    // Get menu template
-    const menu = Menu.getApplicationMenu();
-    if (!menu) {
-      return;
-    }
-
-    // Find or create Plugins menu
-    let pluginMenuIndex = menu.items.findIndex(item => item.label === 'Plugins');
-
     const activePlugins = this.registry.getPluginsByStatus('active');
 
     // Build plugin menu items
@@ -248,38 +240,26 @@ class PluginManager {
       });
     }
 
-    // Create/update Plugins menu
-    if (pluginMenuIndex === -1) {
-      // Add new Plugins menu after View menu
-      const viewMenuIndex = menu.items.findIndex(item => item.label === 'View');
-      const insertIndex = viewMenuIndex !== -1 ? viewMenuIndex + 1 : menu.items.length;
+    // Rebuild the full menu from the base template every time rather than
+    // reading back Menu.getApplicationMenu().items. That base template is
+    // plain MenuItemConstructorOptions (never live MenuItem instances), so
+    // click handlers on every submenu survive the rebuild, and rebuilding
+    // from source each time makes repeated calls idempotent — no
+    // accumulation of stale/duplicate Plugins menus.
+    const baseTemplate = getBaseMenuTemplate();
+    const viewMenuIndex = baseTemplate.findIndex(item => item.label === 'View');
+    const insertIndex = viewMenuIndex !== -1 ? viewMenuIndex + 1 : baseTemplate.length;
 
-      const newMenu = Menu.buildFromTemplate([
-        ...menu.items.slice(0, insertIndex),
-        {
-          label: 'Plugins',
-          submenu: pluginMenuItems,
-        },
-        ...menu.items.slice(insertIndex),
-      ]);
+    const fullTemplate: Electron.MenuItemConstructorOptions[] = [
+      ...baseTemplate.slice(0, insertIndex),
+      {
+        label: 'Plugins',
+        submenu: pluginMenuItems,
+      },
+      ...baseTemplate.slice(insertIndex),
+    ];
 
-      Menu.setApplicationMenu(newMenu);
-    } else {
-      // Update existing Plugins menu
-      const newMenu = Menu.buildFromTemplate(
-        menu.items.map((item, index) => {
-          if (index === pluginMenuIndex) {
-            return {
-              label: 'Plugins',
-              submenu: pluginMenuItems,
-            };
-          }
-          return item;
-        })
-      );
-
-      Menu.setApplicationMenu(newMenu);
-    }
+    Menu.setApplicationMenu(Menu.buildFromTemplate(fullTemplate));
 
     logWithCategory('debug', LogCategory.SYSTEM, 'Plugin menu updated');
   }


### PR DESCRIPTION
## Summary
- Application submenus (Diagnostics, Help) went dead after plugins loaded because `updatePluginMenu()` in `src/main/plugin-manager.ts` rebuilt the menu from `Menu.getApplicationMenu().items` — live `MenuItem` instances — and fed them back into `Menu.buildFromTemplate()`, which silently drops `click` handlers. Native `role:` items (cut/copy/paste, zoom) kept working, which made the breakage look partial.
- Exported `getBaseMenuTemplate(): Electron.MenuItemConstructorOptions[]` from `src/main/index.ts`, returning a fresh copy of the menu template each call; `createMenu()` now builds from it.
- `updatePluginMenu()` no longer reads back live menu state. It now gets a fresh base template via `getBaseMenuTemplate()` and splices the Plugins submenu in at the same position as before (after View), then calls `Menu.buildFromTemplate()` once on the full plain-options template. Rebuilding from source on every call is inherently idempotent, so the old find-existing-index/replace-vs-insert branching was removed along with the live-instance slicing.

## Test plan
- [x] `npm run build` (tsc renderer + tsc main + asset copy) passes cleanly with no errors.
- [ ] `npm test`: pre-existing failure, unrelated to this change — all 16 jest suites fail to parse with a babel/TypeScript syntax error (`Missing semicolon` on a `let x: Type;` declaration), reproduced identically on unmodified `develop` (verified via `git stash`). No jest coverage exists for `plugin-manager.ts` or the menu (`__tests__` directories searched; none found), so this change has no targeted automated test to add confidence beyond the build and manual verification of the diff against the spec's acceptance criteria.
- [x] Manually verified: no other code path reads `Menu.getApplicationMenu()` (searched `src/`) — the live-instance round-trip is fully removed.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)