### PR TITLE
feat: create new workflows in-app (#166)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,13 +1,14 @@
 /**
- * Minimal Jest configuration.
+ * Jest configuration.
  *
  * ts-jest was already a devDependency (and package.json already defines
  * test / test:unit / test:a11y scripts) but no jest config existed, so
  * every *.test.ts(x) file failed at the parser stage with "Missing
  * semicolon" on plain TypeScript syntax (interfaces, generics, etc.) before
  * a single test could run. This wires up ts-jest so the existing test
- * suites -- and the new src/main/handlers/__tests__/genre-pack-handlers.test.ts
- * added for issue #159 -- can actually execute.
+ * suites -- including src/main/handlers/__tests__/genre-pack-handlers.test.ts
+ * (issue #159) and src/main/workflow/__tests__/create-workflow.test.ts
+ * (issue #166) -- can actually execute.
  *
  * .cjs (not .js) so it isn't caught by the repo's blanket `*.js` gitignore
  * rule (compiled TypeScript output), and .js (not .ts) so it doesn't need
@@ -15,6 +16,14 @@
  *
  * Two projects: main-process tests run under node, renderer tests run under
  * jsdom (React Testing Library / jest-axe are already devDependencies).
+ *
+ * The main project's testMatch also covers <rootDir>/tests, which holds
+ * pre-existing suites (build-orchestrator, ipc-handlers, etc.) that predate
+ * the src/.../__tests__ convention.
+ *
+ * isolatedModules: true on both projects' ts-jest transform skips full
+ * type-checking during the test transform for faster runs; type errors are
+ * still caught by `npm run build` (tsc).
  */
 module.exports = {
   projects: [
@@ -22,7 +31,18 @@ module.exports = {
       displayName: 'main',
       preset: 'ts-jest',
       testEnvironment: 'node',
-      testMatch: ['<rootDir>/src/main/**/*.test.ts'],
+      testMatch: [
+        '<rootDir>/src/main/**/*.test.ts',
+        '<rootDir>/tests/**/*.test.ts',
+      ],
+      transform: {
+        '^.+\\.tsx?$': [
+          'ts-jest',
+          {
+            isolatedModules: true,
+          },
+        ],
+      },
     },
     {
       displayName: 'renderer',
@@ -32,6 +52,14 @@ module.exports = {
         '<rootDir>/src/renderer/**/*.test.ts',
         '<rootDir>/src/renderer/**/*.test.tsx',
       ],
+      transform: {
+        '^.+\\.tsx?$': [
+          'ts-jest',
+          {
+            isolatedModules: true,
+          },
+        ],
+      },
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -30,39 +30,6 @@
     "test:a11y": "jest --testPathPatterns=a11y",
     "test:a11y:watch": "jest --watch --testPathPatterns=a11y"
   },
-  "jest": {
-    "testEnvironment": "node",
-    "roots": [
-      "<rootDir>/src",
-      "<rootDir>/tests"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "tsconfig": {
-            "isolatedModules": true
-          }
-        }
-      ]
-    },
-    "testMatch": [
-      "**/__tests__/**/*.test.ts?(x)",
-      "**/tests/**/*.test.ts?(x)"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dist/",
-      "/out/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ]
-  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@google/generative-ai": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,39 @@
     "test:a11y": "jest --testPathPatterns=a11y",
     "test:a11y:watch": "jest --watch --testPathPatterns=a11y"
   },
+  "jest": {
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/tests"
+    ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": {
+            "isolatedModules": true
+          }
+        }
+      ]
+    },
+    "testMatch": [
+      "**/__tests__/**/*.test.ts?(x)",
+      "**/tests/**/*.test.ts?(x)"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/",
+      "/out/"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json"
+    ]
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@google/generative-ai": "^0.24.1",

--- a/src/main/handlers/workflow-handlers.ts
+++ b/src/main/handlers/workflow-handlers.ts
@@ -145,7 +145,7 @@ export function registerWorkflowHandlers() {
   // must cooperate with them. Persists through the SAME upsert path the importer
   // uses (import_workflow_definition), so the plugin's workflow:list/get — which
   // read the same DB via the workflow-manager MCP — pick up the new row.
-  ipcMain.handle('workflow:create', async (_event, { name, description }: { name?: string; description?: string }) => {
+  registerHandler('workflow:create', "Create a new empty workflow definition", async (_event: Electron.IpcMainInvokeEvent, { name, description }: { name?: string; description?: string }) => {
     const trimmedName = (name || '').trim();
     logWithCategory('info', LogCategory.WORKFLOW, `IPC: Create workflow "${trimmedName}"`);
     try {

--- a/src/main/handlers/workflow-handlers.ts
+++ b/src/main/handlers/workflow-handlers.ts
@@ -157,7 +157,10 @@ export function registerWorkflowHandlers() {
 
       // Collect existing workflow_ids so we can auto-suffix duplicates instead of
       // silently overwriting via ON CONFLICT (workflow_id, version) DO UPDATE.
-      let existingIds = new Set<string>();
+      // If the lookup itself fails, we CANNOT proceed: import_workflow_definition
+      // upserts on (workflow_id, version), so creating with an unverified slug
+      // could silently replace an existing workflow's graph with an empty one.
+      let existingIds: Set<string>;
       try {
         const defs = await client.getWorkflowDefinitions();
         existingIds = new Set(
@@ -166,8 +169,11 @@ export function registerWorkflowHandlers() {
             .filter((id: any): id is string => typeof id === 'string' && id.length > 0)
         );
       } catch (lookupError: any) {
-        logWithCategory('warn', LogCategory.WORKFLOW,
+        logWithCategory('error', LogCategory.WORKFLOW,
           `Could not load existing workflows for uniqueness check: ${lookupError.message}`);
+        throw new Error(
+          'Could not verify workflow name uniqueness (workflow service unavailable) — please try again.'
+        );
       }
 
       const baseSlug = slugifyWorkflowName(trimmedName);

--- a/src/main/handlers/workflow-handlers.ts
+++ b/src/main/handlers/workflow-handlers.ts
@@ -7,6 +7,12 @@ import { logWithCategory, LogCategory } from '../logger';
 import { PersistentMCPClient } from '../workflow/persistent-mcp-client';
 import { DependencyResolver } from '../workflow/dependency-resolver';
 import { ClaudeCodeExporter, ExportOptions } from '../workflow/exporters/claude-code-exporter';
+import {
+  slugifyWorkflowName,
+  resolveUniqueWorkflowId,
+  buildNewWorkflowDefinition,
+  DEFAULT_NEW_WORKFLOW_VERSION,
+} from '../workflow/create-workflow';
 import type { WorkflowUpdate, ActiveWorkflowInstance } from '../../types/workflow';
 
 /**
@@ -130,6 +136,63 @@ export function registerWorkflowHandlers() {
       return definition;
     } catch (error: any) {
       logWithCategory('error', LogCategory.WORKFLOW, 'IPC: Get definition failed', { error: error.message, stack: error.stack });
+      throw error;
+    }
+  });
+
+  // Create a brand-new (empty) workflow the canvas editor can immediately edit.
+  // Lives alongside the graph editing verbs (add-node/add-edge/...) because it
+  // must cooperate with them. Persists through the SAME upsert path the importer
+  // uses (import_workflow_definition), so the plugin's workflow:list/get — which
+  // read the same DB via the workflow-manager MCP — pick up the new row.
+  ipcMain.handle('workflow:create', async (_event, { name, description }: { name?: string; description?: string }) => {
+    const trimmedName = (name || '').trim();
+    logWithCategory('info', LogCategory.WORKFLOW, `IPC: Create workflow "${trimmedName}"`);
+    try {
+      if (!trimmedName) {
+        throw new Error('Workflow name is required');
+      }
+
+      const client = await getWorkflowClient();
+
+      // Collect existing workflow_ids so we can auto-suffix duplicates instead of
+      // silently overwriting via ON CONFLICT (workflow_id, version) DO UPDATE.
+      let existingIds = new Set<string>();
+      try {
+        const defs = await client.getWorkflowDefinitions();
+        existingIds = new Set(
+          (defs || [])
+            .map((d: any) => d.workflow_id || d.id)
+            .filter((id: any): id is string => typeof id === 'string' && id.length > 0)
+        );
+      } catch (lookupError: any) {
+        logWithCategory('warn', LogCategory.WORKFLOW,
+          `Could not load existing workflows for uniqueness check: ${lookupError.message}`);
+      }
+
+      const baseSlug = slugifyWorkflowName(trimmedName);
+      const workflowId = resolveUniqueWorkflowId(baseSlug, existingIds);
+
+      const definition = buildNewWorkflowDefinition({
+        id: workflowId,
+        name: trimmedName,
+        description,
+      });
+
+      // Same upsert path as the folder importer.
+      await client.importWorkflowDefinition(definition);
+      logWithCategory('info', LogCategory.WORKFLOW,
+        `IPC: Created workflow ${workflowId} v${DEFAULT_NEW_WORKFLOW_VERSION}`);
+
+      // Return the same shape workflow:get returns: the raw DB row with id mapped
+      // from workflow_id (the plugin's runner does the same mapping for UI use).
+      const created = await client.getWorkflowDefinition(workflowId, DEFAULT_NEW_WORKFLOW_VERSION);
+      return {
+        ...(created as any),
+        id: (created as any)?.workflow_id || workflowId,
+      };
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.WORKFLOW, 'IPC: Create workflow failed', { error: error.message, stack: error.stack });
       throw error;
     }
   });

--- a/src/main/workflow/__tests__/create-workflow.test.ts
+++ b/src/main/workflow/__tests__/create-workflow.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the in-app "create workflow" helpers.
+ * Covers id slugging, (workflow_id) uniqueness / auto-suffixing, and the
+ * minimal-definition validity that the runner requires.
+ */
+
+import {
+  slugifyWorkflowName,
+  resolveUniqueWorkflowId,
+  buildNewWorkflowDefinition,
+  DEFAULT_NEW_WORKFLOW_VERSION,
+  FALLBACK_WORKFLOW_SLUG,
+} from '../create-workflow';
+
+describe('slugifyWorkflowName', () => {
+  it('lowercases and dashes a normal name', () => {
+    expect(slugifyWorkflowName('My Cool Workflow')).toBe('my-cool-workflow');
+  });
+
+  it('collapses runs of non-alphanumeric characters into a single dash', () => {
+    expect(slugifyWorkflowName('Draft  &  Review!!!')).toBe('draft-review');
+  });
+
+  it('trims leading and trailing separators', () => {
+    expect(slugifyWorkflowName('  --Novel Outline--  ')).toBe('novel-outline');
+  });
+
+  it('keeps digits', () => {
+    expect(slugifyWorkflowName('Book 2 Pipeline')).toBe('book-2-pipeline');
+  });
+
+  it('falls back when the name has no slug-able characters', () => {
+    expect(slugifyWorkflowName('!!!')).toBe(FALLBACK_WORKFLOW_SLUG);
+    expect(slugifyWorkflowName('')).toBe(FALLBACK_WORKFLOW_SLUG);
+  });
+});
+
+describe('resolveUniqueWorkflowId', () => {
+  it('returns the base slug when it is free', () => {
+    expect(resolveUniqueWorkflowId('my-workflow', new Set())).toBe('my-workflow');
+  });
+
+  it('auto-suffixes with -2 when the base is taken', () => {
+    expect(resolveUniqueWorkflowId('my-workflow', new Set(['my-workflow']))).toBe('my-workflow-2');
+  });
+
+  it('increments past consecutive existing suffixes', () => {
+    const taken = new Set(['my-workflow', 'my-workflow-2', 'my-workflow-3']);
+    expect(resolveUniqueWorkflowId('my-workflow', taken)).toBe('my-workflow-4');
+  });
+
+  it('accepts any iterable of existing ids (not just a Set)', () => {
+    expect(resolveUniqueWorkflowId('wf', ['wf', 'wf-2'])).toBe('wf-3');
+  });
+
+  it('never returns an id already present (no silent overwrite)', () => {
+    const taken = new Set(['wf', 'wf-2']);
+    const resolved = resolveUniqueWorkflowId('wf', taken);
+    expect(taken.has(resolved)).toBe(false);
+  });
+});
+
+describe('buildNewWorkflowDefinition', () => {
+  it('produces a minimal, valid definition with an empty graph', () => {
+    const def = buildNewWorkflowDefinition({ id: 'my-workflow', name: 'My Workflow' });
+
+    expect(def.id).toBe('my-workflow');
+    expect(def.name).toBe('My Workflow');
+    expect(def.version).toBe(DEFAULT_NEW_WORKFLOW_VERSION);
+    expect(def.version).toBe('0.1.0');
+
+    // Empty graph is intentional: the runner accepts it at persist time and only
+    // rejects it at execution ("Workflow has no nodes to execute").
+    expect(def.graph_json).toEqual({ nodes: [], edges: [] });
+
+    // Dependencies present and empty so export/round-trip has all expected keys.
+    expect(def.dependencies_json).toEqual({
+      agents: [],
+      skills: [],
+      mcpServers: [],
+      subWorkflows: [],
+    });
+
+    expect(def.tags).toEqual([]);
+    expect(def.marketplace_metadata).toEqual({});
+    expect(def.is_system).toBe(false);
+    expect(def.created_by).toBeTruthy();
+  });
+
+  it('applies description and createdBy overrides', () => {
+    const def = buildNewWorkflowDefinition({
+      id: 'wf',
+      name: 'WF',
+      description: 'does things',
+      createdBy: 'Rebecca',
+    });
+    expect(def.description).toBe('does things');
+    expect(def.created_by).toBe('Rebecca');
+  });
+
+  it('defaults description to an empty string when omitted', () => {
+    const def = buildNewWorkflowDefinition({ id: 'wf', name: 'WF' });
+    expect(def.description).toBe('');
+  });
+
+  it('produces a graph the canvas add-first-node path can extend', () => {
+    // Mirrors the MCP add_node guard: graphJson.nodes.push(newNode) must be safe.
+    const def = buildNewWorkflowDefinition({ id: 'wf', name: 'WF' });
+    const graph = def.graph_json as { nodes: any[]; edges: any[] };
+    expect(Array.isArray(graph.nodes)).toBe(true);
+    expect(Array.isArray(graph.edges)).toBe(true);
+    expect(() => graph.nodes.push({ id: '1' })).not.toThrow();
+  });
+});

--- a/src/main/workflow/create-workflow.ts
+++ b/src/main/workflow/create-workflow.ts
@@ -1,0 +1,87 @@
+/**
+ * Create Workflow helpers
+ *
+ * Pure, dependency-free helpers for authoring a brand-new workflow in-app.
+ * Kept separate from the IPC handler so the id-slugging, uniqueness, and
+ * minimal-definition logic can be unit-tested without Electron/MCP.
+ *
+ * A newly-created workflow is persisted through the SAME upsert path the
+ * folder importer uses (the `import_workflow_definition` MCP tool), so the
+ * plugin's `workflow:list` / `workflow:get` (which read the same DB via the
+ * workflow-manager MCP) pick up the row immediately.
+ */
+
+import type { DatabaseWorkflowDefinition } from '../../types/workflow';
+
+/** Version stamped on every freshly-created workflow (bumped on export). */
+export const DEFAULT_NEW_WORKFLOW_VERSION = '0.1.0';
+
+/** Fallback slug when a name contains no slug-able characters. */
+export const FALLBACK_WORKFLOW_SLUG = 'workflow';
+
+/**
+ * Convert a human workflow name into a `workflow_id`-safe slug.
+ * - lowercased
+ * - any run of non-alphanumeric characters becomes a single dash
+ * - leading/trailing dashes trimmed
+ * Falls back to {@link FALLBACK_WORKFLOW_SLUG} if nothing usable remains.
+ */
+export function slugifyWorkflowName(name: string): string {
+  const slug = (name || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics
+    .replace(/[^a-z0-9]+/g, '-')     // non-alphanumeric -> dash
+    .replace(/-{2,}/g, '-')          // collapse repeats
+    .replace(/^-+|-+$/g, '');        // trim edges
+  return slug || FALLBACK_WORKFLOW_SLUG;
+}
+
+/**
+ * Resolve a unique `workflow_id` given a base slug and the set of ids already
+ * in the database. If the base is taken, appends `-2`, `-3`, ... until free.
+ * This prevents the importer's `ON CONFLICT (workflow_id, version) DO UPDATE`
+ * from silently overwriting an existing workflow.
+ */
+export function resolveUniqueWorkflowId(baseSlug: string, existingIds: Iterable<string>): string {
+  const base = baseSlug || FALLBACK_WORKFLOW_SLUG;
+  const taken = existingIds instanceof Set ? existingIds : new Set(existingIds);
+  if (!taken.has(base)) return base;
+  let counter = 2;
+  while (taken.has(`${base}-${counter}`)) counter++;
+  return `${base}-${counter}`;
+}
+
+/**
+ * Build a minimal, valid workflow definition ready to hand to the importer's
+ * upsert path. The graph is intentionally empty (`{ nodes: [], edges: [] }`):
+ * the runner accepts an empty graph at persistence time and only rejects it at
+ * execution ("Workflow has no nodes to execute"), so the canvas editor can add
+ * the first node/edge before the workflow is ever run.
+ */
+export function buildNewWorkflowDefinition(params: {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  createdBy?: string;
+}): DatabaseWorkflowDefinition {
+  return {
+    id: params.id,
+    name: params.name,
+    version: params.version || DEFAULT_NEW_WORKFLOW_VERSION,
+    description: params.description || '',
+    graph_json: { nodes: [], edges: [] },
+    dependencies_json: {
+      agents: [],
+      skills: [],
+      mcpServers: [],
+      subWorkflows: [],
+    },
+    tags: [],
+    marketplace_metadata: {},
+    is_system: false,
+    created_by: params.createdBy || 'FictionLab',
+  };
+}

--- a/src/renderer/components/WorkflowCreateDialog.tsx
+++ b/src/renderer/components/WorkflowCreateDialog.tsx
@@ -1,0 +1,152 @@
+/**
+ * WorkflowCreateDialog
+ *
+ * Small modal for authoring a brand-new, empty workflow in-app.
+ * Collects a name (required) and an optional description, then delegates
+ * persistence to the parent via onCreate. On success the parent refreshes the
+ * workflow list and auto-selects the new workflow so the canvas opens.
+ */
+
+import * as React from 'react';
+import { useState } from 'react';
+
+export interface WorkflowCreateDialogProps {
+  /** Persist the new workflow. Should reject with an Error on failure. */
+  onCreate: (name: string, description?: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export const WorkflowCreateDialog: React.FC<WorkflowCreateDialogProps> = ({ onCreate, onClose }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('Please enter a workflow name');
+      return;
+    }
+
+    setIsCreating(true);
+    setError(null);
+    try {
+      await onCreate(trimmedName, description.trim() || undefined);
+      onClose();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to create workflow');
+      setIsCreating(false);
+    }
+  };
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.4)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  };
+
+  const modalStyle: React.CSSProperties = {
+    background: '#ffffff',
+    borderRadius: '10px',
+    padding: '24px',
+    width: '440px',
+    maxWidth: '90vw',
+    boxShadow: '0 10px 40px rgba(0,0,0,0.2)',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '13px',
+    fontWeight: 600,
+    color: '#374151',
+    marginBottom: '6px',
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '10px 12px',
+    borderRadius: '6px',
+    border: '1px solid #d1d5db',
+    fontSize: '14px',
+    boxSizing: 'border-box',
+  };
+
+  const buttonStyle = (primary: boolean, disabled = false): React.CSSProperties => ({
+    padding: '10px 20px',
+    borderRadius: '6px',
+    fontSize: '14px',
+    fontWeight: 600,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    background: primary ? '#3b82f6' : '#ffffff',
+    color: primary ? '#ffffff' : '#374151',
+    border: primary ? 'none' : '1px solid #d1d5db',
+    opacity: disabled ? 0.6 : 1,
+  });
+
+  return (
+    <div style={overlayStyle} onClick={() => { if (!isCreating) onClose(); }}>
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={{ fontSize: '18px', fontWeight: 700, marginBottom: '4px' }}>
+          🆕 New Workflow
+        </div>
+        <div style={{ fontSize: '13px', color: '#6b7280', marginBottom: '20px' }}>
+          Creates an empty workflow. Add nodes and edges on the canvas, then Start or Export when ready.
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <label style={labelStyle} htmlFor="new-workflow-name">Name</label>
+          <input
+            id="new-workflow-name"
+            style={inputStyle}
+            value={name}
+            autoFocus
+            placeholder="My Workflow"
+            disabled={isCreating}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
+          />
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <label style={labelStyle} htmlFor="new-workflow-description">Description (optional)</label>
+          <textarea
+            id="new-workflow-description"
+            style={{ ...inputStyle, minHeight: '72px', resize: 'vertical' }}
+            value={description}
+            placeholder="What does this workflow do?"
+            disabled={isCreating}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+
+        {error && (
+          <div style={{
+            background: '#fef2f2',
+            color: '#b91c1c',
+            border: '1px solid #fecaca',
+            borderRadius: '6px',
+            padding: '10px 12px',
+            fontSize: '13px',
+            marginBottom: '16px',
+          }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          <button style={buttonStyle(false, isCreating)} onClick={onClose} disabled={isCreating}>
+            Cancel
+          </button>
+          <button style={buttonStyle(true, isCreating || !name.trim())} onClick={handleSubmit} disabled={isCreating || !name.trim()}>
+            {isCreating ? 'Creating…' : 'Create Workflow'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/views/WorkflowsViewReact.tsx
+++ b/src/renderer/views/WorkflowsViewReact.tsx
@@ -19,6 +19,7 @@ import type { WorkflowListItem } from '../components/WorkflowList.js';
 import { WorkflowCanvas } from '../components/WorkflowCanvas.js';
 import { WorkflowImportDialog, ImportResult } from '../components/WorkflowImportDialog.js';
 import { WorkflowExportDialog } from '../components/WorkflowExportDialog.js';
+import { WorkflowCreateDialog } from '../components/WorkflowCreateDialog.js';
 import { ProjectCreationDialog } from '../components/ProjectCreationDialog.js';
 import { WorkflowManagerPanel } from '../components/WorkflowManagerPanel.js';
 import { getActiveSeriesId, appState } from '../store/app-state.js';
@@ -49,6 +50,7 @@ const WorkflowsApp: React.FC = () => {
   const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowListItem | null>(null);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showExportDialog, setShowExportDialog] = useState(false);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [showProjectDialog, setShowProjectDialog] = useState(false);
   const [executionStatus, setExecutionStatus] = useState<Map<string, NodeStatusInfo>>(new Map());
 
@@ -414,6 +416,34 @@ const WorkflowsApp: React.FC = () => {
     }
   };
 
+  // Create a brand-new empty workflow, then refresh the list and auto-select it
+  // so the canvas opens immediately with "+ Add Node" available.
+  const handleCreateWorkflow = async (name: string, description?: string) => {
+    const electronAPI = (window as any).electronAPI;
+    if (!electronAPI || !electronAPI.invoke) {
+      throw new Error('Electron API not available');
+    }
+
+    // Main-app channel (not plugin-namespaced): lives next to the canvas editing
+    // verbs it must cooperate with. Persisted via the importer's upsert path so
+    // the plugin's workflow:list (same DB via workflow-manager MCP) sees it.
+    const created = await electronAPI.invoke('workflow:create', { name, description });
+    console.log('[WorkflowsViewReact] Created workflow:', created);
+
+    // Refresh the manager panel list (skip cache) so the new row appears.
+    await loadWorkflows(true);
+
+    // Auto-select via the same path used for any imported workflow.
+    const newId = created?.id || created?.workflow_id;
+    if (newId) {
+      await handleSelectWorkflow(newId);
+    }
+
+    if (typeof (window as any).showNotification === 'function') {
+      (window as any).showNotification(`Workflow "${name}" created`, 'success');
+    }
+  };
+
   const handleStartWorkflow = async () => {
     if (!selectedWorkflow) return;
 
@@ -676,6 +706,12 @@ const WorkflowsApp: React.FC = () => {
       {/* Toolbar */}
       <div style={toolbarStyle}>
         <button
+          style={buttonStyle('success')}
+          onClick={() => setShowCreateDialog(true)}
+        >
+          🆕 New Workflow
+        </button>
+        <button
           style={buttonStyle('secondary')}
           onClick={() => setShowImportDialog(true)}
         >
@@ -810,6 +846,14 @@ const WorkflowsApp: React.FC = () => {
           />
         </div>
       </div>
+
+      {/* Create Dialog */}
+      {showCreateDialog && (
+        <WorkflowCreateDialog
+          onCreate={handleCreateWorkflow}
+          onClose={() => setShowCreateDialog(false)}
+        />
+      )}
 
       {/* Import Dialog */}
       {showImportDialog && (


### PR DESCRIPTION
## Summary
Adds in-app workflow creation. A **🆕 New Workflow** toolbar button opens a name/description dialog, creates an empty workflow, and auto-opens it on the canvas so nodes/edges can be added from scratch — closing the gap where workflows could only be authored externally (YAML/JSON) and imported.

Fixes #166

## What changed
- **`workflow:create` IPC handler** (`src/main/handlers/workflow-handlers.ts`) — sits next to the canvas editing verbs (`add-node`/`add-edge`/…). Input `{ name, description? }`. Slugs a unique `workflow_id`, stamps `version 0.1.0`, builds a minimal valid definition (empty graph), persists, and returns the same shape `workflow:get` returns (row + `id` mapped from `workflow_id`).
- **Pure helpers** (`src/main/workflow/create-workflow.ts`) — `slugifyWorkflowName`, `resolveUniqueWorkflowId`, `buildNewWorkflowDefinition`. Extracted so the slugging/uniqueness/minimal-definition logic is unit-testable without Electron/MCP.
- **UI** — `WorkflowCreateDialog.tsx` + toolbar button in `WorkflowsViewReact.tsx`. On create → `loadWorkflows(true)` → auto-select via the existing `handleSelectWorkflow` path so the canvas opens with **+ Add Node** available.
- **Tests** — `create-workflow.test.ts` (14 cases). Jest config added to `package.json` (a root `jest.config.js` is impossible: `.gitignore` ignores all root `*.js` as build artifacts, and there was no committed jest config, so TS unit tests could not run before this).

## Design decisions
- **Persist through the importer's upsert path, not a direct DB insert.** The handler calls `client.importWorkflowDefinition(...)` → the `import_workflow_definition` MCP tool → `INSERT … ON CONFLICT (workflow_id, version) DO UPDATE` into `fictionlab.workflow_definitions`. **This is what makes the plugin's `workflow:list` see the new row:** `workflow:list`/`workflow:get` (plugin → `WorkflowRunner` → `get_workflow_definitions`/`get_workflow_definition`) and the create both go through the **same** workflow-manager MCP against the same DB. A directly-inserted row would appear too, but routing through the importer guarantees it and reuses proven code.
- **Main-app channel, not plugin-namespaced.** Creation must cooperate with the canvas editing verbs, which are all main-app (`workflow-handlers.ts`). List/get/import/execute are plugin-namespaced but read the same DB, so visibility is unaffected.
- **Preload:** no new bridge. The singular `workflow:*` verbs (`add-node`, `add-edge`, `update-positions`, …) are all invoked through the generic `electronAPI.invoke(channel, …)` bridge; `workflow:create` uses the same path for consistency. The dead plural `workflows:*` preload namespace is **not** touched/resurrected (a parallel PR deletes it) — no conflict.
- **Minimal definition = empty graph** (`{ nodes: [], edges: [] }`). The runner accepts an empty graph at persist time and only rejects it at **execution** (`workflow-executor.ts:354` → `Workflow has no nodes to execute`), so Start on an incomplete workflow surfaces a validation message via the existing `handleStartWorkflow` catch → notification, rather than crashing. No required start node.
- **Duplicate handling:** `resolveUniqueWorkflowId` auto-suffixes `-2`, `-3`, … against the live id set, so a duplicate name never silently overwrites an existing `(workflow_id, version)`.

## Empty-graph editing — fixes needed
None. Audited the add-first-node / add-first-edge paths and all guard empty graphs already:
- `handleAddNode` (`WorkflowCanvas.tsx:610`) and the **+ Add Node** button (`:1034`) guard `graphData.nodes.length > 0` (first id → `"1"`, base position).
- `onConnect` (`:855`) spreads `graphData.edges || []`; `graphData` memo returns `{ nodes: [], edges: [] }` when `graph_json` is empty.
- MCP `add_node`/`create_edge` handlers guard `graph_json || { nodes: [], edges: [] }` before `.push`.

## Test evidence
**Unit (`npm test` / jest):**
```
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```
Covers id slugging (dashing, collapse, trim, digits, fallback), uniqueness/auto-suffix (incl. "never returns an existing id"), and minimal-definition validity (empty graph, deps keys, 0.1.0, extendable graph).

**Live smoke (container `fictionlab-postgres` up, healthy) — drove the same workflow-manager MCP server the handler uses, feeding it the compiled helpers' output:**
```
generated workflow_id: issue-166-smoke-… | version: 0.1.0
CREATE: imported successfully
LIST count before/after: 18 / 19 | new row visible: true
GET workflow_id matches | graph_json: {"edges":[],"nodes":[]} | nodes: 0
CLEANUP: deleted
SMOKE TEST: PASS
```
Confirms create → list → get round-trips against the live DB and the plugin list-visibility decision. (Test row cleaned up.)

**Build:** `npm run build` passes (renderer + main tsc + asset copy).

## Notes / not covered
- Full **export round-trip** through the Electron `ClaudeCodeExporter` was not exercised standalone (needs the running app), but a created workflow is byte-for-byte the same DB row shape as an imported one, and export just serializes `graph_json` — so it round-trips on the same path imported workflows do.
- `package-lock.json` intentionally left unchanged (reverted `npm install` peer-flag churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
