### PR TITLE
fix: list genre packs from workflow plugin resources (#159)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,37 @@
+/**
+ * Minimal Jest configuration.
+ *
+ * ts-jest was already a devDependency (and package.json already defines
+ * test / test:unit / test:a11y scripts) but no jest config existed, so
+ * every *.test.ts(x) file failed at the parser stage with "Missing
+ * semicolon" on plain TypeScript syntax (interfaces, generics, etc.) before
+ * a single test could run. This wires up ts-jest so the existing test
+ * suites -- and the new src/main/handlers/__tests__/genre-pack-handlers.test.ts
+ * added for issue #159 -- can actually execute.
+ *
+ * .cjs (not .js) so it isn't caught by the repo's blanket `*.js` gitignore
+ * rule (compiled TypeScript output), and .js (not .ts) so it doesn't need
+ * ts-node, which isn't a project dependency.
+ *
+ * Two projects: main-process tests run under node, renderer tests run under
+ * jsdom (React Testing Library / jest-axe are already devDependencies).
+ */
+module.exports = {
+  projects: [
+    {
+      displayName: 'main',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      testMatch: ['<rootDir>/src/main/**/*.test.ts'],
+    },
+    {
+      displayName: 'renderer',
+      preset: 'ts-jest',
+      testEnvironment: 'jsdom',
+      testMatch: [
+        '<rootDir>/src/renderer/**/*.test.ts',
+        '<rootDir>/src/renderer/**/*.test.tsx',
+      ],
+    },
+  ],
+};

--- a/src/main/handlers/__tests__/genre-pack-handlers.test.ts
+++ b/src/main/handlers/__tests__/genre-pack-handlers.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the project:list-genre-packs handler logic.
+ *
+ * These tests exercise listGenrePacks() with an injected fake
+ * GenrePackScanner so they don't depend on the real @fictionlab/workflow-runner
+ * package being installed, or on any real plugin/resources directory.
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { listGenrePacks, GenrePackScanner } from '../genre-pack-handlers';
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => 'C:/fake-userdata'),
+  },
+  ipcMain: {
+    handle: jest.fn(),
+  },
+}));
+
+jest.mock('../../logger', () => ({
+  LogCategory: { SYSTEM: 'SYSTEM' },
+  logWithCategory: jest.fn(),
+}));
+
+jest.mock('fs-extra');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe('listGenrePacks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns [] and does not throw when the scanner cannot be loaded (plugin not installed)', async () => {
+    const loadScanner = jest.fn().mockReturnValue(null);
+
+    const result = await listGenrePacks(loadScanner);
+
+    expect(result).toEqual([]);
+    expect(loadScanner).toHaveBeenCalledWith(path.join('C:/fake-userdata', 'plugins', 'fictionlab-workflow'));
+  });
+
+  it('returns [] when the resources directory cannot be located', async () => {
+    const scanner: GenrePackScanner = {
+      getResourcesPath: jest.fn(() => {
+        throw new Error('Could not locate resources directory');
+      }),
+      listAvailableGenrePacks: jest.fn(),
+    };
+
+    const result = await listGenrePacks(() => scanner);
+
+    expect(result).toEqual([]);
+    expect(scanner.listAvailableGenrePacks).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when the genre-packs directory is empty or missing', async () => {
+    const scanner: GenrePackScanner = {
+      getResourcesPath: jest.fn(() => 'C:/resources'),
+      listAvailableGenrePacks: jest.fn().mockResolvedValue([]),
+    };
+
+    const result = await listGenrePacks(() => scanner);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns id + display name pairs read from each pack manifest.json', async () => {
+    const scanner: GenrePackScanner = {
+      getResourcesPath: jest.fn(() => 'C:/resources'),
+      listAvailableGenrePacks: jest
+        .fn()
+        .mockResolvedValue(['gothic-romance-horror', 'urban-fantasy-police-procedural']),
+    };
+
+    mockedFs.readJson.mockImplementation(async (manifestPath: any) => {
+      const p = String(manifestPath);
+      if (p.includes('gothic-romance-horror')) {
+        return { name: 'Steampunk Gothic Horror Romance' };
+      }
+      if (p.includes('urban-fantasy-police-procedural')) {
+        return { name: 'Urban Fantasy Police Procedural' };
+      }
+      throw new Error(`unexpected manifest path: ${p}`);
+    });
+
+    const result = await listGenrePacks(() => scanner);
+
+    expect(result).toEqual([
+      { id: 'gothic-romance-horror', name: 'Steampunk Gothic Horror Romance' },
+      { id: 'urban-fantasy-police-procedural', name: 'Urban Fantasy Police Procedural' },
+    ]);
+  });
+
+  it('falls back to the directory id as the display name when a manifest is unreadable', async () => {
+    const scanner: GenrePackScanner = {
+      getResourcesPath: jest.fn(() => 'C:/resources'),
+      listAvailableGenrePacks: jest.fn().mockResolvedValue(['broken-pack']),
+    };
+
+    mockedFs.readJson.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await listGenrePacks(() => scanner);
+
+    expect(result).toEqual([{ id: 'broken-pack', name: 'broken-pack' }]);
+  });
+
+  it('returns [] when the scan itself throws', async () => {
+    const scanner: GenrePackScanner = {
+      getResourcesPath: jest.fn(() => 'C:/resources'),
+      listAvailableGenrePacks: jest.fn().mockRejectedValue(new Error('EACCES')),
+    };
+
+    const result = await listGenrePacks(() => scanner);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/main/handlers/genre-pack-handlers.ts
+++ b/src/main/handlers/genre-pack-handlers.ts
@@ -1,0 +1,143 @@
+import { app, ipcMain } from 'electron';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { logWithCategory, LogCategory } from '../logger';
+
+/**
+ * The plugin ID for the FictionLab workflow plugin (installed under
+ * {userData}/plugins/{id}, same convention used by PluginManager.importPlugin()
+ * and PluginLoader.setupBundledDependencies()).
+ */
+const WORKFLOW_PLUGIN_ID = 'fictionlab-workflow';
+
+export interface GenrePack {
+  id: string;
+  name: string;
+}
+
+/**
+ * Minimal shape of @fictionlab/workflow-runner's ResourceCopier that this
+ * handler depends on. Kept narrow so tests can supply a fake implementation
+ * without needing the real package installed.
+ */
+export interface GenrePackScanner {
+  getResourcesPath(): string;
+  listAvailableGenrePacks(): Promise<string[]>;
+}
+
+/**
+ * Dynamically load the ResourceCopier that ships with the FictionLab workflow
+ * plugin. The plugin is installed at {userData}/plugins/fictionlab-workflow
+ * (see PluginManager.importPlugin) and, when activated, resolves
+ * @fictionlab/workflow-runner out of its own node_modules (copied there by
+ * PluginLoader.setupBundledDependencies / PluginManager's bundled-dependency
+ * setup). We reuse that exact resolution instead of hardcoding any
+ * dev-machine path so this works the same way in a packaged install.
+ */
+export function loadGenrePackScanner(pluginDir: string): GenrePackScanner | null {
+  try {
+    const modulePath = path.join(pluginDir, 'node_modules', '@fictionlab', 'workflow-runner');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ResourceCopier } = require(modulePath);
+    if (typeof ResourceCopier !== 'function') {
+      return null;
+    }
+    return new ResourceCopier();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List genre packs available to the "Create New Project" dialog.
+ *
+ * Resolves the workflow plugin's ResourceCopier the same way it is reached
+ * at workflow-run time (workflow-executor.ts -> ResourceCopier.copyResourcesToProject),
+ * then reuses ResourceCopier.getResourcesPath()/listAvailableGenrePacks() so the
+ * path-resolution logic is never duplicated here.
+ *
+ * Any failure (plugin not installed, resources directory missing, unreadable
+ * manifest, etc.) is handled gracefully by logging a warning and returning an
+ * empty list -- the dialog should show only "None", never an error.
+ */
+export async function listGenrePacks(
+  loadScanner: (pluginDir: string) => GenrePackScanner | null = loadGenrePackScanner
+): Promise<GenrePack[]> {
+  const pluginDir = path.join(app.getPath('userData'), 'plugins', WORKFLOW_PLUGIN_ID);
+
+  const scanner = loadScanner(pluginDir);
+  if (!scanner) {
+    logWithCategory(
+      'warn',
+      LogCategory.SYSTEM,
+      `Genre packs: could not load ResourceCopier from workflow plugin at ${pluginDir}. ` +
+        'Is the fictionlab-workflow plugin installed? Returning empty list.'
+    );
+    return [];
+  }
+
+  let resourcesPath: string;
+  try {
+    resourcesPath = scanner.getResourcesPath();
+  } catch (error: any) {
+    logWithCategory(
+      'warn',
+      LogCategory.SYSTEM,
+      `Genre packs: could not locate resources directory (${error?.message || error}). Returning empty list.`
+    );
+    return [];
+  }
+
+  let packIds: string[];
+  try {
+    packIds = await scanner.listAvailableGenrePacks();
+  } catch (error: any) {
+    logWithCategory('warn', LogCategory.SYSTEM, `Genre packs: scan failed (${error?.message || error}). Returning empty list.`);
+    return [];
+  }
+
+  if (!packIds || packIds.length === 0) {
+    logWithCategory('debug', LogCategory.SYSTEM, 'Genre packs: none found (empty or missing genre-packs directory).');
+    return [];
+  }
+
+  const packs: GenrePack[] = [];
+  for (const id of packIds) {
+    const manifestPath = path.join(resourcesPath, 'genre-packs', id, 'manifest.json');
+    let name = id;
+    try {
+      const manifest = await fs.readJson(manifestPath);
+      if (manifest && typeof manifest.name === 'string' && manifest.name.trim()) {
+        name = manifest.name;
+      }
+    } catch (error: any) {
+      logWithCategory(
+        'warn',
+        LogCategory.SYSTEM,
+        `Genre packs: failed to read manifest for '${id}' (${error?.message || error}). Falling back to id as name.`
+      );
+    }
+    packs.push({ id, name });
+  }
+
+  logWithCategory('info', LogCategory.SYSTEM, `Genre packs: found ${packs.length} (${packs.map((p) => p.id).join(', ')}).`);
+  return packs;
+}
+
+/**
+ * Register the project:list-genre-packs IPC handler.
+ */
+export function registerGenrePackHandlers(): void {
+  ipcMain.handle('project:list-genre-packs', async () => {
+    logWithCategory('debug', LogCategory.SYSTEM, 'IPC: Listing genre packs');
+    try {
+      return await listGenrePacks();
+    } catch (error: any) {
+      // Defensive: listGenrePacks() already handles its own failure modes,
+      // but never let this handler throw and surface an error dialog to the
+      // Create Project UI -- an empty list just means "None" is shown.
+      logWithCategory('error', LogCategory.SYSTEM, `IPC: Listing genre packs failed unexpectedly: ${error?.message || error}`);
+      return [];
+    }
+  });
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -409,6 +409,7 @@ import { registerImportHandlers } from './handlers/import-handlers';
 import { registerBundledPluginsHandlers } from './handlers/bundled-plugins-handlers';
 import { registerWorkflowHandlers } from './handlers/workflow-handlers';
 import { registerPluginUpdateHandlers } from './handlers/plugin-update-handlers';
+import { registerGenrePackHandlers } from './handlers/genre-pack-handlers';
 
 /**
  * Set up IPC handlers for communication between main and renderer processes
@@ -425,6 +426,9 @@ function setupIPC(): void {
 
   // Register workflow handlers
   registerWorkflowHandlers();
+
+  // Register genre pack handlers
+  registerGenrePackHandlers();
 
   // Example IPC handler - ping/pong
   ipcMain.handle('ping', async () => {
@@ -2431,15 +2435,11 @@ function setupIPC(): void {
   });
 
   // List available genre packs
-  // Genre packs are now managed by fictionlab-workflow/resources/genre-packs
-  // and copied to projects when workflows run. This handler returns an empty list
-  // since genre packs are no longer bundled with the Electron app.
-  ipcMain.handle('project:list-genre-packs', async () => {
-    logWithCategory('debug', LogCategory.SYSTEM, 'IPC: Listing genre packs (now workflow-driven)');
-    // Genre packs are now workflow-driven and copied from fictionlab-workflow
-    // when a workflow executes. Return empty list for project creation UI.
-    return [];
-  });
+  // Registered separately via registerGenrePackHandlers() -- see
+  // ./handlers/genre-pack-handlers.ts. Genre packs live with the workflow
+  // plugin's bundled resources (fictionlab-workflow/resources/genre-packs),
+  // not inside this app; the handler resolves them via the workflow
+  // plugin's own ResourceCopier at {userData}/plugins/fictionlab-workflow.
 
   // ========================================
   // Provider Management Handlers


### PR DESCRIPTION
## Summary

The `project:list-genre-packs` IPC handler (`src/main/index.ts`, previously lines 2437-2442) unconditionally returned `[]`, so the "Create New Project" dialog's Genre Pack dropdown only ever showed "None" even though the two genre packs (`gothic-romance-horror`, `urban-fantasy-police-procedural`) exist and a working scanner (`ResourceCopier.listAvailableGenrePacks()` in `@fictionlab/workflow-runner`) was never wired to it.

- Added `src/main/handlers/genre-pack-handlers.ts`. It resolves the FictionLab workflow plugin's `ResourceCopier` the same way the app already reaches it at workflow-run time: the plugin is installed at `{userData}/plugins/fictionlab-workflow`, and `@fictionlab/workflow-runner` lives in that plugin's own `node_modules` (copied there by `PluginManager`/`PluginLoader`'s bundled-dependency setup). The handler dynamically requires it from there — no dev-machine path is hardcoded, and no genre-pack files are bundled into the Electron app itself (per the issue's explicit "don't reintroduce bundling" gotcha).
- It then reuses the scanner's own `getResourcesPath()` / `listAvailableGenrePacks()` (never re-implements path resolution), and reads each pack's `manifest.json` for a display `name`, returning `Array<{id, name}>` — matching the shape `ProjectCreationDialog.tsx` renders (`pack.id` / `pack.name`).
- Any failure mode (plugin not installed, resources directory missing, unreadable manifest, scan error) is caught and logged as a warning; the handler always resolves to `[]` rather than throwing, so the dialog just shows "None" instead of an error.
- Wired the new handler into `setupIPC()` in `src/main/index.ts`, replacing the old stub.
- Added `src/main/handlers/__tests__/genre-pack-handlers.test.ts` (6 tests) covering: scanner unloadable, resources dir missing, empty genre-packs dir, happy path (2 packs w/ manifest names), manifest read failure (falls back to id), and scan throwing.
- Added `jest.config.cjs`: `ts-jest` was already a devDependency and `package.json` already defines `test`/`test:unit`/`test:a11y` scripts, but **no jest config existed at all** — every `*.test.ts(x)` file in the repo failed at the TS-parser stage before a single test could run. This was blocking me from running the new test, so I added a minimal two-project (`main`: node, `renderer`: jsdom) config to unblock it.

### Deviations / things worth flagging
- **Pre-existing test-infra gap, not introduced by this PR**: with jest now actually parsing TypeScript, several *other* pre-existing test suites fail for reasons unrelated to this change (e.g. `src/main/workflow/__tests__/workflow-executor-integration.test.ts` imports a `../workflow-executor` module that no longer exists in `src/main/workflow/`; a few renderer `*.a11y.test.tsx` files are out of sync with current component/type shapes). These were already broken (silently, since nothing ever ran) before this branch — left untouched as out of scope for #159.
- **Manual verification caveat**: the FictionLab workflow plugin currently installed on my dev machine (`%APPDATA%\FictionLab\plugins\fictionlab-workflow`) does not itself bundle a `resources/genre-packs` folder — a separate, pre-existing gap in that plugin's own packaging, not something this PR's handler code can or should paper over. Exercising the new handler's exact resolution logic against that install correctly returns `[]` (graceful, no crash — see below). To confirm the underlying scanner itself is sound, I also ran `ResourceCopier.listAvailableGenrePacks()` directly against the `fictionlab-workflow` monorepo build (where its resources actually live), and it correctly found both packs with their manifest names.

## Verification

**Build:**
```
npm run build
# tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json && node scripts/copy-assets.js
# ✓ Asset copying complete! (exit 0)
```

**New unit tests:**
```
npx jest src/main/handlers/__tests__/genre-pack-handlers.test.ts
PASS main src/main/handlers/__tests__/genre-pack-handlers.test.ts
  listGenrePacks
    √ returns [] and does not throw when the scanner cannot be loaded (plugin not installed)
    √ returns [] when the resources directory cannot be located
    √ returns [] when the genre-packs directory is empty or missing
    √ returns id + display name pairs read from each pack manifest.json
    √ falls back to the directory id as the display name when a manifest is unreadable
    √ returns [] when the scan itself throws
Tests: 6 passed, 6 total
```

**Scanner sanity check** (standalone script exercising `ResourceCopier.listAvailableGenrePacks()` against the `fictionlab-workflow` monorepo build, where the genre-pack resources actually live on this machine):
```
resourcesPath: C:\github\fictionlab-workflow\resources
listAvailableGenrePacks() -> ["gothic-romance-horror","urban-fantasy-police-procedural"]
  gothic-romance-horror -> name: "Steampunk Gothic Horror Romance"
  urban-fantasy-police-procedural -> name: "Urban Fantasy Police Procedural"
```

**Installed-plugin resolution check** (same path resolution the shipped handler uses, against this machine's actual installed plugin — correctly degrades to empty since that install predates resource bundling):
```
modulePath: ...\fictionlab-workflow\node_modules\@fictionlab\workflow-runner
Loaded ResourceCopier: function
getResourcesPath() threw (expected...): Could not locate resources directory...
listAvailableGenrePacks() -> []
```

## Test plan
- [x] `npm run build` passes
- [x] New unit tests pass (6/6)
- [x] Scanner confirmed to find both genre packs when resources are present (monorepo build)
- [x] Handler degrades gracefully (no throw, empty array + logged warning) when the plugin/resources aren't present
- [ ] End-to-end manual check in the running Electron app once a plugin build that bundles `resources/` is installed (blocked on the separate plugin-packaging gap noted above, not this handler)

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)