### PR TITLE
fix: robust Docker daemon detection and container startup in launch gate (#161)

### DIFF
--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -6,6 +6,7 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import Docker from 'dockerode';
 import { getPlatform, checkDockerRunning, getFixedEnv } from './prerequisites';
 import { LogCategory, logWithCategory } from './logger';
 
@@ -44,6 +45,164 @@ export interface DockerOperationResult {
   success: boolean;
   message: string;
   error?: string;
+}
+
+/**
+ * Result of a daemon-level ping probe (dockerode, not the CLI)
+ */
+export interface DockerPingResult {
+  reachable: boolean;
+  attempts: number;
+  elapsedMs: number;
+  error?: string;
+}
+
+/**
+ * Get the platform-appropriate Docker Engine API socket/pipe path.
+ * Windows: named pipe. macOS/Linux: unix socket.
+ * dockerode/docker-modem already default to these same paths, but we set them
+ * explicitly so the probe is authoritative regardless of DOCKER_HOST or other
+ * environment overrides, and so the chosen path is visible in logs.
+ */
+function getDockerSocketPath(): string {
+  const platform = getPlatform();
+  if (platform === 'windows') {
+    return '//./pipe/docker_engine';
+  }
+  // macOS and Linux both use the standard Docker Engine unix socket location
+  return '/var/run/docker.sock';
+}
+
+/**
+ * Single dockerode `docker.ping()` attempt against the Engine API, bounded by
+ * an explicit timeout (dockerode/docker-modem have no built-in per-call timeout).
+ * No retry here - callers compose retry/backoff on top of this primitive.
+ */
+async function pingDockerOnce(timeoutMs: number): Promise<{ ok: boolean; error?: string }> {
+  const socketPath = getDockerSocketPath();
+  const docker = new Docker({ socketPath });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    await docker.ping({ abortSignal: controller.signal } as any);
+    return { ok: true };
+  } catch (error: any) {
+    return { ok: false, error: error?.message || String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Ping the Docker daemon directly via dockerode against the Engine API socket/pipe
+ * (Windows named pipe `//./pipe/docker_engine`, unix socket elsewhere) rather than
+ * shelling out to the `docker` CLI. This is the authoritative liveness signal:
+ * a reachable daemon means Docker is genuinely up, independent of whether the CLI
+ * binary is on PATH or how long `docker info` takes to cold-start.
+ *
+ * Retries a fixed number of short-timeout attempts with backoff before declaring
+ * the daemon unreachable - a cold WSL2 backend can take a few seconds to start
+ * responding even once the process exists.
+ */
+export async function pingDockerDaemon(options: {
+  attempts?: number;
+  attemptTimeoutMs?: number;
+  backoffMs?: number;
+} = {}): Promise<DockerPingResult> {
+  const attempts = options.attempts ?? 5;
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? 3000;
+  const backoffMs = options.backoffMs ?? 3000;
+
+  const start = Date.now();
+  let lastError: string | undefined;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = await pingDockerOnce(attemptTimeoutMs);
+
+    if (result.ok) {
+      const elapsedMs = Date.now() - start;
+      logWithCategory('info', LogCategory.DOCKER,
+        `Docker daemon ping succeeded on attempt ${attempt}/${attempts} (${elapsedMs}ms, socket: ${getDockerSocketPath()})`);
+      return { reachable: true, attempts: attempt, elapsedMs };
+    }
+
+    lastError = result.error;
+    logWithCategory('debug', LogCategory.DOCKER,
+      `Docker daemon ping attempt ${attempt}/${attempts} failed: ${lastError}`);
+
+    if (attempt < attempts) {
+      await new Promise(resolve => setTimeout(resolve, backoffMs));
+    }
+  }
+
+  const elapsedMs = Date.now() - start;
+  logWithCategory('warn', LogCategory.DOCKER,
+    `Docker daemon ping failed after ${attempts} attempts (${elapsedMs}ms): ${lastError}`);
+
+  return { reachable: false, attempts, elapsedMs, error: lastError };
+}
+
+/**
+ * Poll the daemon ping until it succeeds or the timeout expires.
+ * Used by the launch gate for both the "process already running, still
+ * initializing" case (~90s budget) and the "we just started it" case (~120s
+ * budget) - the daemon ping is the readiness signal in both cases, not window
+ * state or the CLI.
+ */
+export async function waitForDockerPingReady(
+  maxTimeoutSeconds: number,
+  progressCallback?: ProgressCallback,
+  checkIntervalSeconds: number = 3
+): Promise<DockerOperationResult> {
+  logWithCategory('info', LogCategory.DOCKER,
+    `Polling Docker daemon ping (timeout: ${maxTimeoutSeconds}s)`);
+
+  const start = Date.now();
+  const timeoutMs = maxTimeoutSeconds * 1000;
+  let attempt = 0;
+  let lastError: string | undefined;
+
+  while (Date.now() - start < timeoutMs) {
+    attempt++;
+    const attemptTimeoutMs = checkIntervalSeconds * 1000;
+    const result = await pingDockerOnce(attemptTimeoutMs);
+
+    if (result.ok) {
+      const message = 'Docker daemon is ready!';
+      logWithCategory('info', LogCategory.DOCKER, `${message} (after ${attempt} poll(s))`);
+
+      if (progressCallback) {
+        progressCallback({ message, percent: 100, step: 'ready' });
+      }
+
+      return { success: true, message };
+    }
+
+    lastError = result.error;
+    const elapsed = Date.now() - start;
+    const percent = Math.min(90, Math.floor((elapsed / timeoutMs) * 90));
+    const message = `Waiting for Docker daemon... (attempt ${attempt}, ${Math.floor(elapsed / 1000)}s elapsed)`;
+
+    logWithCategory('debug', LogCategory.DOCKER, `${message}: ${lastError}`);
+
+    if (progressCallback) {
+      progressCallback({ message, percent, step: 'waiting' });
+    }
+
+    // pingDockerOnce already blocks for up to attemptTimeoutMs on failure/timeout,
+    // so only add a small gap between attempts rather than a full extra interval.
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  const errorMessage = `Docker daemon did not respond within ${maxTimeoutSeconds} seconds`;
+  logWithCategory('error', LogCategory.DOCKER, `${errorMessage}${lastError ? `: ${lastError}` : ''}`);
+
+  if (progressCallback) {
+    progressCallback({ message: 'Docker daemon did not respond in time', percent: 100, step: 'timeout' });
+  }
+
+  return { success: false, message: 'Docker daemon did not respond in time', error: lastError || errorMessage };
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2693,6 +2693,153 @@ function setupIPC(): void {
   logger.info('IPC handlers registered');
 }
 
+/**
+ * Launch-time Docker readiness gate.
+ *
+ * Replaces the old single-shot `docker info` (CLI-only, no retry, no process
+ * awareness) with:
+ *   1. A direct dockerode daemon ping (authoritative - independent of the
+ *      `docker` CLI being slow/missing on PATH).
+ *   2. If unreachable, check whether Docker Desktop's process is already
+ *      running - if so, this is the "still initializing" case: poll the ping
+ *      for up to ~90s and do NOT relaunch it.
+ *   3. If the process isn't running, start Docker Desktop (tray-only - the
+ *      dashboard window is controlled by Docker Desktop's own startup
+ *      setting) and poll the ping for up to ~120s.
+ *   4. Once the daemon is reachable, ensure the core containers
+ *      (postgres/pgbouncer) are up via mcpSystem.ensureCoreContainers()
+ *      before returning, so the DB pool init that follows doesn't hit a cold
+ *      database.
+ *
+ * Returns true when it's safe to proceed, false when the user chose to quit.
+ * Never calls app.quit() itself - caller owns that decision.
+ */
+async function ensureDockerReadyForLaunch(): Promise<boolean> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    logWithCategory('info', LogCategory.DOCKER, 'Pinging Docker daemon (dockerode)...');
+    const pingResult = await docker.pingDockerDaemon();
+    let daemonReady = pingResult.reachable;
+
+    if (!daemonReady) {
+      const processRunning = await docker.isDockerDesktopProcessRunning();
+
+      if (processRunning) {
+        logWithCategory('info', LogCategory.DOCKER,
+          'Docker Desktop process is running but daemon is not responding yet - ' +
+          'treating as still-initializing and polling (no relaunch)...');
+
+        const waitResult = await docker.waitForDockerPingReady(90, (progress) => {
+          logWithCategory('debug', LogCategory.DOCKER,
+            `Docker init wait: ${progress.message} (${progress.percent}%)`);
+        });
+        daemonReady = waitResult.success;
+      } else {
+        logWithCategory('info', LogCategory.DOCKER,
+          'Docker Desktop process is not running - starting it...');
+
+        const startResult = await docker.startDockerDesktop((progress) => {
+          logWithCategory('debug', LogCategory.DOCKER,
+            `Docker start: ${progress.message} (${progress.percent}%)`);
+        });
+
+        if (!startResult.success) {
+          logWithCategory('warn', LogCategory.DOCKER,
+            `startDockerDesktop reported failure (continuing to poll anyway): ${startResult.error}`);
+        }
+
+        const waitResult = await docker.waitForDockerPingReady(120, (progress) => {
+          logWithCategory('debug', LogCategory.DOCKER,
+            `Docker start wait: ${progress.message} (${progress.percent}%)`);
+        });
+        daemonReady = waitResult.success;
+      }
+    }
+
+    if (!daemonReady) {
+      // Secondary confirmation via the CLI before giving up entirely - the ping
+      // is authoritative, but this catches the unlikely case of a socket/pipe
+      // probe issue where the CLI path would still work.
+      const cliStatus = await docker.checkDockerHealth();
+      daemonReady = cliStatus.running && cliStatus.healthy;
+
+      if (daemonReady) {
+        logWithCategory('info', LogCategory.DOCKER,
+          'Daemon ping failed but CLI confirms Docker is healthy - proceeding');
+      }
+    }
+
+    if (daemonReady) {
+      logWithCategory('info', LogCategory.DOCKER, 'Docker daemon is reachable - ensuring core containers...');
+
+      const containerResult = await mcpSystem.ensureCoreContainers((progress) => {
+        logWithCategory('debug', LogCategory.DOCKER,
+          `Core container startup: ${progress.message} (${progress.percent}%)`);
+      });
+
+      if (containerResult.success) {
+        return true;
+      }
+
+      if (containerResult.error === 'INVALID_CONFIG') {
+        // First-run case: env config (MCP_AUTH_TOKEN/POSTGRES_PASSWORD) isn't
+        // written yet. That's the setup wizard's job, not this gate's - let
+        // launch proceed so isFirstRun()/createWizardWindow() can run.
+        logWithCategory('info', LogCategory.DOCKER,
+          'Core containers not started - environment not configured yet (first run). Deferring to setup wizard.');
+        return true;
+      }
+
+      // Surface the result (including PORT_CONFLICT) - never swallow it.
+      logWithCategory('error', LogCategory.DOCKER,
+        `Failed to ensure core containers (${containerResult.error}): ${containerResult.message}`);
+
+      const isPortConflict = containerResult.error === 'PORT_CONFLICT';
+      const choice = await dialog.showMessageBox({
+        type: 'error',
+        title: isPortConflict ? 'Port Conflict' : 'Container Startup Failed',
+        message: isPortConflict
+          ? 'A required port is already in use'
+          : 'Could not start required Docker containers',
+        detail: `${containerResult.message}\n\nWould you like to retry, open Docker Desktop to investigate, or quit?`,
+        buttons: ['Retry', 'Open Docker Desktop', 'Quit'],
+        defaultId: 0,
+        cancelId: 2,
+      });
+
+      if (choice.response === 0) continue; // Retry the whole gate
+      if (choice.response === 1) {
+        await docker.startDockerDesktop();
+        continue; // Loop back and re-check after giving the user a look
+      }
+      return false; // Quit
+    }
+
+    // Daemon genuinely unreachable - offer Retry / Open Docker Desktop / Quit
+    // instead of exiting immediately.
+    const choice = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Docker Desktop Required',
+      message: 'Docker daemon is not responding',
+      detail:
+        `FictionLab could not reach the Docker daemon.\n\n` +
+        (pingResult.error ? `Last error: ${pingResult.error}\n\n` : '') +
+        `Make sure Docker Desktop is installed and running, then click Retry. ` +
+        `If it's still starting up, give it a few more seconds first.`,
+      buttons: ['Retry', 'Open Docker Desktop', 'Quit'],
+      defaultId: 0,
+      cancelId: 2,
+    });
+
+    if (choice.response === 0) continue;
+    if (choice.response === 1) {
+      await docker.startDockerDesktop();
+      continue;
+    }
+    return false;
+  }
+}
+
 // This method will be called when Electron has finished initialization
 app.whenReady().then(async () => {
   // Initialize logging system after app is ready
@@ -2739,50 +2886,48 @@ app.whenReady().then(async () => {
       return;
     }
 
-    // Docker is installed, now check if it's running
-    const dockerStatus = await docker.checkDockerHealth();
-
-    if (!dockerStatus.running || !dockerStatus.healthy) {
-      logWithCategory('warn', LogCategory.DOCKER,
-        `Docker daemon is not ready (running: ${dockerStatus.running}, healthy: ${dockerStatus.healthy}): ${dockerStatus.message}`);
-
-      // Attempt to start Docker Desktop
-      logWithCategory('info', LogCategory.DOCKER, 'Attempting to start Docker Desktop...');
-      const startResult = await docker.startAndWaitForDocker((progress) => {
-        logWithCategory('debug', LogCategory.DOCKER,
-          `Docker startup progress: ${progress.message} (${progress.percent}%)`);
-      });
-
-      if (!startResult.success) {
-        // Failed to start Docker - show error and quit
-        const errorMessage =
-          `Docker Desktop is required to run this application but failed to start.\n\n` +
-          `Error: ${startResult.error || startResult.message}\n\n` +
-          `Please start Docker Desktop manually and try again.\n\n` +
-          `The application will now exit.`;
-
-        logWithCategory('error', LogCategory.DOCKER, errorMessage);
-        dialog.showErrorBox('Docker Required', errorMessage);
-        app.quit();
-        return;
-      }
-
-      logWithCategory('info', LogCategory.DOCKER, 'Docker Desktop started successfully');
-    } else {
-      logWithCategory('info', LogCategory.DOCKER, 'Docker is already running and healthy');
+    // Docker is installed - run the daemon-ping-first readiness gate (with
+    // process-awareness, retries, and container startup). Offers Retry/Open/Quit
+    // on failure instead of exiting immediately.
+    const dockerReady = await ensureDockerReadyForLaunch();
+    if (!dockerReady) {
+      logWithCategory('warn', LogCategory.DOCKER, 'User chose to quit from the Docker readiness gate');
+      app.quit();
+      return;
     }
-  } catch (error: any) {
-    const errorMessage =
-      `Failed to check or start Docker Desktop.\n\n` +
-      `Error: ${error.message}\n\n` +
-      `Docker Desktop is required to run this application.\n` +
-      `Please ensure Docker Desktop is installed and start it manually.\n\n` +
-      `The application will now exit.`;
 
-    logWithCategory('error', LogCategory.DOCKER, errorMessage);
-    dialog.showErrorBox('Docker Required', errorMessage);
-    app.quit();
-    return;
+    logWithCategory('info', LogCategory.DOCKER, 'Docker daemon and core containers are ready');
+  } catch (error: any) {
+    const errorMessage = error.message || String(error);
+    logWithCategory('error', LogCategory.DOCKER, `Unexpected error in Docker readiness gate: ${errorMessage}`);
+
+    const choice = await dialog.showMessageBox({
+      type: 'error',
+      title: 'Docker Required',
+      message: 'Unexpected error while checking Docker Desktop',
+      detail:
+        `Error: ${errorMessage}\n\n` +
+        `Docker Desktop is required to run this application.\n\n` +
+        `Would you like to retry, open Docker Desktop, or quit?`,
+      buttons: ['Retry', 'Open Docker Desktop', 'Quit'],
+      defaultId: 0,
+      cancelId: 2,
+    });
+
+    if (choice.response === 2) {
+      app.quit();
+      return;
+    }
+    if (choice.response === 1) {
+      await docker.startDockerDesktop();
+    }
+
+    // Give the gate one more shot (Retry, or after opening Docker Desktop)
+    const retryReady = await ensureDockerReadyForLaunch();
+    if (!retryReady) {
+      app.quit();
+      return;
+    }
   }
 
   setupIPC();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2918,13 +2918,29 @@ app.whenReady().then(async () => {
       app.quit();
       return;
     }
-    if (choice.response === 1) {
-      await docker.startDockerDesktop();
-    }
+    // Give the gate one more shot (Retry, or after opening Docker Desktop).
+    // Bounded: if this second attempt itself throws, don't let the rejection
+    // escape the promise chain and leave the app with no window and no
+    // dialog - show a final error and quit instead.
+    try {
+      if (choice.response === 1) {
+        await docker.startDockerDesktop();
+      }
 
-    // Give the gate one more shot (Retry, or after opening Docker Desktop)
-    const retryReady = await ensureDockerReadyForLaunch();
-    if (!retryReady) {
+      const retryReady = await ensureDockerReadyForLaunch();
+      if (!retryReady) {
+        app.quit();
+        return;
+      }
+    } catch (retryError: any) {
+      const retryErrorMessage = retryError.message || String(retryError);
+      logWithCategory('error', LogCategory.DOCKER, `Docker readiness retry failed: ${retryErrorMessage}`);
+      await dialog.showMessageBox({
+        type: 'error',
+        title: 'Docker Required',
+        message: 'Docker Desktop could not be verified',
+        detail: `Error: ${retryErrorMessage}\n\nThe application will now close.`,
+      });
       app.quit();
       return;
     }

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -860,6 +860,187 @@ async function waitForHealthy(
 }
 
 /**
+ * Ensure the core containers required before the DB pool can initialize
+ * (postgres, pgbouncer) are up and healthy.
+ *
+ * This is a NARROW extraction of the postgres/pgbouncer portion of
+ * startMCPSystem() - deliberately not the full wizard-oriented path:
+ * - no mcp-writing-servers image build (that's a from-source image only
+ *   needed for mcp-connector/mcp-writing-servers, not the DB)
+ * - no mcp-connector/mcp-writing-servers containers
+ * - no aggressive stopExistingContainers() unless a real port conflict is found
+ *
+ * Used by the launch gate (index.ts) after the Docker daemon is confirmed
+ * reachable, so a machine with Docker up but containers down doesn't sail
+ * straight into a DB pool init failure.
+ *
+ * Port-conflict handling here intentionally stays a thin, read-only consumer
+ * of the existing checkPortConflicts()/stopExistingContainers() exports rather
+ * than re-implementing the richer conflict-resolution/retry logic that lives
+ * in startMCPSystem() (~line 1007+) - that logic is in-flight in a parallel PR.
+ * On an unresolved conflict this returns error: 'PORT_CONFLICT' for the caller
+ * to surface directly to the user; it must not be swallowed.
+ */
+export async function ensureCoreContainers(
+  progressCallback?: ProgressCallback
+): Promise<SystemOperationResult> {
+  logWithCategory('info', LogCategory.DOCKER, 'Ensuring core containers (postgres, pgbouncer) are up...');
+
+  try {
+    const coreFile = getDockerComposeFilePath('core');
+
+    // Fast path: if postgres + pgbouncer are already running and healthy
+    // (the common case - Docker was already up), skip straight to success.
+    if (progressCallback) {
+      progressCallback({
+        message: 'Checking core containers...',
+        percent: 5,
+        step: 'check-existing',
+        status: 'checking',
+      });
+    }
+
+    const existingHealth = await getContainerHealth([coreFile]);
+    const postgresUp = existingHealth.find(c => c.name.includes('postgres'));
+    const pgbouncerUp = existingHealth.find(c => c.name.includes('pgbouncer'));
+
+    if (postgresUp?.running && postgresUp.health === 'healthy' &&
+        pgbouncerUp?.running && pgbouncerUp.health === 'healthy') {
+      logWithCategory('info', LogCategory.DOCKER, 'Core containers already running and healthy - nothing to do');
+
+      if (progressCallback) {
+        progressCallback({ message: 'Core containers ready', percent: 100, step: 'complete', status: 'ready' });
+      }
+
+      return { success: true, message: 'Core containers already running and healthy' };
+    }
+
+    // Verify environment configuration is valid before starting anything
+    const config = await envConfig.loadEnvConfig();
+    if (!config.MCP_AUTH_TOKEN || config.MCP_AUTH_TOKEN.trim() === '' ||
+        !config.POSTGRES_PASSWORD || config.POSTGRES_PASSWORD.trim() === '') {
+      logWithCategory('warn', LogCategory.DOCKER,
+        'Environment configuration incomplete - cannot start core containers yet');
+      return {
+        success: false,
+        message: 'Environment configuration is incomplete. Please complete the setup wizard before starting the system.',
+        error: 'INVALID_CONFIG',
+      };
+    }
+
+    if (progressCallback) {
+      progressCallback({
+        message: 'Preparing configuration...',
+        percent: 15,
+        step: 'config',
+        status: 'checking',
+      });
+    }
+
+    await initializeDockerDirectory();
+    await ensureDockerComposeFiles();
+
+    const pgbouncerResult = await pgbouncerConfig.generatePgBouncerConfig(config);
+    if (!pgbouncerResult.success) {
+      logWithCategory('warn', LogCategory.DOCKER, `Failed to generate PgBouncer config: ${pgbouncerResult.error}`);
+      // Continue anyway - matches startMCPSystem's tolerance for this failure
+    }
+
+    // Check for port conflicts (reuses the existing exported check - not modified here)
+    if (progressCallback) {
+      progressCallback({
+        message: 'Checking for port conflicts...',
+        percent: 25,
+        step: 'port-check',
+        status: 'checking',
+      });
+    }
+
+    let portCheck = await checkPortConflicts();
+    if (!portCheck.success) {
+      logWithCategory('warn', LogCategory.DOCKER,
+        `Port conflicts detected before starting core containers: ${portCheck.conflicts.join(', ')}`);
+
+      // Only postgres/pgbouncer are in play here - a single cleanup attempt via
+      // the existing exported helper is enough; do not retry aggressively.
+      await stopExistingContainers();
+      portCheck = await checkPortConflicts();
+
+      if (!portCheck.success) {
+        const conflictMsg = `Port conflicts detected on ports: ${portCheck.conflicts.join(', ')}. ` +
+          `Could not automatically free them.`;
+        logWithCategory('error', LogCategory.DOCKER, conflictMsg);
+        return {
+          success: false,
+          message: conflictMsg,
+          error: 'PORT_CONFLICT',
+        };
+      }
+    }
+
+    if (progressCallback) {
+      progressCallback({
+        message: 'Starting PostgreSQL and PgBouncer...',
+        percent: 40,
+        step: 'starting-core',
+        status: 'starting',
+      });
+    }
+
+    try {
+      await execDockerCompose(coreFile, 'up', ['-d', 'postgres', 'pgbouncer']);
+      logWithCategory('info', LogCategory.DOCKER, 'Core containers (postgres, pgbouncer) started');
+    } catch (error: any) {
+      const errorStderr = error.stderr || '';
+      if (errorStderr.includes('port is already allocated')) {
+        const match = errorStderr.match(/port (\d+) is already allocated/);
+        const port = match ? match[1] : 'unknown';
+        return {
+          success: false,
+          message: `Port ${port} is already in use. Please change the port in environment configuration or stop the conflicting service.`,
+          error: 'PORT_CONFLICT',
+        };
+      }
+
+      logWithCategory('error', LogCategory.DOCKER, 'Failed to start core containers', error);
+      return {
+        success: false,
+        message: `Failed to start PostgreSQL/PgBouncer: ${error.message || error}`,
+        error: 'CONTAINER_START_FAILED',
+      };
+    }
+
+    if (progressCallback) {
+      progressCallback({
+        message: 'Waiting for core containers to become healthy...',
+        percent: 60,
+        step: 'health-check',
+        status: 'checking',
+      });
+    }
+
+    const healthResult = await waitForHealthy([coreFile], progressCallback);
+    if (!healthResult.success) {
+      return {
+        success: false,
+        message: healthResult.message,
+        error: 'CONTAINER_UNHEALTHY',
+      };
+    }
+
+    return { success: true, message: 'Core containers are up and healthy' };
+  } catch (error: any) {
+    const errorMessage = error.message || String(error);
+    logWithCategory('error', LogCategory.DOCKER, 'Error ensuring core containers', error);
+    return {
+      success: false,
+      message: `Failed to ensure core containers: ${errorMessage}`,
+      error: 'UNKNOWN_ERROR',
+    };
+  }
+}
+
+/**
  * Start the MCP system
  */
 export async function startMCPSystem(

--- a/src/main/prerequisites.ts
+++ b/src/main/prerequisites.ts
@@ -4,9 +4,10 @@
  * Cross-platform support for Windows, macOS, and Linux
  */
 
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as log from 'electron-log';
 
 const execAsync = promisify(exec);
@@ -57,12 +58,72 @@ async function executeCommand(
 }
 
 /**
+ * Cache for the one-time `where`/`which docker` (or DOCKER_HOME override) lookup so
+ * getFixedEnv() - which runs on every exec call - doesn't re-shell-out each time.
+ */
+let cachedDockerCliResolution: { dir: string | null; source: string } | null = null;
+let loggedDockerCliResolution = false;
+
+/**
+ * Resolve the directory containing the `docker` binary beyond the hardcoded
+ * default-install guesses, so non-default installs (custom drive, portable
+ * install, symlinked binary, etc.) still get picked up.
+ *
+ * Resolution order:
+ * 1. `DOCKER_HOME` (or legacy `DOCKER_CLI_PATH`) env override, if set and it exists.
+ * 2. `where docker` (Windows) / `which docker` (macOS/Linux) - whatever the OS
+ *    would actually resolve on the current PATH right now.
+ */
+function resolveDockerCliDirectory(): { dir: string | null; source: string } {
+  if (cachedDockerCliResolution) {
+    return cachedDockerCliResolution;
+  }
+
+  const override = process.env.DOCKER_HOME || process.env.DOCKER_CLI_PATH;
+  if (override) {
+    try {
+      if (fs.existsSync(override)) {
+        cachedDockerCliResolution = { dir: override, source: `DOCKER_HOME/DOCKER_CLI_PATH override (${override})` };
+        return cachedDockerCliResolution;
+      }
+    } catch {
+      // ignore access errors, fall through
+    }
+  }
+
+  try {
+    const lookupCommand = process.platform === 'win32' ? 'where docker' : 'which docker';
+    const output = execSync(lookupCommand, { timeout: 3000, windowsHide: true, encoding: 'utf8' });
+    const firstMatch = output
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .find(line => line.length > 0);
+
+    if (firstMatch) {
+      cachedDockerCliResolution = { dir: path.dirname(firstMatch), source: `${lookupCommand} (${firstMatch})` };
+      return cachedDockerCliResolution;
+    }
+  } catch {
+    // docker not resolvable via where/which right now - fall back to hardcoded defaults
+  }
+
+  cachedDockerCliResolution = { dir: null, source: 'not found via DOCKER_HOME override or where/which docker' };
+  return cachedDockerCliResolution;
+}
+
+/**
  * Get environment variables with fixed PATH
  * Adds common locations for Docker and other tools on all platforms
  */
 export function getFixedEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   const currentPath = env.PATH || '';
+  const resolved = resolveDockerCliDirectory();
+
+  if (!loggedDockerCliResolution) {
+    loggedDockerCliResolution = true;
+    log.info(`Docker CLI PATH resolution: ${resolved.dir || 'none found beyond hardcoded defaults'} (source: ${resolved.source})`);
+  }
 
   if (process.platform === 'win32') {
     // Use %ProgramFiles% so this works regardless of install drive/locale
@@ -73,6 +134,12 @@ export function getFixedEnv(): NodeJS.ProcessEnv {
       `${programFiles}\\Docker\\Docker`,
       `${programData}\\DockerDesktop\\version-bin`,
     ];
+
+    // Prefer whatever `where docker`/DOCKER_HOME actually resolved - it wins ties
+    // with non-default installs that the hardcoded guesses above would miss.
+    if (resolved.dir && !commonPaths.includes(resolved.dir)) {
+      commonPaths.unshift(resolved.dir);
+    }
 
     // Append Docker paths that aren't already in PATH
     const missingPaths = commonPaths.filter(p => !currentPath.includes(p));
@@ -88,6 +155,10 @@ export function getFixedEnv(): NodeJS.ProcessEnv {
       '/usr/sbin',
       '/sbin'
     ];
+
+    if (resolved.dir && !commonPaths.includes(resolved.dir)) {
+      commonPaths.unshift(resolved.dir);
+    }
 
     // Add paths if missing, prioritizing them
     // We rebuild the PATH to ensure our paths come first


### PR DESCRIPTION
## Summary

Fixes the launch-time Docker gate (`src/main/index.ts:2707-2786`) that could report a *live* Docker daemon as down and exit the app. Root cause (per `github-issues/triage-2026-07-04/issue-04-docker-launch-detection.md`, not re-investigated here): the old gate did a single-shot 20s `docker info` CLI check with no retry, no dockerode ping, and never checked whether Docker Desktop's process was already running/initializing before deciding to relaunch or quit.

### What changed

- **`src/main/docker.ts`**
  - `pingDockerDaemon()` — dockerode ping against the Engine API socket/pipe (`//./pipe/docker_engine` on Windows, `/var/run/docker.sock` on macOS/Linux), ~3s per-attempt timeout, 5 attempts with backoff. This is the authoritative liveness signal now, independent of the `docker` CLI's PATH/cold-start behavior.
  - `waitForDockerPingReady(maxTimeoutSeconds, progressCallback)` — ping-based poller used for both the "still initializing" and "just started it" wait loops. The existing CLI-based `waitForDockerReady` is left in place as a secondary fallback, not removed.

- **`src/main/index.ts`**
  - New `ensureDockerReadyForLaunch()` reorders the gate:
    1. `pingDockerDaemon()` — reachable → skip straight to container startup.
    2. Not reachable → `isDockerDesktopProcessRunning()`. If **running** (still initializing), poll the ping for up to **~90s** — **does not relaunch**.
    3. If **not running**, `startDockerDesktop()` (tray-only, same as before) then poll the ping for up to **~120s**.
    4. Once reachable, `mcpSystem.ensureCoreContainers()` starts postgres/pgbouncer before the DB pool init at `:2793`.
    5. On any failure (daemon unreachable, or container startup failure) → **Retry / Open Docker Desktop / Quit** dialog instead of `app.quit()` + error box. `PORT_CONFLICT` is surfaced in this dialog, never swallowed. `INVALID_CONFIG` (first run, env not written yet) is treated as a pass-through to the existing setup-wizard flow, not an error.
  - Existing `docker:*` IPC handlers (`:658-724`) untouched — they call `startDockerDesktop`, `waitForDockerReady`, `startAndWaitForDocker`, `stopDocker`, `restartDocker`, `checkDockerHealth`, `getContainersStatus`, none of which were modified.

- **`src/main/mcp-system.ts`**
  - New `ensureCoreContainers()` — a **narrow** extraction of the postgres/pgbouncer portion of `startMCPSystem()`: no `mcp-writing-servers` image build, no mcp-connector/mcp-writing-servers containers, just postgres+pgbouncer (with a fast-path skip if they're already healthy). Reuses the existing exported `checkPortConflicts()` / `stopExistingContainers()` rather than reimplementing port-conflict handling, since **PR #162** is actively changing that logic in `mcp-system.ts:1007-1059` — this PR does not touch that region at all.

- **`src/main/prerequisites.ts`**
  - Widened `getFixedEnv()` PATH resolution: honors a `DOCKER_HOME`/`DOCKER_CLI_PATH` env override, and falls back to `where docker` (Windows) / `which docker` (macOS/Linux) before relying solely on the hardcoded `%ProgramFiles%` guess. Result is cached and logged once (which path won).

### Coordination notes

- **PR #162** (port-conflict handling in `mcp-system.ts:1007-1059`): not touched. `ensureCoreContainers()` is new code placed before `startMCPSystem()`, calling the existing exported `checkPortConflicts()`/`stopExistingContainers()` as-is. `PORT_CONFLICT` results are surfaced to the user via dialog, never swallowed.
- **PR #171** (ipcMain.handle → registry migration): this branch is off `develop` and doesn't touch the registry; any new IPC surface would use plain `ipcMain.handle` (none was needed for this fix — it's all pre-launch, pre-window code).

### Verification

`npm run build` (tsc renderer + tsc main) passes clean.

Live verification against the real Docker daemon on this machine (positive-path only, per live-machine safety — no stop/restart of Docker or any container):

```
--- Step 1: raw dockerode ping via named pipe ---
docker.ping() via //./pipe/docker_engine succeeded in 9ms. Raw result: <Buffer 4f 4b>

--- Step 2: version sanity check (proves it is the real live daemon) ---
Docker Engine version: 29.4.1, API version: 1.54, OS/Arch: linux/amd64

--- Step 3: pingDockerDaemon() retry wrapper (compiled dist/main/docker.js) ---
[DOCKER] Docker daemon ping succeeded on attempt 1/5 (3ms, socket: //./pipe/docker_engine)
pingDockerDaemon() result: { reachable: true, attempts: 1, elapsedMs: 3 }
Wrapper wall-clock time: 5ms (should be well under one 3s attempt+backoff cycle since it succeeds on attempt 1)

--- Step 4: isDockerDesktopProcessRunning() (process detection, positive path) ---
Docker CLI PATH resolution: C:\Program Files\Docker\Docker\resources\bin (source: where docker (C:\Program Files\Docker\Docker\resources\bin\docker))
[DOCKER] Docker Desktop process running (Windows): true
Docker Desktop process running: true

All checks passed.
```

Confirmed via `docker ps` before/after that all four `fictionlab-*` containers remained `Up 7 days` throughout — nothing was stopped or restarted.

`npm test` is broken repo-wide (no jest config has ever existed) — pre-existing, not addressed here; `tsc` is the verification gate per the issue triage.

### Deviations from the spec's plan

- Kept CLI confirmation (`checkDockerHealth()`) as a fallback only when the ping fails, exactly as the spec's gotcha suggests ("keep CLI as secondary confirmation") — not exercised on this run since the daemon was up.
- Added an explicit `INVALID_CONFIG` pass-through in the gate that the spec didn't call out: without it, first-run launches (before the setup wizard writes `MCP_AUTH_TOKEN`/`POSTGRES_PASSWORD`) would have shown a scary "Container Startup Failed" dialog instead of proceeding to the wizard as today. Caught this before it shipped as a regression.
- Daemon-down / cold-start / timeout paths got code-review-level verification only (per live-machine safety constraints on this task) — not exercised live, since Docker Desktop is live with real data on this machine.

## Test plan

- [x] `npm run build` passes (tsc renderer + tsc main, no errors)
- [x] Live positive-path verification: dockerode ping via named pipe, `pingDockerDaemon()` wrapper, `isDockerDesktopProcessRunning()` — all succeed against the real daemon
- [x] Confirmed no live containers were stopped/restarted during verification
- [ ] Manual test: daemon-down cold start (start Docker Desktop with the daemon stopped, confirm the app waits with progress instead of exiting) — not exercised (live-machine safety), recommend a maintainer test on a disposable machine/VM before merge
- [ ] Manual test: Retry / Open Docker Desktop / Quit dialog on a genuinely unavailable daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)