### PR TITLE
fix: port conflict auto-remediation, parameterized ports, Ports settings panel (#162)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,9 @@ services:
     networks:
       - mcp-network
     ports:
-      - "${PGBOUNCER_PORT}:${PGBOUNCER_PORT}"
+      # Host side is remappable via PGBOUNCER_PORT; container side stays fixed at 6432
+      # (MCP servers hardwire fictionlab-pgbouncer:6432 internally)
+      - "${PGBOUNCER_PORT}:6432"
     volumes:
       - ${DOCKER_DIR}/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
       - ${DOCKER_DIR}/userlist.txt:/etc/pgbouncer/userlist.txt:ro
@@ -91,8 +93,8 @@ services:
     ports:
       - "${HTTP_SSE_PORT}:3001"
       - "${DB_ADMIN_PORT}:3010"
-      - "3011:3011"  # NPE Server
-      - "3012:3012"  # Workflow Manager
+      - "${NPE_PORT}:3011"  # NPE Server (host side remappable, container fixed at 3011)
+      - "${WORKFLOW_MANAGER_PORT}:3012"  # Workflow Manager (host side remappable, container fixed at 3012)
     environment:
       # PRIMARY: Use PgBouncer for connection pooling (internal Docker network port)
       # CRITICAL: Use container name and INTERNAL port (6432), NOT the external ${PGBOUNCER_PORT} variable

--- a/linux-db-diagnostic.sh
+++ b/linux-db-diagnostic.sh
@@ -83,7 +83,54 @@ echo ""
 
 # 6. Check port conflicts
 echo -e "${YELLOW}[6/10] Checking for port conflicts...${NC}"
-PORTS=(5432 6432 3001 50880)
+
+# Locate the app's .env file so we check the ACTUAL configured ports rather than
+# hardcoded defaults - ports are user-configurable (Setup Wizard / Ports settings
+# panel / auto-remediation) and commonly get remapped away from these defaults,
+# especially on Linux where native Postgres often already holds 5432.
+# Electron's userData dir for this app lives under ~/.config/<app name> on Linux;
+# check both the package.json "name" and "productName" casings to be safe.
+ENV_CANDIDATES=(
+    "$HOME/.config/fictionlab/.env"
+    "$HOME/.config/FictionLab/.env"
+    "$XDG_CONFIG_HOME/fictionlab/.env"
+)
+ENV_FILE=""
+for candidate in "${ENV_CANDIDATES[@]}"; do
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+        ENV_FILE="$candidate"
+        break
+    fi
+done
+
+if [ -n "$ENV_FILE" ]; then
+    echo -e "${GREEN}  Reading configured ports from: $ENV_FILE${NC}"
+else
+    echo -e "${YELLOW}  No .env file found in expected locations - falling back to defaults${NC}"
+fi
+
+# Read a PORT_NAME=value out of the .env file, or fall back to the given default
+# (these defaults must match DEFAULT_CONFIG in src/main/env-config.ts)
+get_env_port() {
+    local var_name="$1"
+    local default_value="$2"
+    if [ -n "$ENV_FILE" ]; then
+        local value
+        value=$(grep -E "^${var_name}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d '=' -f2- | tr -d '"'"'"'\r')
+        if [ -n "$value" ]; then
+            echo "$value"
+            return
+        fi
+    fi
+    echo "$default_value"
+}
+
+POSTGRES_PORT_VAL=$(get_env_port "POSTGRES_PORT" 5432)
+PGBOUNCER_PORT_VAL=$(get_env_port "PGBOUNCER_PORT" 6432)
+HTTP_SSE_PORT_VAL=$(get_env_port "HTTP_SSE_PORT" 3001)
+MCP_CONNECTOR_PORT_VAL=$(get_env_port "MCP_CONNECTOR_PORT" 51300)
+
+PORTS=("$POSTGRES_PORT_VAL" "$PGBOUNCER_PORT_VAL" "$HTTP_SSE_PORT_VAL" "$MCP_CONNECTOR_PORT_VAL")
 PORT_NAMES=("PostgreSQL" "PgBouncer" "MCP-HTTP" "MCP-Connector")
 for i in "${!PORTS[@]}"; do
     PORT=${PORTS[$i]}

--- a/src/main/env-config.ts
+++ b/src/main/env-config.ts
@@ -29,6 +29,8 @@ export interface EnvConfig {
   DB_ADMIN_PORT: number;
   MCP_AUTH_TOKEN: string;
   PGBOUNCER_PORT: number;
+  NPE_PORT: number;
+  WORKFLOW_MANAGER_PORT: number;
   TYPING_MIND_PORT: number;
   GITHUB_TOKEN?: string;
 }
@@ -46,6 +48,8 @@ export const DEFAULT_CONFIG: EnvConfig = {
   DB_ADMIN_PORT: 3010,
   MCP_AUTH_TOKEN: '',
   PGBOUNCER_PORT: 6432,
+  NPE_PORT: 3011,
+  WORKFLOW_MANAGER_PORT: 3012,
   TYPING_MIND_PORT: 8080,
   GITHUB_TOKEN: '',
 };
@@ -453,6 +457,8 @@ export async function checkAllPortsAndSuggestAlternatives(
     { port: config.HTTP_SSE_PORT, name: 'HTTP/SSE', key: 'HTTP_SSE_PORT' as const },
     { port: config.DB_ADMIN_PORT, name: 'DB Admin', key: 'DB_ADMIN_PORT' as const },
     { port: config.PGBOUNCER_PORT, name: 'PgBouncer', key: 'PGBOUNCER_PORT' as const },
+    { port: config.NPE_PORT, name: 'NPE Server', key: 'NPE_PORT' as const },
+    { port: config.WORKFLOW_MANAGER_PORT, name: 'Workflow Manager', key: 'WORKFLOW_MANAGER_PORT' as const },
   ];
 
   // Check configurable ports
@@ -620,6 +626,12 @@ export function parseEnvFile(content: string): Partial<EnvConfig> {
         case 'PGBOUNCER_PORT':
           config.PGBOUNCER_PORT = parseInt(unquotedValue, 10);
           break;
+        case 'NPE_PORT':
+          config.NPE_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'WORKFLOW_MANAGER_PORT':
+          config.WORKFLOW_MANAGER_PORT = parseInt(unquotedValue, 10);
+          break;
         case 'GITHUB_TOKEN':
           config.GITHUB_TOKEN = unquotedValue;
           break;
@@ -720,6 +732,8 @@ export function formatEnvFile(config: EnvConfig): string {
     `DB_ADMIN_PORT=${config.DB_ADMIN_PORT}`,
     `MCP_AUTH_TOKEN=${config.MCP_AUTH_TOKEN}`,
     `PGBOUNCER_PORT=${config.PGBOUNCER_PORT}`,
+    `NPE_PORT=${config.NPE_PORT}`,
+    `WORKFLOW_MANAGER_PORT=${config.WORKFLOW_MANAGER_PORT}`,
   ];
 
   // Only include GITHUB_TOKEN if it's set
@@ -809,6 +823,16 @@ export function validateConfig(config: EnvConfig): { valid: boolean; errors: str
   const pgBouncerPortValidation = validatePort(config.PGBOUNCER_PORT);
   if (!pgBouncerPortValidation.valid) {
     errors.push(`PgBouncer port: ${pgBouncerPortValidation.error}`);
+  }
+
+  const npePortValidation = validatePort(config.NPE_PORT);
+  if (!npePortValidation.valid) {
+    errors.push(`NPE port: ${npePortValidation.error}`);
+  }
+
+  const workflowManagerPortValidation = validatePort(config.WORKFLOW_MANAGER_PORT);
+  if (!workflowManagerPortValidation.valid) {
+    errors.push(`Workflow Manager port: ${workflowManagerPortValidation.error}`);
   }
 
   // Validate auth token

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -558,7 +558,7 @@ async function identifyPortUser(port: number): Promise<string | null> {
 /**
  * Check if ports are available before starting
  */
-export async function checkPortConflicts(): Promise<{ success: boolean; conflicts: number[]; details?: any }> {
+export async function checkPortConflicts(): Promise<{ success: boolean; conflicts: number[]; details?: any; suggestedConfig?: envConfig.EnvConfig }> {
   logWithCategory('info', LogCategory.DOCKER, 'Checking for port conflicts...');
 
   const config = await envConfig.loadEnvConfig();
@@ -567,22 +567,23 @@ export async function checkPortConflicts(): Promise<{ success: boolean; conflict
   if (result.hasConflicts) {
     const conflictPorts = result.conflicts.map(c => c.port);
     logWithCategory('warn', LogCategory.DOCKER, `Port conflicts detected: ${conflictPorts.join(', ')}`);
-    
+
     // On Linux, try to identify what's using the ports
     if (process.platform === 'linux') {
       for (const conflict of result.conflicts) {
         const portUser = await identifyPortUser(conflict.port);
         if (portUser) {
-          logWithCategory('info', LogCategory.DOCKER, 
+          logWithCategory('info', LogCategory.DOCKER,
             `Port ${conflict.port} is being used by:\n${portUser}`);
         }
       }
     }
-    
-    return { 
-      success: false, 
+
+    return {
+      success: false,
       conflicts: conflictPorts,
-      details: result.conflicts
+      details: result.conflicts,
+      suggestedConfig: result.suggestedConfig,
     };
   }
 
@@ -673,6 +674,8 @@ async function execDockerCompose(
         MCP_CONNECTOR_PORT: String(config.MCP_CONNECTOR_PORT),
         HTTP_SSE_PORT: String(config.HTTP_SSE_PORT),
         DB_ADMIN_PORT: String(config.DB_ADMIN_PORT),
+        NPE_PORT: String(config.NPE_PORT),
+        WORKFLOW_MANAGER_PORT: String(config.WORKFLOW_MANAGER_PORT),
         MCP_AUTH_TOKEN: config.MCP_AUTH_TOKEN,
         // Path to MCP config file for Docker volume mounting
         MCP_CONFIG_FILE_PATH: mcpConfigPath,
@@ -1020,9 +1023,59 @@ export async function startMCPSystem(
       }
 
       await stopExistingContainers();
-      
+
       // Re-check ports
       portCheck = await checkPortConflicts();
+
+      if (!portCheck.success) {
+        // Conflicts persist even after stopping our own containers - something else
+        // (or another process) still holds these ports. Attempt automatic remediation:
+        // apply the suggested (available) ports, persist them, and retry once before
+        // giving up. This runs on every platform (not just Linux) - when there are no
+        // conflicts, this branch never executes, so Windows behavior is unchanged.
+        logWithCategory('warn', LogCategory.DOCKER,
+          `Port conflicts persist after cleanup on ports: ${portCheck.conflicts.join(', ')}. Attempting automatic port remediation...`);
+
+        if (progressCallback) {
+          progressCallback({
+            message: 'Port conflicts persist. Remapping to available ports...',
+            percent: 16,
+            step: 'port-remediation',
+            status: 'checking',
+          });
+        }
+
+        if (portCheck.suggestedConfig && Array.isArray(portCheck.details) && portCheck.details.length > 0) {
+          // Log prominently which ports are moving before we apply the change
+          for (const detail of portCheck.details) {
+            logWithCategory('warn', LogCategory.DOCKER,
+              `PORT REMAP: ${detail.name} port ${detail.port} is in use - moving to ${detail.suggested}`);
+          }
+
+          const saveResult = await envConfig.saveEnvConfig(portCheck.suggestedConfig);
+
+          if (saveResult.success) {
+            logWithCategory('info', LogCategory.DOCKER,
+              `Auto-remediated port configuration saved to ${saveResult.path}. Retrying startup with new ports...`);
+
+            // Retry the conflict check once with the remediated configuration
+            portCheck = await checkPortConflicts();
+
+            if (portCheck.success) {
+              logWithCategory('info', LogCategory.DOCKER, 'Port remediation succeeded - all ports now available.');
+            } else {
+              logWithCategory('error', LogCategory.DOCKER,
+                `Port remediation retry failed - conflicts remain on ports: ${portCheck.conflicts.join(', ')}`);
+            }
+          } else {
+            logWithCategory('error', LogCategory.DOCKER,
+              `Failed to persist auto-remediated port configuration: ${saveResult.error}`);
+          }
+        } else {
+          logWithCategory('warn', LogCategory.DOCKER,
+            'No suggested port configuration available - cannot auto-remediate port conflicts.');
+        }
+      }
 
       if (!portCheck.success) {
         // Build a detailed error message with process info if available
@@ -1033,21 +1086,16 @@ export async function startMCPSystem(
             if (detail.processInfo) {
               conflictDetails += `:\n  ${detail.processInfo.split('\n').join('\n  ')}`;
             }
-            // Special note for PgBouncer port which cannot be changed
-            if (detail.port === 6432) {
-              conflictDetails += '\n  ⚠️ This port is required by PgBouncer and cannot be changed.';
-              conflictDetails += '\n  You must stop whatever is using port 6432 before starting.';
-            }
           }
         }
 
         const conflictMsg = `Port conflicts detected on ports: ${portCheck.conflicts.join(', ')}.\n` +
           (conflictDetails ? `\nConflict details:${conflictDetails}\n` : '') +
-          `\nThe application attempted to free these ports automatically but was unable to do so.\n\n` +
+          `\nThe application attempted to free these ports automatically (including remapping to suggested alternatives) but was unable to do so.\n\n` +
           `Please try one of the following:\n` +
           `1. Stop any other applications using these ports (check details above)\n` +
           `2. On Linux, run: sudo lsof -i :<port> to see what's using a port\n` +
-          `3. For configurable ports, change them in the Setup Wizard (Environment Configuration step)\n` +
+          `3. For configurable ports, change them in the Setup Wizard (Environment Configuration step) or the Ports settings panel\n` +
           `4. Restart your computer to clear all port locks\n` +
           `5. Check the logs for more details`;
 

--- a/src/main/pgbouncer-config.ts
+++ b/src/main/pgbouncer-config.ts
@@ -61,12 +61,19 @@ export async function generatePgBouncerConfig(config: EnvConfig): Promise<{
 
     // Generate pgbouncer.ini content
     // Use container hostname for cross-platform compatibility
+    //
+    // NOTE: listen_port is intentionally hardcoded to 6432, NOT config.PGBOUNCER_PORT.
+    // The container-internal port must stay fixed at 6432 because docker-compose.yml
+    // maps "${PGBOUNCER_PORT}:6432" (host:container) and MCP servers hardwire
+    // fictionlab-pgbouncer:6432 for internal networking. Only the HOST-side publish
+    // port (config.PGBOUNCER_PORT) is allowed to move; PgBouncer inside the container
+    // must always listen on 6432 or the compose port mapping breaks.
     const iniContent = `[databases]
 * = host=postgres port=5432 dbname=${config.POSTGRES_DB}
 
 [pgbouncer]
 listen_addr = *
-listen_port = ${config.PGBOUNCER_PORT}
+listen_port = 6432
 auth_type = scram-sha-256
 auth_file = /etc/pgbouncer/userlist.txt
 admin_users = ${config.POSTGRES_USER}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -75,6 +75,9 @@ interface EnvConfig {
   HTTP_SSE_PORT: number;
   DB_ADMIN_PORT: number;
   MCP_AUTH_TOKEN: string;
+  PGBOUNCER_PORT: number;
+  NPE_PORT: number;
+  WORKFLOW_MANAGER_PORT: number;
   TYPING_MIND_PORT: number;
 }
 

--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -48,8 +48,34 @@ interface EnvConfig {
   HTTP_SSE_PORT: number;
   DB_ADMIN_PORT: number;
   MCP_AUTH_TOKEN: string;
+  PGBOUNCER_PORT: number;
+  NPE_PORT: number;
+  WORKFLOW_MANAGER_PORT: number;
   TYPING_MIND_PORT: number;
 }
+
+/**
+ * A single row in the Ports settings table
+ */
+interface PortRowDefinition {
+  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT';
+  name: string;
+}
+
+/**
+ * Canonical list of all user-facing ports.
+ * NOTE: TYPING_MIND_PORT is intentionally excluded - it is dead config being
+ * removed elsewhere and must not be surfaced in this panel.
+ */
+const PORT_ROWS: PortRowDefinition[] = [
+  { key: 'POSTGRES_PORT', name: 'PostgreSQL' },
+  { key: 'PGBOUNCER_PORT', name: 'PgBouncer' },
+  { key: 'MCP_CONNECTOR_PORT', name: 'MCP Connector' },
+  { key: 'HTTP_SSE_PORT', name: 'HTTP/SSE' },
+  { key: 'DB_ADMIN_PORT', name: 'DB Admin' },
+  { key: 'NPE_PORT', name: 'NPE Server' },
+  { key: 'WORKFLOW_MANAGER_PORT', name: 'Workflow Manager' },
+];
 
 interface DockerStatus {
   running: boolean;
@@ -61,6 +87,7 @@ interface DockerStatus {
 export class ServicesTab {
   private updateInterval: NodeJS.Timeout | null = null;
   private readonly REFRESH_INTERVAL = 5000; // 5 seconds
+  private lastSuggestedPortsConfig: EnvConfig | null = null;
 
   constructor() {
     console.log('ServicesTab component initialized');
@@ -78,6 +105,9 @@ export class ServicesTab {
 
       // Load initial service status
       await this.refreshAllServices();
+
+      // Load the Ports settings table
+      await this.loadPortsTable();
 
       // Start auto-refresh
       this.startAutoRefresh();
@@ -109,6 +139,261 @@ export class ServicesTab {
     const refreshBtn = document.getElementById('services-refresh-all');
     if (refreshBtn) {
       refreshBtn.addEventListener('click', () => this.refreshAllServices());
+    }
+
+    // Ports section controls
+    this.setupPortsListeners();
+  }
+
+  /**
+   * Setup Ports section listeners
+   */
+  private setupPortsListeners(): void {
+    const checkAllBtn = document.getElementById('ports-check-all');
+    const useSuggestedBtn = document.getElementById('ports-use-suggested');
+    const saveBtn = document.getElementById('ports-save');
+
+    if (checkAllBtn) checkAllBtn.addEventListener('click', () => this.handleCheckAllPorts());
+    if (useSuggestedBtn) useSuggestedBtn.addEventListener('click', () => this.handleUseSuggestedPorts());
+    if (saveBtn) saveBtn.addEventListener('click', () => this.handleSavePorts());
+  }
+
+  /**
+   * Build the current port values from the table's input fields.
+   * Falls back to the last-loaded config for any row not yet rendered.
+   */
+  private readPortsFromInputs(baseConfig: EnvConfig): EnvConfig {
+    const config: EnvConfig = { ...baseConfig };
+    for (const row of PORT_ROWS) {
+      const input = document.getElementById(`port-input-${row.key}`) as HTMLInputElement | null;
+      if (input && input.value.trim() !== '') {
+        const parsed = parseInt(input.value, 10);
+        if (!isNaN(parsed)) {
+          (config as any)[row.key] = parsed;
+        }
+      }
+    }
+    return config;
+  }
+
+  /**
+   * Render a single port row's markup
+   */
+  private renderPortRowHtml(row: PortRowDefinition, port: number): string {
+    return `
+      <tr id="port-row-${row.key}" style="border-bottom: 1px solid rgba(255,255,255,0.08);">
+        <td style="padding: 8px;">${row.name}</td>
+        <td style="padding: 8px;">
+          <input type="number" id="port-input-${row.key}" value="${port}" min="1024" max="65535"
+                 style="width: 100px; padding: 4px 6px; background: rgba(0,0,0,0.2); color: inherit; border: 1px solid rgba(255,255,255,0.2); border-radius: 4px;" />
+        </td>
+        <td style="padding: 8px;">
+          <span id="port-status-${row.key}" class="port-status">
+            <span class="loading">checking…</span>
+          </span>
+        </td>
+      </tr>
+    `;
+  }
+
+  /**
+   * Load the Ports table: fetch current config, render rows, and check live status
+   */
+  private async loadPortsTable(): Promise<void> {
+    const tbody = document.getElementById('ports-table-body');
+    if (!tbody) return;
+
+    try {
+      const config = await window.electronAPI.envConfig.getConfig() as EnvConfig;
+
+      tbody.innerHTML = PORT_ROWS.map(row => this.renderPortRowHtml(row, (config as any)[row.key])).join('');
+
+      // Wire up per-row "check on change"
+      for (const row of PORT_ROWS) {
+        const input = document.getElementById(`port-input-${row.key}`) as HTMLInputElement | null;
+        if (input) {
+          input.addEventListener('change', () => {
+            const port = parseInt(input.value, 10);
+            if (!isNaN(port)) {
+              this.refreshPortRowStatus(row.key, port);
+            }
+          });
+        }
+      }
+
+      // Live-check each port's current availability
+      await Promise.all(PORT_ROWS.map(row => this.refreshPortRowStatus(row.key, (config as any)[row.key])));
+
+      this.updatePortsLastChecked();
+    } catch (error) {
+      console.error('Error loading ports table:', error);
+      tbody.innerHTML = '<tr><td colspan="3" style="padding: 8px;">Failed to load ports</td></tr>';
+    }
+  }
+
+  /**
+   * Check a single port's availability and update its status cell
+   */
+  private async refreshPortRowStatus(key: PortRowDefinition['key'], port: number): Promise<void> {
+    const statusEl = document.getElementById(`port-status-${key}`);
+    if (!statusEl) return;
+
+    try {
+      const available = await window.electronAPI.envConfig.checkPort(port);
+      statusEl.innerHTML = available
+        ? '<span class="available" style="color: #4CAF50;">✓ Available</span>'
+        : '<span class="unavailable" style="color: #f44336;">✗ In use</span>';
+    } catch (error) {
+      console.error(`Error checking port ${port}:`, error);
+      statusEl.innerHTML = '<span class="unavailable">? Unknown</span>';
+    }
+  }
+
+  /**
+   * "Check All" - runs checkAllPortsAndSuggestAlternatives against the current
+   * table values and surfaces any conflicts plus a "Use Suggested" option.
+   */
+  private async handleCheckAllPorts(): Promise<void> {
+    const statusMsg = document.getElementById('ports-status-message');
+    const useSuggestedBtn = document.getElementById('ports-use-suggested');
+
+    try {
+      if (statusMsg) statusMsg.innerHTML = '<div style="opacity: 0.8;">Checking all ports…</div>';
+
+      const baseConfig = await window.electronAPI.envConfig.getConfig() as EnvConfig;
+      const config = this.readPortsFromInputs(baseConfig);
+
+      const result = await window.electronAPI.envConfig.checkAllPorts(config as any);
+
+      // Refresh each row's live status against the values actually checked
+      await Promise.all(PORT_ROWS.map(row => this.refreshPortRowStatus(row.key, (config as any)[row.key])));
+
+      if (result.hasConflicts) {
+        this.lastSuggestedPortsConfig = (result.suggestedConfig as EnvConfig) || null;
+
+        const conflictList = result.conflicts.map((c: any) =>
+          `<li><strong>${c.name}</strong>: port ${c.port} is in use (suggested: ${c.suggested})</li>`
+        ).join('');
+
+        if (statusMsg) {
+          statusMsg.innerHTML = `
+            <div class="alert warning">
+              <strong>Port conflicts detected</strong>
+              <ul style="margin: 5px 0 0 20px; padding: 0;">${conflictList}</ul>
+            </div>
+          `;
+        }
+
+        if (useSuggestedBtn) useSuggestedBtn.style.display = 'inline-block';
+      } else {
+        this.lastSuggestedPortsConfig = null;
+        if (statusMsg) {
+          statusMsg.innerHTML = '<div class="alert success">All ports are available.</div>';
+        }
+        if (useSuggestedBtn) useSuggestedBtn.style.display = 'none';
+      }
+
+      this.updatePortsLastChecked();
+    } catch (error) {
+      console.error('Error checking all ports:', error);
+      if (statusMsg) statusMsg.innerHTML = '<div class="alert error">Failed to check ports.</div>';
+    }
+  }
+
+  /**
+   * "Use Suggested" - applies the last-computed suggestedConfig to the input fields
+   */
+  private handleUseSuggestedPorts(): void {
+    if (!this.lastSuggestedPortsConfig) return;
+
+    for (const row of PORT_ROWS) {
+      const input = document.getElementById(`port-input-${row.key}`) as HTMLInputElement | null;
+      const value = (this.lastSuggestedPortsConfig as any)[row.key];
+      if (input && value !== undefined) {
+        input.value = String(value);
+        input.style.borderColor = '#4CAF50';
+        setTimeout(() => { input.style.borderColor = 'rgba(255, 255, 255, 0.2)'; }, 2000);
+      }
+    }
+
+    this.showNotification('Applied suggested available ports. Click Save to persist.', 'success');
+
+    // Re-check with the newly applied values
+    this.handleCheckAllPorts();
+  }
+
+  /**
+   * "Save" - persists the port configuration to .env and prompts to restart services
+   */
+  private async handleSavePorts(): Promise<void> {
+    const statusMsg = document.getElementById('ports-status-message');
+    const saveBtn = document.getElementById('ports-save') as HTMLButtonElement | null;
+
+    try {
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving...';
+      }
+
+      const baseConfig = await window.electronAPI.envConfig.getConfig() as EnvConfig;
+      const config = this.readPortsFromInputs(baseConfig);
+
+      const validation = await window.electronAPI.envConfig.validateConfig(config as any);
+      if (!validation.valid) {
+        if (statusMsg) {
+          statusMsg.innerHTML = `<div class="alert error">Validation failed: ${validation.errors.join(', ')}</div>`;
+        }
+        return;
+      }
+
+      const result = await window.electronAPI.envConfig.saveConfig(config as any);
+
+      if (result.success) {
+        if (statusMsg) {
+          statusMsg.innerHTML = `<div class="alert success">Ports saved to ${result.path}. Restart services for changes to take effect.</div>`;
+        }
+        this.showNotification('Ports saved successfully', 'success');
+
+        const shouldRestart = window.confirm(
+          'Port configuration saved. Services must be restarted for the new ports to take effect. Restart now?'
+        );
+        if (shouldRestart) {
+          this.showNotification('Restarting MCP system...', 'info');
+          const restartResult = await window.electronAPI.mcpSystem.restart();
+          if (restartResult.success) {
+            this.showNotification('Services restarted successfully', 'success');
+            await this.refreshAllServices();
+          } else {
+            this.showNotification(`Failed to restart services: ${restartResult.message}`, 'error');
+          }
+        }
+
+        await this.loadPortsTable();
+      } else {
+        if (statusMsg) {
+          statusMsg.innerHTML = `<div class="alert error">Failed to save: ${result.error}</div>`;
+        }
+        this.showNotification('Failed to save port configuration', 'error');
+      }
+    } catch (error) {
+      console.error('Error saving ports:', error);
+      if (statusMsg) statusMsg.innerHTML = '<div class="alert error">Error saving port configuration.</div>';
+      this.showNotification('Error saving port configuration', 'error');
+    } finally {
+      if (saveBtn) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+      }
+    }
+  }
+
+  /**
+   * Update the "last checked" timestamp for the Ports section
+   */
+  private updatePortsLastChecked(): void {
+    const el = document.getElementById('ports-last-checked');
+    if (el) {
+      el.textContent = `Last checked: ${new Date().toLocaleTimeString()}`;
     }
   }
 

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -232,6 +232,9 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       PGBOUNCER_PORT: currentEnvConfig?.PGBOUNCER_PORT || 6432,
       NPE_PORT: currentEnvConfig?.NPE_PORT || 3011,
       WORKFLOW_MANAGER_PORT: currentEnvConfig?.WORKFLOW_MANAGER_PORT || 3012,
+      // Not exposed as a form field on this form - preserve existing value so a
+      // re-save doesn't silently erase a stored GitHub token
+      GITHUB_TOKEN: currentEnvConfig?.GITHUB_TOKEN,
     };
 
     const validation = await (window as any).electronAPI.envConfig.validateConfig(config);

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -14,6 +14,8 @@ interface EnvConfig {
   DB_ADMIN_PORT: number;
   MCP_AUTH_TOKEN: string;
   PGBOUNCER_PORT: number;
+  NPE_PORT: number;
+  WORKFLOW_MANAGER_PORT: number;
   GITHUB_TOKEN?: string;
 }
 
@@ -225,7 +227,11 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       HTTP_SSE_PORT: parseInt((form.elements.namedItem('HTTP_SSE_PORT') as HTMLInputElement).value, 10),
       DB_ADMIN_PORT: parseInt((form.elements.namedItem('DB_ADMIN_PORT') as HTMLInputElement).value, 10),
       MCP_AUTH_TOKEN: (form.elements.namedItem('MCP_AUTH_TOKEN') as HTMLInputElement).value,
-      PGBOUNCER_PORT: 6432, // Fixed port for PgBouncer
+      // Not exposed as form fields on this basic config form - preserve existing
+      // values (editable from the Ports settings panel instead), default otherwise
+      PGBOUNCER_PORT: currentEnvConfig?.PGBOUNCER_PORT || 6432,
+      NPE_PORT: currentEnvConfig?.NPE_PORT || 3011,
+      WORKFLOW_MANAGER_PORT: currentEnvConfig?.WORKFLOW_MANAGER_PORT || 3012,
     };
 
     const validation = await (window as any).electronAPI.envConfig.validateConfig(config);

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -69,7 +69,22 @@ interface EnvConfig {
   HTTP_SSE_PORT: number;
   DB_ADMIN_PORT: number;
   MCP_AUTH_TOKEN: string;
+  PGBOUNCER_PORT: number;
+  NPE_PORT: number;
+  WORKFLOW_MANAGER_PORT: number;
   TYPING_MIND_PORT: number;
+}
+
+interface PortConflictDetail {
+  port: number;
+  name: string;
+  suggested: number;
+}
+
+interface PortConflictCheckResult {
+  hasConflicts: boolean;
+  conflicts: PortConflictDetail[];
+  suggestedConfig?: EnvConfig;
 }
 
 interface ConfigValidationResult {
@@ -284,6 +299,7 @@ interface ElectronAPI {
     generatePassword: (length?: number) => Promise<string>;
     generateToken: () => Promise<string>;
     checkPort: (port: number) => Promise<boolean>;
+    checkAllPorts: (config: EnvConfig) => Promise<PortConflictCheckResult>;
     resetDefaults: () => Promise<EnvConfig>;
     validateConfig: (config: EnvConfig) => Promise<ConfigValidationResult>;
     calculatePasswordStrength: (password: string) => Promise<'weak' | 'medium' | 'strong'>;

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -716,6 +716,11 @@ async function saveEnvironmentConfig(): Promise<boolean> {
     const statusEl = document.getElementById('env-config-status');
 
     try {
+        // Get current config first so we can preserve fields the wizard form doesn't
+        // expose (credentials, and ports like NPE_PORT/WORKFLOW_MANAGER_PORT that are
+        // only editable from the Ports settings panel, not this wizard step)
+        const currentConfig = await (window as any).electronAPI.envConfig.getConfig();
+
         // Get form values
         const config = {
             POSTGRES_DB: (document.getElementById('postgres-db') as HTMLInputElement).value,
@@ -727,12 +732,12 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             DB_ADMIN_PORT: parseInt((document.getElementById('db-admin-port') as HTMLInputElement).value),
             MCP_AUTH_TOKEN: '', // Will be auto-generated
             TYPING_MIND_PORT: parseInt((document.getElementById('typing-mind-port') as HTMLInputElement).value),
-            PGBOUNCER_PORT: parseInt((document.getElementById('pgbouncer-port') as HTMLInputElement).value)
+            PGBOUNCER_PORT: parseInt((document.getElementById('pgbouncer-port') as HTMLInputElement).value),
+            // Not exposed in this wizard step - preserve existing value, default otherwise
+            NPE_PORT: currentConfig?.NPE_PORT || 3011,
+            WORKFLOW_MANAGER_PORT: currentConfig?.WORKFLOW_MANAGER_PORT || 3012,
         };
 
-        // Get current config to check if credentials already exist
-        const currentConfig = await (window as any).electronAPI.envConfig.getConfig();
-        
         // Check if .env file actually exists on disk
         // This is critical to prevent password regeneration
         const envFileExists = await (window as any).electronAPI.envConfig.fileExists();

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -736,6 +736,9 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             // Not exposed in this wizard step - preserve existing value, default otherwise
             NPE_PORT: currentConfig?.NPE_PORT || 3011,
             WORKFLOW_MANAGER_PORT: currentConfig?.WORKFLOW_MANAGER_PORT || 3012,
+            // Not exposed in this wizard step - preserve existing value so a re-save
+            // doesn't silently erase a stored GitHub token
+            GITHUB_TOKEN: currentConfig?.GITHUB_TOKEN,
         };
 
         // Check if .env file actually exists on disk

--- a/src/renderer/views/ServicesView.ts
+++ b/src/renderer/views/ServicesView.ts
@@ -60,6 +60,49 @@ export class ServicesView implements View {
             <span id="services-last-updated" class="last-updated">Last updated: --:--:--</span>
           </div>
         </div>
+
+        ${this.renderPortsSection()}
+      </div>
+    `;
+  }
+
+  /**
+   * Render the Ports settings section: lists every configurable service port
+   * with a live in-use indicator, an editable field, and controls to check for
+   * conflicts, apply suggested alternatives, and save + restart.
+   */
+  private renderPortsSection(): string {
+    return `
+      <div class="dashboard-card" style="margin-top: 20px;">
+        <div class="dashboard-header">
+          <h2>Ports</h2>
+          <div class="dashboard-actions" style="gap: 10px;">
+            <button id="ports-check-all" class="action-button" title="Check all ports for conflicts">Check All</button>
+            <button id="ports-use-suggested" class="action-button" title="Apply suggested available ports" style="display: none;">Use Suggested</button>
+            <button id="ports-save" class="action-button primary" title="Save port configuration">Save</button>
+          </div>
+        </div>
+
+        <div id="ports-status-message" style="margin-bottom: 10px;"></div>
+
+        <div style="overflow-x: auto;">
+          <table class="ports-table" style="width: 100%; border-collapse: collapse;">
+            <thead>
+              <tr style="text-align: left; border-bottom: 1px solid rgba(255,255,255,0.2);">
+                <th style="padding: 8px;">Service</th>
+                <th style="padding: 8px;">Port</th>
+                <th style="padding: 8px;">Status</th>
+              </tr>
+            </thead>
+            <tbody id="ports-table-body">
+              <!-- Rows are injected by ServicesTab.ts -->
+            </tbody>
+          </table>
+        </div>
+
+        <div class="dashboard-footer" style="margin-top: 15px;">
+          <span id="ports-last-checked" class="last-updated">Not checked yet</span>
+        </div>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Implements the fix plan from `github-issues/triage-2026-07-04/issue-05-port-conflicts-and-settings.md` (6 changes):

1. **Parameterized hardcoded ports** - `NPE_PORT` (default 3011) and `WORKFLOW_MANAGER_PORT` (default 3012) added to `EnvConfig`/`DEFAULT_CONFIG`, `parseEnvFile`/`formatEnvFile`, `docker-compose.yml`, and the `execDockerCompose` env injection in `mcp-system.ts`.
2. **Fixed PgBouncer compose mapping** - `docker-compose.yml` line 43 changed from `${PGBOUNCER_PORT}:${PGBOUNCER_PORT}` to `${PGBOUNCER_PORT}:6432` so the host port is remappable while the container-internal port (hardwired elsewhere as `fictionlab-pgbouncer:6432`) stays fixed. Also fixes a latent bug in `pgbouncer-config.ts`: it previously rendered `listen_port = ${config.PGBOUNCER_PORT}` *inside the container*, which would have broken the compose remap the moment PGBOUNCER_PORT actually moved. Now hardcoded to `6432` to match the fixed container side.
3. **New ports added to the probe list** - `NPE_PORT`/`WORKFLOW_MANAGER_PORT` added to `checkAllPortsAndSuggestAlternatives()`'s configurable-port checks. `PGBOUNCER_PORT` was already probed and is now genuinely remappable given fix #2.
4. **Auto-remediation at startup** - `startMCPSystem` now: check conflicts → `stopExistingContainers()` → recheck → **(new)** if conflicts persist, apply `suggestedConfig`, persist via `saveEnvConfig`, log prominently which ports moved, retry the conflict check once → only return `PORT_CONFLICT` (same shape/code as before) if the retry also fails. Runs on every platform, default-on, no feature flag - the branch is only entered when conflicts persist after cleanup, so a normal no-conflict run (Windows or otherwise) is unaffected.
5. **Ports settings panel** - new "Ports" section on the Services tab (`ServicesView.ts` / `ServicesTab.ts`) listing all 7 ports (Postgres, PgBouncer, MCP Connector, HTTP/SSE, DB Admin, NPE, Workflow Manager) with live per-port availability (reusing `checkPortAvailable` via the existing `env:check-port` IPC handler), "Check All" (`checkAllPortsAndSuggestAlternatives` via `env:check-all-ports`), "Use Suggested" (reuses the setup wizard's apply-suggested-config pattern), and "Save" (persists `.env` via the existing `env:save-config` handler, then prompts to restart services). No new IPC handlers were needed - all built on the existing `env:*` group using plain `ipcMain.handle`. `TYPING_MIND_PORT` intentionally excluded everywhere (PR #172 is removing it).
6. **`linux-db-diagnostic.sh`** - reads `POSTGRES_PORT`/`PGBOUNCER_PORT`/`HTTP_SSE_PORT`/`MCP_CONNECTOR_PORT` from the app's `.env` (checking likely userData locations) instead of the hardcoded `PORTS=(5432 6432 3001 50880)` array, falling back to defaults if no `.env` is found. Also fixes a stale default: the script was checking `50880` (the container-internal MCP Connector port) instead of `51300` (the actual default host-published port).

### Side fixes required by the new required EnvConfig fields
Wiring `NPE_PORT`/`WORKFLOW_MANAGER_PORT` as required `EnvConfig` fields surfaced two latent bugs: the setup wizard's save handler and the basic env-config-form handler both constructed full `EnvConfig` objects without these fields, which would have failed main-process `validateConfig` post-#162. Both now preserve the existing value (or default) instead of omitting it. The basic-form handler also stopped hardcoding `PGBOUNCER_PORT: 6432` on every save (it was silently discarding any customized PgBouncer port).

## Verification

- **Build**: `npm run build` (tsc renderer + main, then asset copy) - **exit 0**, no errors.
- **Compose validation**: `docker compose -f docker-compose.yml config` parses cleanly. Confirmed with sample env values that container-internal ports stay fixed (postgres `5432`, pgbouncer `6432`, mcp-writing-servers `3001`/`3010`/`3011`/`3012`) while published host ports follow the corresponding `*_PORT` variables (e.g. `PGBOUNCER_PORT=6499` → `published: "6499"`, `target: 6432`).
- **Tests**: this repo has no committed jest config (pre-existing, out of scope). Wrote an ad-hoc, uncommitted test file + inline jest config (deleted after the run, not part of this PR) covering `checkAllPortsAndSuggestAlternatives`/`formatEnvFile`/`parseEnvFile`/`validateConfig` for the two new ports and the PgBouncer host-remap case. Ran via `npx jest --config jest.adhoc.config.json`. **10/10 passed.** Only high scratch ports (>= 49990) were used/bound in the tests - no real service port or live container was touched, per the live-machine safety constraint for this task.

## Coordination notes
- `PORT_CONFLICT` return shape/code from `startMCPSystem` is unchanged (for PR #161).
- All new IPC handlers (there were none needed) would have used plain `ipcMain.handle`, not a registry (for PR #171).
- `TYPING_MIND_PORT` was never added anywhere (for PR #172); edits near it in `env-config.ts` were kept minimal - a merge conflict there is expected and fine.

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)