### PR TITLE
fix: replace stale hardcoded model ids with current ids + default tracking

### DIFF
--- a/docs/bug-triage-2026-07-04.md
+++ b/docs/bug-triage-2026-07-04.md
@@ -1,0 +1,184 @@
+# FictionLab bug triage — 2026-07-04
+
+User-reported issues, each verified against the codebase by Casey (code investigation,
+not guesses). File:line pointers are to source as of this date. Ordered by
+effort-vs-impact within each tier.
+
+---
+
+## Tier 1 — small fixes, high impact
+
+### 1. Electron submenus don't work (menus visible, clicks do nothing)
+**Root cause found.** The original menu template in `src/main/index.ts:86-250`
+(`createMenu()`) is correct and self-contained — all `click:` handlers live in the main
+process. But `updatePluginMenu()` in `src/main/plugin-manager.ts:179` (called on every
+plugin load/activation at lines 112, 124, 148) rebuilds the app menu by passing live
+`MenuItem` instances from `Menu.getApplicationMenu().items` back into
+`Menu.buildFromTemplate()` (lines 257-281). `buildFromTemplate` expects plain
+`MenuItemConstructorOptions`; feeding it live instances drops the submenu `click`
+callbacks while keeping top-level labels visible. `role:`-based items (Edit/View) keep
+working natively, which makes the breakage look partial.
+**Fix:** keep the constructor-options template from `createMenu()` as the source of
+truth; splice the Plugins submenu into *that* template and rebuild, instead of
+round-tripping live `MenuItem` instances.
+
+### 2. Genre packs dropdown is empty
+**Root cause found — hardcoded stub.** The dropdown loads via `project:list-genre-packs`,
+whose handler at `src/main/index.ts:2437-2442` **unconditionally returns `[]`** (comment:
+"genre packs are no longer bundled with the Electron app"). Meanwhile two valid packs
+exist at `C:\github\fictionlab-workflow\resources\genre-packs\` (`gothic-romance-horror`,
+`urban-fantasy-police-procedural`), and a working scanner already exists:
+`ResourceCopier.listAvailableGenrePacks()` (`resource-copier.ts:410-444`) — it's just
+never called by the handler.
+**Fix:** wire the handler to the existing scanner. Note the pack copy only happens at
+workflow-run time (`resource-copier.ts:208-243`) and needs the pack id the dropdown
+supplies, so fixing the list fixes the chain.
+
+### 3. Workflow dashboard: duplicate buttons that do nothing
+**Root cause found.** The TopBar declares `import` and `refresh` actions
+(`src/renderer/views/WorkflowsViewReact.tsx:850-851`) that duplicate the working in-view
+toolbar buttons — but their dispatcher `handleAction()` (lines 860-864) only does
+`console.log`. These are the visible dead duplicates.
+**Fix:** either wire `handleAction('import')`/`('refresh')` to `setShowImportDialog(true)`
+/ `loadWorkflows(true)`, or remove the TopBar actions.
+**Related dead code (cleanup, same PR or later):**
+- The plugin-namespaced copies of `workflow:list-active/pause/resume/cancel/jump-to-node`
+  in `fictionlab-workflow/packages/workflow-plugin/src/ipc-handlers.ts:139-186` are never
+  invoked by the UI (it calls the non-namespaced main-app versions in
+  `workflow-handlers.ts:671-753`).
+- The entire `electronAPI.workflows.*` preload surface (`src/preload/preload.ts:2449-2526`,
+  channels `workflows:list/get/execute/cancel/get-runs/delete/create/update`) has **no
+  registered ipcMain handlers at all** — dead API.
+
+---
+
+## Tier 2 — medium efforts
+
+### 4. Docker not detected at launch → "restart" prompt
+**Root cause found — CLI-only, single-shot detection.** The launch gate
+(`src/main/index.ts:2707-2786`) calls `checkDockerHealth()` (`src/main/docker.ts:421-491`),
+which shells out to `docker info` / `docker ps` with a single 20s timeout and **no
+retry, no dockerode ping, no named-pipe probe**. Failure modes on Windows:
+- Cold WSL2 backend: first `docker info` after boot routinely exceeds 20s → classified
+  unhealthy → gate fires the start/exit path.
+- PATH shim (`prerequisites.ts:63-102`) only injects the default
+  `C:\Program Files\Docker\...` paths — non-default installs make every exec check fail.
+- The gate never checks `isDockerDesktopProcessRunning()` first, so a
+  running-but-initializing Docker Desktop is treated as down.
+- dockerode is already a dependency but only used post-launch (`update-manager.ts:9,41`).
+**Desired flow is only partially implemented:** daemon check + auto-start + 60s wait
+exist (`docker.ts:551-597`), but (a) Windows start opens the full GUI
+(`docker.ts:145-154`) — Docker Desktop has no true headless mode; closest is launching
+the exe with "Open Dashboard at startup" off so it goes to tray; (b) **container startup
+is not in the launch gate at all** — `docker compose up` lives in
+`startMCPSystem` (`mcp-system.ts:1117`) and only runs from the wizard/dashboard.
+**Fix:** (1) probe the daemon with dockerode `.ping()` against
+`//./pipe/docker_engine` with retries before falling back to CLI; (2) check the
+Desktop process before declaring "not running"; (3) after daemon-up, run the postgres
+container start + verify inside the launch sequence.
+
+### 5. Port conflicts (Linux build failure) + no port visibility/edit UI
+**Diagnosis confirmed:** default `POSTGRES_PORT` is 5432 (`env-config.ts:43`,
+`docker-compose.yml:23-24`) and collides with a system Postgres on Linux.
+**Surprise: detection already exists and is Linux-aware** —
+`checkPortAvailable()` (`env-config.ts:302-338`, ss/netstat/lsof + dual-interface Node
+probe) and `checkAllPortsAndSuggestAlternatives()` (`env-config.ts:436-531`). What's
+missing is remediation outside the setup wizard:
+- `startMCPSystem` aborts with `PORT_CONFLICT` (`mcp-system.ts:1007-1059`) instead of
+  applying `suggestedConfig`; only the wizard's "Use Suggested Ports" button
+  (`setup-wizard-handlers.ts:569-573`) applies it.
+- Ports **3011 (NPE) and 3012 (Workflow Manager) are hardcoded** in
+  `docker-compose.yml:94-95` and are NOT in the pre-flight probe list
+  (`env-config.ts:451-456`) — collisions there surface only as compose
+  "port is already allocated" errors.
+- PgBouncer 6432 is effectively unchangeable (compose maps
+  `${PGBOUNCER_PORT}:${PGBOUNCER_PORT}` and MCP servers hardwire
+  `fictionlab-pgbouncer:6432`; warning comment at `mcp-system.ts:1037-1040`).
+**Full port map** (host side): Postgres 5432, PgBouncer 6432, MCP Connector 51300,
+HTTP/SSE 3001, DB-Admin 3010, NPE 3011*, Workflow Mgr 3012* (*hardcoded).
+Note `formatEnvFile` (`env-config.ts:709-733`) doesn't persist all of these.
+**Fix:** (1) auto-apply `suggestedConfig` in the non-wizard startup path (or at minimum
+on Linux); (2) parameterize 3011/3012 in compose + add to the probe list; (3) add a
+"Ports" settings panel that lists every port above with live in-use status (the probe
+functions already exist) and lets the user edit + persist them.
+
+### 6. TypingMind local-install remnants (dead checks + dead update button)
+**Confirmed dead** (TypingMind is cloud-only now). Dead chain to remove:
+- "Check for Updates" button: `src/renderer/views/SetupView.ts:122-126` →
+  `SetupTab.ts:77-79, 281-350` → preload `preload.ts:1818-1840` → handlers
+  `index.ts:1234-1236, 1265-1275` → `updater.ts:295-331, 813-885` (+ typingMind fields
+  in `checkForAllUpdates` `updater.ts:339-374`).
+- Entire `src/main/typingmind-downloader.ts` module + its 7 IPC handlers
+  (`index.ts:840-914`) + preload bridges (`preload.ts:1200-1243, 289-354`).
+- Local-container health cards + Start/Stop/Restart/Logs controls:
+  `ServicesTab.ts:152-165, 324-381, 502-529`; `ServicesView.ts:55, 131-157`;
+  LogsTab `typing-mind` option (`LogsTab.ts:34,120,1104-1108`).
+- **Actively broken branch:** `mcp-system.ts:1201-1221` runs
+  `docker compose up -d typingmind` — no such service exists in docker-compose.yml
+  (would fail if `services.typingMind` were ever true). Contradicts its own comment at
+  `mcp-system.ts:626-627`.
+- `TYPING_MIND_PORT` (8080) reserved but unused: `env-config.ts:32,49`, wizard field
+  `setup-wizard-handlers.ts:596,674,729`, `.env.test:17-20`.
+- `config/setup-config.json` `typing-mind` clone entries (lines 26-29, 38, 42, 66-68,
+  94-99) and `client-selection.ts:65-84` vestigial `repoUrl`.
+**Keep (live cloud wiring):** the `@typingmind/mcp` connector (docker-compose.yml:52-68,
+`docker/connector-entrypoint.sh`), `typingmind-auto-config.ts`, `mcp-config-generator.ts`
+(fix stale "Open TypingMind at http://localhost:PORT" instruction strings at
+`mcp-config-generator.ts:226`, `configure-typingmind.js:123`), the Open/Configure
+buttons pointing at typingmind.com, and the `'typingmind'` workflow-source tag/badge.
+
+### 7. IPC `-help` not set up
+**Confirmed.** The only argv flag parsed anywhere is `--dev` (`index.ts:288,334,382`).
+No commander/yargs/minimist, no `bin` field, no help channel. The IPC surface is ~20
+groups of `ipcMain.handle` channels starting at `index.ts:430` with no
+enumeration/introspection.
+**Fix:** add an `ipcMain.handle('help', ...)` that returns the registered channel list
+(collect channel names at registration time), and/or parse `--help` in main. The
+run-workflow skill's `ipc-client.js` would be the immediate consumer.
+
+---
+
+## Tier 3 — larger features
+
+### 8. Create-project doesn't create the folders Series Architect needs
+**Confirmed mismatch.** `project:initialize-workspace` (`index.ts:2382-2431`) creates
+`.claude/`, `planning/`, `planning/character-profiles/`, `planning/world-building/`,
+`books/`, `exports/` — but the SA v2 pipeline writes everything under
+**`{{projectFolder}}/outputs/`** (intake_form.md, series_bible.md, market_research.md,
+genre_pack.json, series_framework.md, `outputs/book_N/…` — see
+`FictIonLab-Downloads/workflows/series-architect-*/workflow.yaml` and
+`dramatica-storyform/workflow.yaml:52-148`), and the SA agent also expects
+`series-planning/` (`series-architect-agent.md:22,930`). None of the created folders
+are used by SA; the ones SA is organized around are absent. The genre-pack step of
+init is a log-only stub (`index.ts:2421-2423`).
+Mitigating: SA file-writes self-create dirs (`file-operation-executor.ts:280`
+`fs.ensureDir`), so writes don't fail — the breakage is reads of expected paths and
+the scaffold being misleading. (`createDirectories` node flag is a no-op —
+`WORKFLOW-FIXES.md:78`.)
+**Fix:** align the init scaffold with the SA v2 layout (`outputs/`, `series-planning/`)
+— cross-check the WutheringDragons testbed START-HERE.md checklist, which is the
+canonical empty-project test for this exact flow.
+
+### 9. No way to create a new workflow in-app (import only)
+**Confirmed.** Toolbar offers Import/Export/Start/Refresh/Hide only
+(`WorkflowsViewReact.tsx:657-692`); the canvas editor (`+ Add Node`, edge editing)
+operates only on an existing workflow (`WorkflowCanvas.tsx:472,863,1005`); the latent
+`electronAPI.workflows.create` stub (`preload.ts:2517` → `workflows:create`) has no
+handler. Workflows must be authored externally (YAML/JSON) and imported
+(`workflow:import-from-folder`, or the direct DB importer
+`FictIonLab-Downloads/tools/import-workflow.js`).
+**Fix:** a "New Workflow" button that creates a blank workflow row (name + empty
+graph) and opens it in the existing canvas editor — most of the editing plumbing
+(add-node/add-edge IPC in `workflow-handlers.ts:137-227`) already exists.
+
+---
+
+## Cross-cutting observations
+- Several bugs share one shape: **a working implementation exists but the entry point
+  is a stub** (genre packs handler returns `[]` while the scanner exists; port
+  suggestion exists but startup won't apply it; TopBar actions log instead of dispatch;
+  `workflows:create` exposed but unhandled). Grep for handler stubs before writing new
+  code.
+- The plugin menu rebuild (issue 1) and the duplicate plugin IPC registrations
+  (issue 3) both come from the plugin layer re-wrapping app-level machinery — worth a
+  design pass on what the plugin layer owns vs. delegates.

--- a/github-issues/triage-2026-07-04/issue-01-submenu-clicks-dead.md
+++ b/github-issues/triage-2026-07-04/issue-01-submenu-clicks-dead.md
@@ -1,0 +1,43 @@
+# [BUG] Application submenus stop working after plugins load — menu rebuilt from live MenuItem instances
+
+**Labels:** bug, ui, main-window, priority: high, complexity: low
+
+## Symptom
+The application menu bar renders (File, Edit, View, Diagnostics, Help, Plugins), but clicking submenu items does nothing. `role:`-based items (Edit/View cut-copy-paste, zoom, quit) keep working, which makes the breakage look partial/intermittent.
+
+## Root cause (verified — do not re-investigate)
+The original menu built by `createMenu()` in `src/main/index.ts:86-250` is correct: all submenu items use main-process `click:` callbacks (Diagnostics → functions imported from `./diagnostics`; Help → `shell.openExternal`, `updater.checkForAllUpdates()`, etc.). It is installed once at startup (`index.ts:2789`).
+
+The bug is in `updatePluginMenu()` at `src/main/plugin-manager.ts:179`, called on plugin load/activation (`plugin-manager.ts:112, 124, 148`). It rebuilds the menu like this:
+
+```ts
+const menu = Menu.getApplicationMenu();            // line 185 — live MenuItem instances
+// ...
+Menu.buildFromTemplate([...menu.items.slice(...), pluginsMenu, ...])  // lines 257-281
+Menu.setApplicationMenu(newMenu);
+```
+
+`Menu.buildFromTemplate()` expects plain `MenuItemConstructorOptions`. Live `MenuItem` instances have `.submenu` as a `Menu` object (not an options array), and their `click` callbacks are NOT carried over when round-tripped. Result: top-level labels survive, every custom `click` handler in every submenu is silently dropped. `role:` items keep working because Electron handles them natively — that's the "partial" illusion.
+
+Since plugins load during startup, the menu is effectively always broken by the time the user interacts with it.
+
+## Implementation plan
+1. In `src/main/index.ts`, refactor `createMenu()` so the template (the `MenuItemConstructorOptions[]` array it currently builds inline at lines ~86-247) is available to other modules — e.g. export a `getBaseMenuTemplate(): MenuItemConstructorOptions[]` that returns a fresh copy of the template, and have `createMenu()` use it.
+2. In `src/main/plugin-manager.ts` `updatePluginMenu()` (line 179): stop reading `Menu.getApplicationMenu().items`. Instead:
+   - Get the base template via `getBaseMenuTemplate()`.
+   - Build the Plugins submenu as plain `MenuItemConstructorOptions` (the plugin entries it already constructs are fine — they're built as options, not instances).
+   - Splice the Plugins menu into the base template at the desired position (currently it inserts before Help — preserve that position).
+   - `Menu.setApplicationMenu(Menu.buildFromTemplate(fullTemplate))`.
+3. Ensure repeated calls are idempotent (plugin load fires `updatePluginMenu` multiple times — at `plugin-manager.ts:112, 124, 148`). Rebuilding from the base template each time guarantees this; do NOT accumulate.
+4. Remove the now-unused instance-slicing logic at `plugin-manager.ts:257-281`.
+
+## Acceptance criteria
+- [ ] With plugins loaded, every Diagnostics submenu item works (Open Log File, Open Logs Directory, Export Diagnostic Report, Test System — handlers in `src/main/diagnostics`).
+- [ ] Help submenu items work (external links open, About dialog shows, Check for Updates runs).
+- [ ] Plugins menu still lists loaded plugins and its items still work.
+- [ ] Calling plugin activation repeatedly does not duplicate menus or grow the menu bar.
+- [ ] `npm run build` passes; existing jest tests pass.
+
+## Gotchas
+- The `dist/` build currently matches source, so test with `npm run dev` after rebuilding — the bug reproduces only after plugin load, not at bare startup.
+- Don't try to "fix" by mapping live MenuItems back to options objects — regenerating from the source template is simpler and idempotent.

--- a/github-issues/triage-2026-07-04/issue-02-genre-packs-empty.md
+++ b/github-issues/triage-2026-07-04/issue-02-genre-packs-empty.md
@@ -1,0 +1,32 @@
+# [BUG] Genre packs dropdown is always empty — IPC handler is a hardcoded `return []`
+
+**Labels:** bug, ui, configuration, priority: high, complexity: low
+
+## Symptom
+In the "Create New Project" dialog, the Genre Pack dropdown only ever shows "None". Real genre packs exist on disk but never appear.
+
+## Root cause (verified — do not re-investigate)
+- The dropdown loads via `electronAPI.project.listGenrePacks()` (`src/renderer/components/ProjectCreationDialog.tsx:38-43`) → preload `project:list-genre-packs` (`src/preload/preload.ts:1593`).
+- The main-process handler at `src/main/index.ts:2437-2442` **unconditionally returns `[]`**, with a comment saying genre packs are no longer bundled with the Electron app.
+- But the packs exist and a working scanner exists:
+  - Packs: `C:\github\fictionlab-workflow\packages\...\resources\genre-packs\` — currently `gothic-romance-horror/` and `urban-fantasy-police-procedural/`, each with a `manifest.json`. (In the installed app these resources ship with the workflow plugin — resolve the path the same way `ResourceCopier` does.)
+  - Scanner: `ResourceCopier.listAvailableGenrePacks()` in the workflow-runner package (`resource-copier.ts:410-444`) — reads the `genre-packs` dir, keeps subdirs containing `manifest.json`, skips `_`-prefixed dirs. It is never called by this handler.
+- Downstream, the genre pack is copied into the project at workflow-run time by `resource-copier.ts:208-243`, keyed by the pack id the dropdown supplies — so fixing the list fixes the whole chain.
+
+## Implementation plan
+1. Replace the stub at `src/main/index.ts:2437-2442` with a call into the existing scanner. Either:
+   - import/instantiate `ResourceCopier` from `@fictionlab/workflow-runner` and call `listAvailableGenrePacks()`, or
+   - if the Electron main process shouldn't depend on the runner package directly, route through the workflow plugin (it already has an IPC surface — see `fictionlab-workflow/packages/workflow-plugin/src/ipc-handlers.ts`) and have the renderer call the plugin channel.
+   Prefer whichever direction the codebase already uses for `ResourceCopier` at run time (the run-time copy path resolves the resources dir — reuse that path resolution, do not hardcode a dev-machine path).
+2. Return shape must match what `ProjectCreationDialog.tsx:331-334` renders (id + display name from `manifest.json`).
+3. Handle the missing-directory case gracefully (return `[]`, log a warning) so a broken install doesn't crash the dialog.
+
+## Acceptance criteria
+- [ ] Create Project dialog lists `gothic-romance-horror` and `urban-fantasy-police-procedural` (display names from their manifests) plus "None".
+- [ ] Selecting a pack and creating a project stores the pack id so the run-time copy (`resource-copier.ts:208-243`) receives it.
+- [ ] Empty/missing genre-packs directory → dropdown shows only "None", no error dialog.
+- [ ] `npm run build` passes.
+
+## Gotchas
+- Do NOT reintroduce bundling packs inside the Electron app — the comment in the stub reflects a real decision. The packs live with the workflow plugin resources; list them from there.
+- Related: the project-init "genre pack" step is currently a log-only stub (`src/main/index.ts:2421-2423`) — that's tracked in the project-scaffold issue, not this one.

--- a/github-issues/triage-2026-07-04/issue-03-dashboard-dead-buttons.md
+++ b/github-issues/triage-2026-07-04/issue-03-dashboard-dead-buttons.md
@@ -1,0 +1,27 @@
+# [BUG] Workflow dashboard: TopBar Import/Refresh buttons are no-op duplicates; dead `workflows:*` API surface
+
+**Labels:** bug, ui, cleanup, ipc, complexity: low
+
+## Symptom
+The workflow dashboard shows Import and Refresh buttons in two places. The in-view toolbar buttons work; the TopBar copies do nothing when clicked.
+
+## Root cause (verified — do not re-investigate)
+1. **TopBar no-ops:** `getTopBarConfig()` in `src/renderer/views/WorkflowsViewReact.tsx:846-864` declares actions `{id:'import'}` and `{id:'refresh'}` (lines 850-851), duplicating the working toolbar buttons at lines 658 and 678. Their dispatcher `handleAction(actionId)` (lines 860-864) **only calls `console.log`** — no dispatch.
+2. **Dead API surface:** `src/preload/preload.ts:2449-2526` exposes `electronAPI.workflows.*` invoking channels `workflows:list/get/execute/cancel/get-runs/delete/create/update` (plural namespace). **No `ipcMain.handle` exists for ANY `workflows:*` channel** — the entire surface is dead.
+3. **Duplicate plugin IPC registrations (dead):** the plugin registers namespaced copies of the active-workflow controls in `fictionlab-workflow/packages/workflow-plugin/src/ipc-handlers.ts` — `workflow:list-active` (:139), `pause` (:150), `resume` (:162), `cancel` (:174), `jump-to-node` (:186). The dashboard actually calls the non-namespaced main-app versions in `src/main/handlers/workflow-handlers.ts:671-753` (call sites: `WorkflowManagerPanel.tsx:91,186,196,208,216`; `WorkflowsViewReact.tsx:467`). The plugin copies are registered but never invoked by any UI.
+
+## Implementation plan
+1. **Fix the TopBar buttons** (preferred over removing them): in `WorkflowsViewReact.tsx` `handleAction()`, dispatch `'import'` → `setShowImportDialog(true)` and `'refresh'` → `loadWorkflows(true)` — the same functions the toolbar buttons call (lines 658, 678). If the team prefers a single location instead, delete the two TopBar action declarations (lines 850-851) — pick ONE, don't leave both unwired.
+2. **Delete the dead `electronAPI.workflows.*` surface** in `src/preload/preload.ts:2449-2526` and any renderer type declarations referencing it. Grep for `electronAPI.workflows.` in the renderer first to confirm zero call sites (the investigation found none).
+3. **Remove the plugin's duplicate active-workflow IPC registrations** (`ipc-handlers.ts:139-186` in fictionlab-workflow) OR document why they stay (e.g. reserved for external plugin consumers). If removed, also remove the plugin's duplicate `broadcastWorkflowUpdate` (`ipc-handlers.ts:18`) if nothing else uses it. Note this touches the **fictionlab-workflow repo**, not this repo — split into a companion PR there if needed.
+
+## Acceptance criteria
+- [ ] TopBar Import opens the import dialog; TopBar Refresh reloads the workflow list (or the TopBar duplicates are gone entirely).
+- [ ] No `console.log`-only action dispatch remains in `handleAction`.
+- [ ] `electronAPI.workflows` no longer exists in preload; renderer typechecks clean.
+- [ ] Pause/Resume/Cancel/Jump on active workflow cards still work (they use `workflow-handlers.ts:671-753` — untouched).
+- [ ] `npm run build` + tests pass in both repos if the plugin cleanup is included.
+
+## Gotchas / coordination
+- **Do not delete `workflow:*` (singular) channels** — those are the live ones.
+- The dead `workflows:create` stub (preload:2517) is also referenced by the "create workflows in-app" feature issue. That feature will build its own path; deleting the dead stub here does not conflict.

--- a/github-issues/triage-2026-07-04/issue-04-docker-launch-detection.md
+++ b/github-issues/triage-2026-07-04/issue-04-docker-launch-detection.md
@@ -1,0 +1,46 @@
+# [BUG] Launch falsely reports Docker down and exits — needs pipe-level probe, retries, and container startup in the launch gate
+
+**Labels:** bug, docker, startup, reliability, windows, priority: high, complexity: medium
+
+## Symptom
+On Windows, launching FictionLab while Docker Desktop IS running (or still initializing) shows the "Docker Required / failed to start / please start Docker Desktop manually" error and exits. Desired behavior: detect the daemon properly; if truly down, start Docker Desktop (tray-only, no dashboard window), then start the FictionLab postgres container, then verify everything before the UI proceeds.
+
+## Root cause (verified — do not re-investigate)
+The launch gate is `src/main/index.ts:2707-2786` (in `app.whenReady()`):
+1. `prerequisites.checkDockerInstalled()` (`:2713`) → `docker --version`, disk fallback.
+2. `docker.checkDockerHealth()` (`:2743`) is the ONLY liveness gate → `checkDockerRunning()` (`src/main/prerequisites.ts:212-305`: `docker info` 20s, fallback `docker ps` 20s) then a second `docker info` 20s (`src/main/docker.ts:455`).
+3. On failure → `startAndWaitForDocker()` (`docker.ts:551-597`); if that fails → error box + `app.quit()` (`index.ts:2756-2767`).
+
+Failure modes:
+- **CLI-only detection, no daemon probe.** Everything is `child_process.exec` of the `docker` CLI. `dockerode` is already a dependency but only used post-launch (`src/main/update-manager.ts:9,41`). If the CLI is slow or not on PATH, a live daemon reads as down.
+- **Single-shot 20s `docker info`, no retry.** A cold WSL2 backend routinely exceeds 20s on first call after boot.
+- **PATH shim assumes default install.** `getFixedEnv()` (`prerequisites.ts:63-102`) only appends `%ProgramFiles%\Docker\...` paths — non-default installs fail every exec check.
+- **Gate never checks the process first.** `isDockerDesktopProcessRunning()` (`docker.ts:54-120`, `tasklist` on Windows) exists but the gate calls `checkDockerHealth()` directly, so running-but-initializing Docker Desktop is treated as "not running" and the app tries to relaunch it.
+- **Start opens the full GUI**: `docker.ts:145-154` launches `Docker Desktop.exe` plainly.
+- **Container startup is NOT in the launch gate.** `docker compose up` lives in `startMCPSystem` (`src/main/mcp-system.ts:1117`) and only runs from the setup wizard / dashboard. After the Docker gate, launch proceeds straight to first-run check / DB pool init (`index.ts:2793-2803`) — so a machine with Docker up but containers down still lands in a broken state.
+
+## Implementation plan
+1. **Add a daemon-level probe with retries** in `src/main/docker.ts`:
+   - New `pingDockerDaemon()`: on Windows use dockerode with `socketPath: '//./pipe/docker_engine'`; on macOS/Linux `/var/run/docker.sock`. `await docker.ping()` with a short (~3s) timeout per attempt.
+   - Retry loop: e.g. 5 attempts × 3s backoff before declaring the daemon down. Only fall back to the CLI checks if the pipe/socket probe errors in a way that suggests the CLI would still work (unlikely — treat the probe as authoritative, keep CLI as secondary confirmation).
+2. **Reorder the gate** (`index.ts:2707+`):
+   a. `pingDockerDaemon()` — success → daemon up, skip to step (d).
+   b. `isDockerDesktopProcessRunning()` — if the process is running, poll `pingDockerDaemon()` up to ~90s (initializing case). Do NOT relaunch.
+   c. Not running → `startDockerDesktop()` then poll ping up to ~120s.
+   d. **Start required containers:** call the postgres/pgbouncer portion of `startMCPSystem` (or a new narrower `ensureCoreContainers()` extracted from `mcp-system.ts:1117` area) so the DB is up before `index.ts:2793` initializes the pool.
+   e. Verify: ping DB (existing pool init already does this) and surface a progress UI instead of a modal error until the timeout truly expires.
+3. **Tray-only start on Windows:** launch `Docker Desktop.exe` as today — the dashboard window is controlled by Docker Desktop's own "Open Dashboard at startup" setting; there is no supported fully-headless mode. Do NOT block on window state; the daemon ping is the readiness signal. (Keep the existing macOS `open -a Docker` / Linux `systemctl start docker` paths.)
+4. **Widen PATH resolution:** in `getFixedEnv()`, also honor a `DOCKER_HOME`-style env/config override and try `where docker` before giving up (log which path was used).
+5. Replace the exit-on-failure error box with a dialog offering Retry / Open Docker Desktop / Quit.
+
+## Acceptance criteria
+- [ ] Launching while Docker Desktop is running → no restart prompt, app proceeds (test on cold boot where first `docker info` is slow).
+- [ ] Launching while Docker Desktop is initializing → app waits (with progress feedback) instead of relaunching or exiting.
+- [ ] Launching with Docker fully stopped → Docker Desktop is started, daemon pinged until ready, postgres container comes up, DB pool initializes — no wizard interaction required.
+- [ ] Docker genuinely unavailable → Retry/Open/Quit dialog, not an immediate quit.
+- [ ] Existing `docker:*` IPC handlers (`index.ts:658-724`) still work.
+
+## Gotchas
+- dockerode named-pipe path on Windows is `//./pipe/docker_engine` (works in Node as `\\\\.\\pipe\\docker_engine` too — test both forms; pass via `socketPath`).
+- Don't call the full `startMCPSystem` in the gate if it drags in wizard-only assumptions — extract the container-up + health-check core. Port-conflict handling in that path is covered by the ports issue (coordinate; the gate should surface `PORT_CONFLICT` results, not swallow them).
+- Keep the 60s `waitForDockerReady` CLI poller (`docker.ts:221-289`) only as fallback; primary readiness = daemon ping.

--- a/github-issues/triage-2026-07-04/issue-05-port-conflicts-and-settings.md
+++ b/github-issues/triage-2026-07-04/issue-05-port-conflicts-and-settings.md
@@ -1,0 +1,41 @@
+# [BUG] Port conflicts abort startup instead of auto-remapping (breaks Linux); no way to see/change ports — add a Ports settings panel
+
+**Labels:** bug, docker, configuration, linux, complexity: medium
+
+## Symptom
+On Linux, FictionLab fails because the system already runs PostgreSQL on 5432 and the FictionLab container tries to publish the same port. There is no UI to see which ports FictionLab uses or to change them (outside the setup wizard's one-time conflict prompt).
+
+## Root cause (verified — do not re-investigate)
+**Detection already exists and is Linux-aware** — the gap is remediation and coverage:
+- Default `POSTGRES_PORT` is **5432** (`src/main/env-config.ts:43`), published host-side by `docker-compose.yml:23-24` (`${POSTGRES_PORT}:5432`) → collides with native Postgres on Linux.
+- Probes that already work: `checkPortOnHost()` (`env-config.ts:204-224`, Node `net` probe), `checkPortAvailableLinuxSS/Netstat()` (`:231-294`), `checkPortAvailable()` (`:302-338`, probes both `0.0.0.0` and `127.0.0.1`), `findNextAvailablePort()` (`:345-356`), `checkAllPortsAndSuggestAlternatives()` (`:436-531`, builds conflict list + `suggestedConfig`).
+- **Startup does not remediate:** `startMCPSystem` (`src/main/mcp-system.ts:1007-1059`) checks conflicts, tries `stopExistingContainers()`, then aborts with `PORT_CONFLICT`. Only the setup wizard's "Use Suggested Ports" button applies `suggestedConfig` (`src/renderer/setup-wizard-handlers.ts:569-573,590`).
+- **Unprobed hardcoded ports:** NPE **3011** and Workflow Manager **3012** are literal in `docker-compose.yml:94-95` and absent from the probe list (`env-config.ts:451-456`) — collisions surface only as compose "port is already allocated" errors (`mcp-system.ts:1126`).
+- **PgBouncer 6432 is effectively fixed:** compose maps `${PGBOUNCER_PORT}:${PGBOUNCER_PORT}` (`docker-compose.yml:42-43`) and MCP servers hardwire `fictionlab-pgbouncer:6432` internally; `mcp-system.ts:1037-1040` warns it "cannot be changed."
+- `formatEnvFile` (`env-config.ts:709-733`) does not persist all port vars (missing `TYPING_MIND_PORT`, no vars exist yet for 3011/3012).
+
+**Full current port map (host side):** Postgres 5432, PgBouncer 6432, MCP Connector 51300 (`MCP_CONNECTOR_PORT`), HTTP/SSE 3001, DB-Admin 3010, NPE 3011 (hardcoded), Workflow Manager 3012 (hardcoded).
+
+## Implementation plan
+1. **Parameterize the hardcoded ports:** add `NPE_PORT` (default 3011) and `WORKFLOW_MANAGER_PORT` (default 3012) to `DEFAULT_CONFIG` (`env-config.ts:39-51`), `docker-compose.yml:94-95` (`${NPE_PORT}:3011` style — container side stays fixed), `formatEnvFile`, and the env injection in `execDockerCompose` (`mcp-system.ts:664-683`).
+2. **Add them to the probe list** in `checkAllPortsAndSuggestAlternatives()` (`env-config.ts:451-456`). Exclude `PGBOUNCER_PORT` from "suggestable" (it can't actually move — see above) or fix the compose mapping to `${PGBOUNCER_PORT}:6432` so the host side CAN move while the container network stays 6432. Prefer the latter — it's a one-line compose change that makes 6432 remappable.
+3. **Auto-remediate at startup:** in `startMCPSystem` (`mcp-system.ts:1007-1059`), when conflicts persist after `stopExistingContainers()`, apply `suggestedConfig` (persist via the existing env-config save path), log prominently which ports moved, and retry once. Only return `PORT_CONFLICT` if the retry also fails. Gate this behind a config flag if cautious, but default it ON for Linux.
+4. **Ports settings panel (UI):** add a "Ports" section (Settings or Services tab):
+   - Table: service name, current port, editable field, live in-use status (reuse `checkPortAvailable()` per row; mark "in use by FictionLab" vs "in use by another process" — the Linux `ss`/`lsof` path already returns process info).
+   - "Check all" button → `checkAllPortsAndSuggestAlternatives()`; "Use suggested" → apply `suggestedConfig` (reuse wizard logic from `setup-wizard-handlers.ts:590`).
+   - Save → persist `.env` (userData `.env`, `env-config.ts:56-60`) and prompt to restart services.
+   - New IPC handlers as needed (`env:*` group already exists at `index.ts:568-651` — extend it).
+5. **Linux default:** consider defaulting `POSTGRES_PORT` to 5433 on Linux only (first-run), since a native 5432 Postgres is the common case. Auto-remap (step 3) covers it either way; the changed default just avoids the first failed attempt.
+
+## Acceptance criteria
+- [ ] On a Linux host with native Postgres on 5432: FictionLab starts successfully with no wizard interaction; logs show the remapped port; connections work through the remapped value.
+- [ ] Occupying 3011 or 3012 before startup is detected pre-flight (named conflict, suggestion offered) instead of a raw compose error.
+- [ ] Ports panel lists all seven ports with live status, allows editing, persists, and services restart onto the new ports.
+- [ ] Windows behavior unchanged when no conflicts exist.
+- [ ] `linux-db-diagnostic.sh` updated if it assumes fixed ports (`PORTS=(5432 6432 3001 50880)` at line 86 — read from `.env` instead, or document).
+
+## Gotchas / coordination
+- The container-internal wiring must keep `fictionlab-pgbouncer:6432` and postgres `5432` — only HOST-side publishes move. Compose changes must preserve `host:container` shape with fixed container side.
+- MCP connector config generation hardcodes server ports 3001-3009 (`src/main/mcp-config-generator.ts:59-115`) — if HTTP_SSE_PORT moves, verify generated client configs pick up the new value.
+- Coordinate with the Docker-launch-gate issue: the gate will call the container-start path and must surface (not swallow) any remaining `PORT_CONFLICT`.
+- `TYPING_MIND_PORT` (8080) is dead config being removed by the TypingMind cleanup issue — don't add it to the panel.

--- a/github-issues/triage-2026-07-04/issue-06-typingmind-cleanup.md
+++ b/github-issues/triage-2026-07-04/issue-06-typingmind-cleanup.md
@@ -1,0 +1,57 @@
+# [Cleanup] Remove dead TypingMind local-install machinery (update button, downloader, container controls) — keep cloud connector wiring
+
+**Labels:** cleanup, typing-mind, complexity: medium
+
+## Context
+TypingMind was originally run locally; it now runs at typingmind.com (cloud). The local-install machinery remains: health checks for a local container that never exists, a "Check for Updates" button for a local install that's never present, a downloader module, and one **actively broken** code path. This is dead weight and user-visible confusion (an Offline card, a button that always says "not installed").
+
+Every line below was verified 2026-07-04. This is a deletion map — follow it rather than re-grepping from scratch, but DO grep for stragglers after each removal (`typingmind|typing-mind|typing_mind`, case-insensitive).
+
+## DELETE — dead local-install chain
+
+**A. "Check for Updates" button + updater chain**
+- `src/renderer/views/SetupView.ts:122-126` — button + status div in Setup UI.
+- `src/renderer/components/SetupTab.ts:77-79` (wiring), `:281-350` (`handleUpdateTypingMind`).
+- `src/preload/preload.ts:1818-1820, 1839-1840` — `checkTypingMind`/`updateTypingMind` bridges.
+- `src/main/index.ts:1234-1236, 1265-1275` — `updater:check-typing-mind`/`updater:update-typing-mind` handlers.
+- `src/main/updater.ts:295-331` (`checkForTypingMindUpdate`), `:813-885` (`updateTypingMind`), the `typingMind` branches in `checkForAllUpdates` (`:339-374`) and the update-all flow (`:984-992`), `typingMind` fields on result interfaces (`:56,81,95`), import at `:13`.
+- `src/renderer/renderer.ts:381,384` — dead type decls.
+
+**B. Local downloader**
+- `src/main/typingmind-downloader.ts` — entire module.
+- `src/main/index.ts:20` (import), `:840-914` — the 7 `typingmind:*` IPC handlers (download, cancel-download, is-installed, get-version, uninstall, check-updates, get-install-path).
+- `src/preload/preload.ts:1200-1243` (bridges), `:1305-1313` (progress listeners), `:289-354, 474, 498, 542` (types/fields).
+- `src/main/update-manager.ts:70-82, 173-174` — TM repo git-pull path.
+- `scripts/debug-metadata.js:26-52`, `scripts/linux-verification.sh:48-60` — local-install diagnostics.
+
+**C. Local container controls / health rendering**
+- `src/renderer/components/ServicesTab.ts:324-381` (`updateTypingMindCard` container-health version), `:152-165, 191, 502-529, 548, 681` — Start/Stop/Restart/View-Logs handlers and maps. KEEP Open-Browser/Configure (cloud).
+- `src/renderer/views/ServicesView.ts:55, 131-157` — card's Start/Stop/Restart/View Logs buttons, "Port: 8080" label. Keep the card only if reduced to cloud link + configure.
+- **Actively broken:** `src/main/mcp-system.ts:1201-1221` — `execDockerCompose(coreFile, 'up', ['-d','typingmind'])`: no `typingmind` service exists in `docker-compose.yml`; contradicts the comment at `mcp-system.ts:626-627`. Delete the branch; simplify `services.typingMind` selection (`:598-627`) accordingly.
+- `src/main/mcp-system.ts:1614-1629` — log fetch mapping `'typing-mind'` → container `fictionlab-typingmind` (doesn't exist).
+- Logs plumbing for the dead service: `src/renderer/components/LogsTab.ts:34,120,1104-1108,1283` (dropdown option + maps), `src/preload/preload.ts:1507`, `src/renderer/renderer.ts:326`, `src/main/index.ts:1089` (serviceName unions), `dashboard-handlers.ts:861-865`, `ServicesTab.ts:681`.
+
+**D. Dead config/env**
+- `TYPING_MIND_PORT` (default 8080): `src/main/env-config.ts:32,49`; wizard field `#typing-mind-port` (`src/renderer/setup-wizard-handlers.ts:596,674,729`); `.env.test:17,19-20`; type fields in `ServicesTab.ts:37,51`, `dashboard-handlers.ts:22,43`, `renderer.ts:72,185`.
+- `config/setup-config.json:26-29,38,42,66-68,94-99` — `typing-mind` clone/build entries (the LOCAL app repo). **KEEP lines 17-20,57-59 (`typingmind-mcp`)** — that's the connector.
+- `src/main/client-selection.ts:65-84` — keep the `'typingmind'` client (cloud is a real client) but remove the vestigial `repoUrl` (only the deleted downloader used it).
+- `src/types/wizard.ts:50` + `setup-wizard-handlers.ts:898-925,1219` — `typingMindCompleted` download-gate (already neutralized; remove).
+- `scripts/debug-docker-ports.{bat,sh}` — `typing-mind-` container filters (bat:23,81,90,93; sh:29,96,98).
+
+## KEEP — live cloud wiring (do not touch except noted)
+- `@typingmind/mcp` connector: `docker-compose.yml:52-68`, `docker/connector-entrypoint.sh`.
+- `src/main/typingmind-auto-config.ts`, `src/main/mcp-config-generator.ts`, `scripts/configure-typingmind.js` — **fix stale instruction strings** telling users to open `http://localhost:${TYPING_MIND_PORT}` (`mcp-config-generator.ts:226`, `configure-typingmind.js:123`, and the instruction text near `typingmind-auto-config.ts:395`) → point at `https://www.typingmind.com`.
+- Cloud open/configure buttons + "Ready" card: `dashboard-handlers.ts:578-605, 128-192, 793-821`, `DashboardTab.ts:130-133, 252-267`.
+- Workflow source tag `'typingmind'` + "TM" badge: `src/types/workflow.ts:291`, `workflow-handlers.ts:778`, `persistent-mcp-client.ts:834`, `ActiveWorkflowCard.tsx:26-27`.
+- `mcp-system.ts:1249-1267` (auto-config generation) and `:1455-1457` (cloud URL).
+
+## Acceptance criteria
+- [ ] Setup tab has no TypingMind "Check for Updates" button; Services shows (at most) a cloud card with Open/Configure — no Offline badge, no Start/Stop/Restart.
+- [ ] `grep -ri "typingmind\|typing-mind\|typing_mind" src/ config/ scripts/` returns only the KEEP list above.
+- [ ] `checkForAllUpdates()` no longer reports a typingMind component; update-all works.
+- [ ] MCP config generation still works and its instructions reference typingmind.com, not localhost:8080.
+- [ ] App boots, wizard completes, `npm run build` + tests pass.
+
+## Coordination
+- Ports issue: `TYPING_MIND_PORT` removal overlaps `env-config.ts` — land this first or rebase.
+- Do this as ONE PR — partial removal leaves dangling references across preload/renderer type surfaces (they typecheck as a unit).

--- a/github-issues/triage-2026-07-04/issue-07-ipc-help.md
+++ b/github-issues/triage-2026-07-04/issue-07-ipc-help.md
@@ -1,0 +1,26 @@
+# [Feature] IPC help/introspection — `help` channel enumerating registered channels + `--help` CLI flag
+
+**Labels:** enhancement, ipc, help, complexity: low
+
+## Context (verified)
+There is no way to discover the app's IPC surface or CLI flags:
+- The only argv flag parsed anywhere is `--dev` (`src/main/index.ts:288,334,382`). No commander/yargs/minimist, no `bin` field in package.json — `-help`/`--help` do nothing.
+- The IPC surface is ~20 groups of `ipcMain.handle` channels registered flat in `setupIPC()` (first handler `'ping'` at `src/main/index.ts:430`; groups include `window:*`, `prerequisites:*`, `logger:*`, `env:*`, `docker:*`, `wizard:*`, `client:*`, plugin/build/LLM channels, plus `workflow:*` in `src/main/handlers/workflow-handlers.ts` and plugin-namespaced channels via `src/main/plugin-context.ts:742`). Nothing enumerates them.
+- External consumers exist: the `run-workflow` skill drives the app via `ipc-client.js` and has no discovery mechanism.
+
+## Implementation plan
+1. **Registration wrapper:** add a small module (e.g. `src/main/ipc-registry.ts`) exporting `registerHandler(channel, description, handler)` that calls `ipcMain.handle(channel, handler)` AND records `{channel, description}` in a registry array. Migrate registrations to it incrementally — start by wrapping `ipcMain.handle` calls in `setupIPC()` and `workflow-handlers.ts` mechanically (description can default to `''`; fill in the important ones). Plugin-namespaced registrations go through `plugin-context.ts:742` — hook the registry there too so plugin channels are captured with their `plugin:<id>:` prefix.
+2. **`help` channel:** `registerHandler('help', ...)` returning the sorted registry: `[{channel, description, source: 'app'|'plugin:<id>'}]`. Include a `help <prefix>` filter arg (e.g. `help('docker')` → only `docker:*`).
+3. **`--help` flag:** in the main entry before `app.whenReady()`, if `process.argv` includes `--help` or `-help`, print usage (app name/version, supported flags: `--dev`, `--help`) plus a note that IPC channel listing is available via the `help` IPC channel, then `app.quit()` / `process.exit(0)`. Note: a packaged Electron app can't print to the parent console on Windows without attach tricks — write to stdout anyway (works when launched from a shell in dev; document the limitation).
+4. **Wire the external client:** if in scope, add a `help` verb to the run-workflow skill's `ipc-client.js` consumer path (that client lives at `~/.claude/skills/run-workflow/ipc-client.js` outside this repo — at minimum, ensure the channel it would call exists and is documented in this repo's README/docs).
+
+## Acceptance criteria
+- [ ] Invoking the `help` IPC channel returns every registered channel, including plugin-namespaced ones, with descriptions for at least the `workflow:*`, `docker:*`, `env:*`, and `project:*` groups.
+- [ ] `help('workflow')` (or equivalent filter arg) returns only matching channels.
+- [ ] `electron . --help` in dev prints usage and exits 0 without opening a window.
+- [ ] No behavior change for any existing channel (wrapper is pass-through).
+- [ ] `npm run build` + tests pass.
+
+## Gotchas
+- Don't try to introspect `ipcMain` internals for already-registered channels — Electron doesn't expose a supported handler list; the registry wrapper is the reliable way.
+- Renderer-exposed API (preload contextBridge) is a separate surface from main-process channels; the help output should reflect main-process channels (what an IPC client can actually call).

--- a/github-issues/triage-2026-07-04/issue-08-project-scaffold-series-architect.md
+++ b/github-issues/triage-2026-07-04/issue-08-project-scaffold-series-architect.md
@@ -1,0 +1,41 @@
+# [BUG] Project workspace init creates folders Series Architect never uses — align scaffold with SA v2 layout
+
+**Labels:** bug, setup, configuration, complexity: medium
+
+## Symptom
+"Create New Project" (with Initialize Workspace checked) succeeds, but the folder structure it creates is not what the Series Architect workflows use. SA output lands in folders the scaffold never created, and the scaffolded folders stay empty — misleading for users and for any workflow step that READS an expected path.
+
+## Root cause (verified — do not re-investigate)
+**What init creates** — `project:initialize-workspace` handler, `src/main/index.ts:2382-2431`:
+- `.claude/`, `planning/`, `planning/character-profiles/`, `planning/world-building/`, `books/`, `exports/` (`:2392-2397`), `.claude/settings.json` (`:2400`), a `CLAUDE.md` template copy (`:2407-2416`).
+- Genre pack step is a **log-only stub**: `:2421-2423` ("will be copied when workflow runs").
+- The dialog's helper text advertises this structure (`src/renderer/components/ProjectCreationDialog.tsx:316-318`).
+- Note `project:create` itself (`index.ts:2319` → `project-manager.ts:168` → MCP `create_project`) only writes a DB row — all disk scaffolding is in initialize-workspace.
+
+**What SA v2 actually uses** (from `C:\github\FictIonLab-Downloads`):
+- Everything under **`{{projectFolder}}/outputs/`**: `intake_form.md` (`workflows/series-architect-intake/workflow.yaml:247`), `INDEX.md` + `series_bible.md` (`series-architect-output/workflow.yaml:259,276`), `market_research.md` + `genre_pack.json` (`series-architect-research/workflow.yaml:290,307`), `series_framework.md` (`series-architect-framework/workflow.yaml:362`), world/character files flat in `outputs/` (`dramatica-storyform/workflow.yaml:52-62`), per-book `outputs/book_{{currentBookNumber}}/…` (`dramatica-storyform/workflow.yaml:135,148`; `series-architect-development/workflow.yaml:431-516`).
+- The SA agent additionally expects **`series-planning/`** (`series-architect-agent.md:22`, `:930`).
+- Intake declares a tiered structure `world/ characters/ continuity/ books/` (`series-architect-intake/workflow.yaml:214`).
+
+**Why nothing crashes today:** workflow file-writes self-create parent dirs — `FileOperationExecutor.executeWrite` always calls `fs.ensureDir(path.dirname(finalPath))` (`file-operation-executor.ts:280`). The node-level `createDirectories` flag is a no-op (never read; corroborated by `FictIonLab-Downloads/WORKFLOW-FIXES.md:78`). The damage is: reads of expected-but-absent paths, and a scaffold that actively misleads.
+
+## Implementation plan
+1. **Decide the canonical scaffold with the SA v2 layout as source of truth.** Cross-check the WutheringDragons testbed `START-HERE.md` checklist (the canonical empty-project test for this flow) before coding. Proposed:
+   - `outputs/` (SA writes here — create it so users see where results will land)
+   - `series-planning/` (SA agent workspace)
+   - `.claude/` + settings + CLAUDE.md (keep as-is)
+   - Keep `books/` and `exports/` ONLY if a current workflow or doc references them; otherwise drop. Drop `planning/character-profiles/` and `planning/world-building/` (nothing writes there).
+2. Update the folder list in `index.ts:2392-2397` and the dialog helper text (`ProjectCreationDialog.tsx:316-318`) to match.
+3. **Implement the genre-pack step** (replacing the log stub at `:2421-2423`): if a pack id was selected, invoke the existing copy logic (`ResourceCopier`, `resource-copier.ts:208-243` in the workflow-runner package) at init time, OR keep run-time copy but write a marker (e.g. store the chosen pack id in project config) so the workflow run picks it up — match whatever the genre-packs-dropdown fix (separate issue) establishes as the id flow.
+4. Optional but cheap: drop a `README.md` into the project root describing each created folder, so an empty `outputs/` isn't mysterious.
+
+## Acceptance criteria
+- [ ] A newly initialized project contains exactly the documented scaffold, including `outputs/` and `series-planning/`.
+- [ ] Running the SA intake workflow against a fresh project writes into pre-existing folders (no structure invented at runtime for the standard flow).
+- [ ] Dialog text matches reality.
+- [ ] Genre pack selection results in the pack actually reaching the project (at init or verified at first run), not a log line.
+- [ ] Existing projects are unaffected (init only runs for new projects).
+
+## Coordination
+- Depends on / relates to the genre-packs-dropdown issue (the pack id must exist to be copied).
+- The SA workflows themselves are authored in `FictIonLab-Downloads` — if step 1 reveals a disagreement between workflows (`outputs/` flat vs tiered `world/characters/continuity/books`), resolve it THERE first and scaffold to the resolved layout. Flag it rather than guessing.

--- a/github-issues/triage-2026-07-04/issue-09-create-workflow-in-app.md
+++ b/github-issues/triage-2026-07-04/issue-09-create-workflow-in-app.md
@@ -1,0 +1,34 @@
+# [Feature] Create new workflows in-app — "New Workflow" button opening a blank canvas
+
+**Labels:** enhancement, feature, ui, complexity: high
+
+## Context (verified)
+Workflows can only be authored externally (YAML/JSON) and imported. In-app:
+- Toolbar offers Import / Export / Start / Refresh / Hide-Panel only (`src/renderer/views/WorkflowsViewReact.tsx:657-692`). No create.
+- The canvas editor is real and works — but only on an existing workflow: "+ Add Node" (`src/renderer/components/WorkflowCanvas.tsx:1005`), node config dialog, edge editing (`:1210`), all call `workflow:add-node`/`add-edge`/`update-*` with `workflow.id` (`WorkflowCanvas.tsx:472,863`; handlers in `src/main/handlers/workflow-handlers.ts:137-227`).
+- The canvas renders only when `selectedWorkflow` exists (`WorkflowsViewReact.tsx:699`), else "Select a workflow from the panel to visualize" (`:773`).
+- The only latent "create" plumbing was a dead preload stub (`electronAPI.workflows.create` → `workflows:create`, no handler) — being removed by the dashboard dead-buttons cleanup issue. Build fresh; don't resurrect it.
+- Import path for reference: `workflow:import-from-folder` (`WorkflowsViewReact.tsx:377` → plugin `ipc-handlers.ts:77` → `workflow.importFromFolder`), plugin channels namespaced via `plugin-context.ts:742`. Workflow definitions persist in the `fictionlab` schema of `mcp_writing_db` (`fictionlab.workflow_definitions`, upsert keyed on `workflow_id, version`).
+
+Most of the editing plumbing already exists — the missing piece is instantiating a blank workflow to edit.
+
+## Implementation plan
+1. **Backend — create verb.** Add a `workflow:create` handler (main app, alongside the existing `workflow:*` editing handlers in `workflow-handlers.ts` — same layer the canvas editing already uses). Input: `{name, description?}`. Behavior: generate a `workflow_id` (slug from name + uniqueness check), `version: '0.1.0'`, minimal valid definition (empty nodes/edges, or a single start node if the runner requires an entry node — check `@fictionlab/workflow-runner`'s validation in the workflow-runner package before deciding), insert via the same upsert path the importer uses (`INSERT … ON CONFLICT (workflow_id, version) DO UPDATE` into `fictionlab.workflow_definitions`). Return the created workflow in the same shape `workflow:get` returns.
+2. **Preload bridge** for `workflow:create` next to the existing workflow bridges.
+3. **UI:** add "🆕 New Workflow" to the toolbar (`WorkflowsViewReact.tsx:657-692`). Click → small dialog (name, optional description) → `workflow:create` → `loadWorkflows(true)` → select the new workflow so the canvas opens immediately with "+ Add Node" available.
+4. **Editing loop sanity:** confirm `workflow:add-node`/`add-edge`/`update-positions`/`get-definition` (`workflow-handlers.ts:137-227`) work against a workflow with zero nodes (empty-graph edge cases: first node, first edge). Fix any assumption that a graph is non-empty.
+5. **Runability:** a fresh workflow will fail validation until it has required structure — surface the runner's validation errors in the UI when Start is pressed rather than blocking creation. (Check how `workflow:execute` errors currently surface via `ipc-handlers.ts:67`.)
+6. **Export round-trip:** verify the existing Export dialog produces valid YAML/JSON from a created-in-app workflow, so in-app authoring and the external authoring loop (`FictIonLab-Downloads`) stay interchangeable. This is the key acceptance test.
+
+## Acceptance criteria
+- [ ] "New Workflow" button → name dialog → blank workflow appears in the manager panel and opens on the canvas.
+- [ ] Nodes and edges can be added/configured/connected starting from empty; positions persist across reload.
+- [ ] Created workflow survives app restart (persisted in `fictionlab.workflow_definitions`).
+- [ ] Export of a created workflow produces a folder/file that re-imports cleanly (round-trip).
+- [ ] Starting an incomplete workflow shows a validation message, not a crash.
+- [ ] Duplicate name → clear error or auto-suffixed id, no silent overwrite (respect the `(workflow_id, version)` uniqueness).
+
+## Gotchas
+- Decide main-app channel vs plugin-namespaced channel deliberately: the canvas EDITING channels are main-app (`workflow-handlers.ts`), while list/get/import/execute are plugin-namespaced. Creating via the main-app layer keeps it next to the editing verbs it must cooperate with; just make sure the plugin's `workflow:list` picks up the new row (it reads the same DB through the workflow-manager MCP).
+- Version bumping on edit is out of scope — created workflows can stay at `0.1.0` until export.
+- Coordinate with the dashboard dead-buttons cleanup (it deletes the old dead `workflows:*` preload surface — no conflict, different namespace, but rebase whichever lands second).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2529,7 +2529,7 @@ function setupIPC(): void {
           name: 'Claude Code (Default)',
           enabled: true,
           config: {
-            model: 'claude-sonnet-4-5',
+            model: 'default',
             headless: true,
             outputFormat: 'text'
           }

--- a/src/main/llm/adapters/claude-code-cli-adapter.ts
+++ b/src/main/llm/adapters/claude-code-cli-adapter.ts
@@ -63,7 +63,12 @@ export class ClaudeCodeCLIAdapter implements LLMProviderAdapter {
       return {
         success: true,
         output: result.output,
-        model: provider.config?.model || 'claude-sonnet-4-5',
+        // The actual model is chosen by the Claude Code CLI session (executeSkill passes no --model).
+        // config.model is a label/hint only — don't fabricate a specific retired id when unset.
+        model:
+          provider.config?.model && provider.config.model !== 'default'
+            ? provider.config.model
+            : 'claude-code-cli (session default)',
       };
 
     } catch (error: any) {

--- a/src/renderer/components/ProviderSelector.tsx
+++ b/src/renderer/components/ProviderSelector.tsx
@@ -20,13 +20,20 @@ export interface ProviderSelectorProps {
  */
 const MODEL_OPTIONS = {
   'claude-code-cli': [
-    { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-    { value: 'claude-opus-4-5', label: 'Claude Opus 4.5' },
+    { value: 'default', label: 'Default (CLI-selected — recommended, never ages)' },
+    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+    { value: 'claude-fable-5', label: 'Claude Fable 5' },
+    { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (legacy)' },
+    { value: 'claude-opus-4-5', label: 'Claude Opus 4.5 (legacy)' },
   ],
   'claude-api': [
-    { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
-    { value: 'claude-opus-4', label: 'Claude Opus 4' },
-    { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet (Oct 2024)' },
+    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+    { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (legacy)' },
+    { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet (Oct 2024, legacy)' },
   ],
   'openai': [
     { value: 'gpt-4o', label: 'GPT-4o' },

--- a/src/renderer/components/dialogs/NodeConfigDialog.tsx
+++ b/src/renderer/components/dialogs/NodeConfigDialog.tsx
@@ -1806,7 +1806,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
               <select
                 id="config-model"
                 style={styles.select}
-                value={provider.config?.model || 'claude-sonnet-4-5'}
+                value={provider.config?.model || 'default'}
                 onChange={(e) => {
                   setFormData({
                     ...formData,
@@ -1818,8 +1818,13 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
                   setIsDirty(true);
                 }}
               >
-                <option value="claude-sonnet-4-5">Claude Sonnet 4.5</option>
-                <option value="claude-opus-4-5">Claude Opus 4.5</option>
+                <option value="default">Default (CLI-selected — recommended, never ages)</option>
+                <option value="claude-opus-4-8">Claude Opus 4.8</option>
+                <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+                <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
+                <option value="claude-fable-5">Claude Fable 5</option>
+                <option value="claude-sonnet-4-5">Claude Sonnet 4.5 (legacy)</option>
+                <option value="claude-opus-4-5">Claude Opus 4.5 (legacy)</option>
               </select>
             </div>
 
@@ -1931,9 +1936,11 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
               >
                 {provider.type === 'claude-api' && (
                   <>
-                    <option value="claude-sonnet-4-5">Claude Sonnet 4.5</option>
-                    <option value="claude-opus-4">Claude Opus 4</option>
-                    <option value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet</option>
+                    <option value="claude-opus-4-8">Claude Opus 4.8</option>
+                    <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+                    <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
+                    <option value="claude-sonnet-4-5">Claude Sonnet 4.5 (legacy)</option>
+                    <option value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet (legacy)</option>
                   </>
                 )}
                 {provider.type === 'openai' && (

--- a/src/types/llm-providers.ts
+++ b/src/types/llm-providers.ts
@@ -27,7 +27,20 @@ export interface ClaudeCodeCLIProvider extends BaseLLMProviderConfig {
   type: 'claude-code-cli';
 
   config: {
-    model?: 'claude-sonnet-4-5' | 'claude-opus-4-5';
+    /**
+     * PREFER 'default' (or omit) so the node tracks the Claude Code CLI's CURRENT model and never
+     * pins a foundation version that ages out. Explicit ids accepted; `(string & {})` keeps any
+     * future id valid without a type break. Adapter treats 'default'/undefined as "CLI decides".
+     */
+    model?:
+      | 'default'
+      | 'claude-opus-4-8'
+      | 'claude-sonnet-4-6'
+      | 'claude-haiku-4-5'
+      | 'claude-fable-5'
+      | 'claude-sonnet-4-5'   // back-compat
+      | 'claude-opus-4-5'     // back-compat
+      | (string & {});
     outputFormat: 'json' | 'text';
     headless?: boolean;  // true = automatic, false = interactive
   };
@@ -41,7 +54,14 @@ export interface ClaudeAPIProvider extends BaseLLMProviderConfig {
 
   config: {
     apiKey: string;  // Will be encrypted in storage
-    model: 'claude-sonnet-4-5' | 'claude-opus-4' | 'claude-3-5-sonnet-20241022';
+    model:
+      | 'claude-opus-4-8'
+      | 'claude-sonnet-4-6'
+      | 'claude-haiku-4-5'
+      | 'claude-sonnet-4-5'
+      | 'claude-opus-4'
+      | 'claude-3-5-sonnet-20241022'
+      | (string & {});
     maxTokens?: number;
     temperature?: number;
   };


### PR DESCRIPTION
Rescues the uncommitted model-id work from the develop working tree (done 2026-06-30, never committed).

- Replaces stale hardcoded model unions (claude-sonnet-4-5 | claude-opus-4-5) with current ids
- Adds a `default` option so Claude Code CLI nodes track the CLI's current model instead of pinning an aging id
- `(string & {})` keeps future model ids valid without a type break
- Second commit adds the 2026-07-04 triage doc + issue specs for #158-#166

Merge LAST in the current batch (after #171/#169) — touches index.ts/NodeConfigDialog which those PRs also touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)