### PR TITLE
fix: align project scaffold with SA v2 layout, per-book isolation (#165)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -411,6 +411,54 @@ import { registerWorkflowHandlers } from './handlers/workflow-handlers';
 import { registerPluginUpdateHandlers } from './handlers/plugin-update-handlers';
 
 /**
+ * Build the README.md dropped into a newly-initialized project root
+ * (project:initialize-workspace handler). Documents the SA v2-aligned
+ * scaffold (outputs/, series-planning/, .claude/) and the per-book
+ * isolation rule: each book's artifacts live under outputs/book_N/ and
+ * book N+1 must never overwrite book N's folder/files. See issue #165.
+ */
+function buildProjectReadme(projectName: string): string {
+  return `# ${projectName}
+
+This project was initialized by FictionLab / MCP Electron App using the
+Series Architect v2 scaffold.
+
+## Folder layout
+
+- \`outputs/\` — everything the Series Architect (SA) workflows write:
+  series-level documents (e.g. \`INDEX.md\`, \`series_bible.md\`,
+  \`market_research.md\`, \`genre_pack.json\`, \`series_framework.md\`) live
+  flat in \`outputs/\`, shared across the whole series. Per-book artifacts
+  live in their own \`outputs/book_N/\` subfolder (see below).
+- \`series-planning/\` — the Series Architect agent's own working folder.
+- \`.claude/\` — app + workflow metadata: \`settings.json\` (project settings,
+  including the selected genre pack id once one is chosen) and a
+  \`CLAUDE.md\` template used to resume workflow runs.
+
+Nothing else is scaffolded up front. Workflow steps create any additional
+folder they need at runtime (e.g. \`outputs/book_N/\`) via
+\`fs.ensureDir\`/\`fs-extra\`'s automatic parent-directory creation, so an
+empty folder here would only go stale -- the folders above are the ones
+every SA v2 workflow run actually reads from and writes to.
+
+## Per-book isolation (binding rule)
+
+Each book in the series gets its **own** folder: \`outputs/book_1/\`,
+\`outputs/book_2/\`, \`outputs/book_3/\`, and so on. This is enforced by the
+SA v2 workflows themselves (e.g. \`dramatica-storyform\` and
+\`series-architect-development\`), which parameterize every per-book file
+path by the current book number.
+
+**Book N+1 must never overwrite Book N's folder or files.** If you are
+authoring or modifying a workflow step that writes book-specific content,
+make sure its output path is parameterized by the book number (e.g.
+\`outputs/book_{{currentBookNumber}}/...\`) rather than a fixed or shared
+path -- a hardcoded or unparameterized path is a bug that will silently
+clobber a previous book's work.
+`;
+}
+
+/**
  * Set up IPC handlers for communication between main and renderer processes
  */
 function setupIPC(): void {
@@ -2388,20 +2436,41 @@ function setupIPC(): void {
     try {
       const { folderPath, projectName, genrePack } = options;
 
-      // Create standard directories
+      // Create standard directories. This mirrors the Series Architect v2
+      // workflow layout (FictIonLab-Downloads: outputs/ + series-planning/),
+      // not the earlier tiered planning/ proposal -- see issue #165. Per-book
+      // artifacts are NOT scaffolded here; SA v2 creates outputs/book_N/ at
+      // runtime (dramatica-storyform/workflow.yaml, series-architect-development
+      // /workflow.yaml), one folder per book, so book N+1 never touches book N.
       await fse.ensureDir(path.join(folderPath, '.claude'));
-      await fse.ensureDir(path.join(folderPath, 'planning'));
-      await fse.ensureDir(path.join(folderPath, 'planning', 'character-profiles'));
-      await fse.ensureDir(path.join(folderPath, 'planning', 'world-building'));
-      await fse.ensureDir(path.join(folderPath, 'books'));
-      await fse.ensureDir(path.join(folderPath, 'exports'));
+      await fse.ensureDir(path.join(folderPath, 'outputs'));
+      await fse.ensureDir(path.join(folderPath, 'series-planning'));
 
-      // Create settings.json
-      await fse.writeJson(path.join(folderPath, '.claude', 'settings.json'), {
+      // Create settings.json. Genre packs are copied to the project folder
+      // when a workflow runs, via the ResourceCopier in
+      // fictionlab-workflow/packages/workflow-runner (keyed by pack id --
+      // see #159/genre-pack-handlers.ts's GenrePack.id shape). We don't copy
+      // pack contents here at project-creation time, but we DO persist the
+      // selected id into settings.json so that later run knows which pack to
+      // copy instead of silently defaulting to none. The key is `genrePack`,
+      // matching the id field the run-time consumers already use
+      // (ResourceCopyOptions.genrePack / workflow-executor's
+      // initialVariables.genrePack).
+      const projectSettings: {
+        name: string;
+        projectType: string;
+        createdAt: string;
+        genrePack?: string;
+      } = {
         name: projectName,
         projectType: 'fiction-series',
         createdAt: new Date().toISOString()
-      }, { spaces: 2 });
+      };
+      if (genrePack && genrePack !== 'none') {
+        projectSettings.genrePack = genrePack;
+        logWithCategory('info', LogCategory.SYSTEM, `Genre pack '${genrePack}' recorded in project settings; will be copied when workflow runs`);
+      }
+      await fse.writeJson(path.join(folderPath, '.claude', 'settings.json'), projectSettings, { spaces: 2 });
 
       // Copy CLAUDE.md template for workflow resumption support
       const templatePath = app.isPackaged
@@ -2415,11 +2484,12 @@ function setupIPC(): void {
         logWithCategory('warn', LogCategory.SYSTEM, `CLAUDE.md template not found at ${templatePath}`);
       }
 
-      // Genre packs are now copied to the project folder when a workflow runs
-      // via the ResourceCopier in fictionlab-workflow/packages/workflow-runner
-      // No need to copy them here at project creation time
-      if (genrePack && genrePack !== 'none') {
-        logWithCategory('info', LogCategory.SYSTEM, `Genre pack '${genrePack}' will be copied when workflow runs`);
+      // Drop a README describing the scaffold + the per-book isolation rule
+      // (outputs/book_N/ per book; book N+1 must never write into book N's folder).
+      const readmePath = path.join(folderPath, 'README.md');
+      if (!(await fse.pathExists(readmePath))) {
+        await fse.writeFile(readmePath, buildProjectReadme(projectName), 'utf8');
+        logWithCategory('info', LogCategory.SYSTEM, 'Wrote project README.md');
       }
 
       logWithCategory('info', LogCategory.SYSTEM, `Workspace initialized at ${folderPath}`);

--- a/src/renderer/components/ProjectCreationDialog.tsx
+++ b/src/renderer/components/ProjectCreationDialog.tsx
@@ -314,7 +314,7 @@ export const ProjectCreationDialog: React.FC<ProjectCreationDialogProps> = ({
               </span>
             </label>
             <div style={{ fontSize: '12px', color: '#6b7280', marginLeft: '24px', marginTop: '4px' }}>
-              Creates .claude/, planning/, books/, and exports/ directories
+              Creates .claude/, outputs/, and series-planning/ directories
             </div>
           </div>
 


### PR DESCRIPTION
## What

Aligns the `project:initialize-workspace` scaffold with the Series Architect v2 layout, per the owner's design decision on #165: scaffold the stable top level only, and make per-book isolation the binding rule.

### New scaffold (verified by exercising the compiled handler against a temp dir)

```
<project root>/
  .claude/
    CLAUDE.md          (template copy, unchanged behavior)
    settings.json      (now also stores the selected genre-pack id)
  outputs/             (SA workflow results; per-book under outputs/book_N/)
  series-planning/     (SA agent workspace)
  README.md            (new: documents folders + per-book isolation rule)
```

Dropped: `planning/`, `planning/character-profiles/`, `planning/world-building/`, `books/`, `exports/`.

- `books/` + `exports/` drop check: no current workflow references `{{projectFolder}}/books` or `{{projectFolder}}/exports`. The only hits anywhere are a legacy example (`FictIonLab-Downloads/reference/node-examples.json:185`) and the legacy 12-phase diagram (`workflows/12-phase-novel-series-diagram.md:229`) — neither is a current workflow, so both dirs were dropped per the decision.
- `series-planning/` is confirmed used by the SA agent (`series-architect-v2/agents/series-architect-agent.md:22`, `:930`).

### Genre-pack marker (replaces the log-only stub)

When a pack is selected, its id is persisted to the project's `.claude/settings.json` as `genrePack` — the same id shape #170's `project:list-genre-packs` returns (`GenrePack.id`) and the same key the run-time consumers use (`ResourceCopyOptions.genrePack` in `@fictionlab/workflow-runner`'s ResourceCopier; `workflow-executor.ts`'s `initialVariables.genrePack`). Pack contents are still copied at workflow run time by ResourceCopier; no listing/copy logic is duplicated here.

Note for follow-up wiring: workflow-executor currently sources the pack id from `initialVariables`/workflow metadata only — reading the project's `settings.json.genrePack` as a fallback is a small fictionlab-workflow follow-up.

### Dialog text

`ProjectCreationDialog.tsx` helper text updated to "Creates .claude/, outputs/, and series-planning/ directories".

## Per-book parameterization spot-check (FictIonLab-Downloads, read-only)

All per-book file writes in the spec's referenced workflows ARE parameterized — no follow-up fix needed:

- `workflows/series-architect-v2/sub-workflows/dramatica-storyform/workflow.yaml:135,148` (also `:86,:89,:110`) — all per-book paths use `{{projectFolder}}/outputs/book_{{currentBookNumber}}/...`
- `workflows/series-architect-v2/sub-workflows/series-architect-development/workflow.yaml:431,448,465,482,499,516` — all six write paths use `{{projectFolder}}/outputs/book_{{currentBook}}/...` (`currentBook` is the workflow's loop iterator variable, `iteratorVariable: currentBook`, line 109)
- Grep for non-parameterized `outputs/book_` write targets across series-architect-v2: only comment/description mentions of the optional `outputs/book_1/` dev reference (dramatica-pipeline header comments, orchestrator description) — none are write targets.

Minor naming note (not a bug): dramatica-storyform uses `{{currentBookNumber}}` while series-architect-development uses `{{currentBook}}` — two names for the same concept; both resolve per book so isolation holds.

## Verification

- `npm run build` passes.
- Compiled `dist/main/index.js` handler inspected + its exact statement sequence executed against a temp dir; resulting tree matches the scaffold above, `settings.json` carries `genrePack: "urban-fantasy-police-procedural"`, and no stale `genrePackId` key exists.

## Rebase awareness

index.ts changes are scoped to the `project:initialize-workspace` handler body plus one new top-level `buildProjectReadme()` helper, to minimize conflicts with #170/#171.

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
