### PR TITLE
feat(kanban): S11 kanban board view — host-bundled React view

### DIFF
--- a/src/main/plugin-context.ts
+++ b/src/main/plugin-context.ts
@@ -47,6 +47,46 @@ async function getWorkflowMCPClient(): Promise<PersistentMCPClient> {
   }
 }
 
+// Singleton instance of PersistentMCPClient for kanban-server stdio communication.
+// Same stdio-first treatment workflow-manager gets (S11 §4a / GH issue #179 §2:
+// "give kanban the same stdio treatment workflow-manager gets... rather than the
+// HTTP /api/tool-call branch"). A second singleton pair, mirroring
+// workflowMCPClient/getWorkflowMCPClient() above, rather than generalizing a
+// shared cache keyed by serverId -- called out in the issue as an acceptable v1
+// shortcut ("a minimally-duplicated second PersistentMCPClient instance").
+let kanbanMCPClient: PersistentMCPClient | null = null;
+let kanbanMCPClientStartPromise: Promise<void> | null = null;
+
+/**
+ * Get or create the singleton PersistentMCPClient for kanban-server.
+ * Uses stdio for low-latency communication, same as workflow-manager.
+ */
+async function getKanbanMCPClient(): Promise<PersistentMCPClient> {
+  if (kanbanMCPClient && kanbanMCPClient.isReady()) {
+    return kanbanMCPClient;
+  }
+
+  if (kanbanMCPClientStartPromise) {
+    await kanbanMCPClientStartPromise;
+    if (kanbanMCPClient) {
+      return kanbanMCPClient;
+    }
+  }
+
+  kanbanMCPClient = new PersistentMCPClient('kanban-server');
+  kanbanMCPClientStartPromise = kanbanMCPClient.start();
+
+  try {
+    await kanbanMCPClientStartPromise;
+    logWithCategory('info', LogCategory.SYSTEM, 'PersistentMCPClient started for kanban-server stdio communication');
+    return kanbanMCPClient;
+  } catch (error: any) {
+    kanbanMCPClient = null;
+    kanbanMCPClientStartPromise = null;
+    throw error;
+  }
+}
+
 import {
   PluginContext,
   PluginServices,
@@ -255,6 +295,7 @@ function createMCPConnectionManager(
         'review': 3007,
         'reporting': 3008,
         'author': 3009,
+        'kanban': 3015,
       };
 
       const port = serverPorts[serverId];
@@ -306,6 +347,25 @@ function createMCPConnectionManager(
         } catch (error: any) {
           logWithCategory('error', LogCategory.SYSTEM,
             `Plugin ${pluginId} workflow-manager stdio error:`, error);
+          throw new Error(`Failed to call MCP tool ${toolName} on ${serverId}: ${error.message}`);
+        }
+      }
+
+      // Use stdio (PersistentMCPClient) for kanban-server -- same treatment as
+      // workflow-manager (S11 §4a / GH issue #179 §2: the proven path, rather
+      // than the HTTP /api/tool-call branch).
+      if (serverId === 'kanban') {
+        try {
+          logWithCategory('info', LogCategory.SYSTEM,
+            `Plugin ${pluginId} calling kanban-server tool via stdio: ${toolName}`, args);
+
+          const client = await getKanbanMCPClient();
+          const result = await client.callTool(toolName, args);
+
+          return result as T;
+        } catch (error: any) {
+          logWithCategory('error', LogCategory.SYSTEM,
+            `Plugin ${pluginId} kanban-server stdio error:`, error);
           throw new Error(`Failed to call MCP tool ${toolName} on ${serverId}: ${error.message}`);
         }
       }
@@ -377,6 +437,16 @@ function createMCPConnectionManager(
         }
       }
 
+      // For kanban, same stdio ready-check as workflow-manager
+      if (serverId === 'kanban') {
+        try {
+          const client = await getKanbanMCPClient();
+          return client.isReady();
+        } catch {
+          return false;
+        }
+      }
+
       // For other servers, use HTTP health check
       const endpoint = this.getEndpoint(serverId);
       if (!endpoint) {
@@ -407,6 +477,28 @@ function createMCPConnectionManager(
             endpoint: 'stdio',
             status: running ? 'running' : 'stopped',
             tools: [], // Tools list not available via stdio without additional protocol
+          };
+        } catch (error) {
+          return {
+            id: serverId,
+            name: serverId,
+            endpoint: 'stdio',
+            status: 'error',
+          };
+        }
+      }
+
+      // For kanban, same stdio client shape as workflow-manager
+      if (serverId === 'kanban') {
+        try {
+          const client = await getKanbanMCPClient();
+          const running = client.isReady();
+          return {
+            id: serverId,
+            name: serverId,
+            endpoint: 'stdio',
+            status: running ? 'running' : 'stopped',
+            tools: [],
           };
         } catch (error) {
           return {

--- a/src/main/workflow/persistent-mcp-client.ts
+++ b/src/main/workflow/persistent-mcp-client.ts
@@ -1,16 +1,25 @@
 /**
  * Persistent MCP Client
  *
- * Maintains a single persistent Node.js process for the workflow-manager MCP server
- * to eliminate the 1-2 second process spawning overhead on every operation.
+ * Maintains a single persistent Node.js process for an MCP-Writing-Servers
+ * server (workflow-manager by default; any `src/mcps/<serverDir>/index.js`
+ * that supports MCP_STDIO_MODE, e.g. kanban-server, via the constructor's
+ * `serverDir` param) to eliminate the 1-2 second process spawning overhead
+ * on every operation.
  *
  * Key features:
- * - Spawn workflow-manager-server/index.js once on startup
+ * - Spawn <serverDir>/index.js once on startup
  * - Keep stdio connection open throughout app lifecycle
  * - Queue requests with unique IDs
  * - Parse responses asynchronously via stdout
  * - Auto-restart on crash with exponential backoff
  * - Graceful shutdown
+ *
+ * The high-level convenience methods below (importWorkflowDefinition,
+ * listActiveWorkflows, etc.) are workflow-manager-specific and simply go
+ * unused by a client constructed for a different serverDir (e.g. kanban) --
+ * only the generic callTool()/start()/shutdown()/isReady() surface is
+ * shared across servers.
  */
 
 import { spawn, ChildProcess } from 'child_process';
@@ -49,15 +58,21 @@ export class PersistentMCPClient {
   private stdoutBuffer: string = '';
   private databaseUrl: string | null = null;
 
-  constructor() {
-    // Path to workflow-manager MCP server
+  /**
+   * @param serverDir MCP-Writing-Servers `src/mcps/<serverDir>` folder to spawn
+   *   (its `index.js` must support `MCP_STDIO_MODE`, per workflow-manager-server
+   *   and kanban-server's shared pattern). Defaults to workflow-manager-server
+   *   for backward compatibility with existing callers.
+   */
+  constructor(serverDir: string = 'workflow-manager-server') {
+    // Path to the target MCP server
     const userDataPath = app.getPath('userData');
     const mcpServersDir = path.join(userDataPath, 'repositories', 'mcp-writing-servers');
     this.mcpServerPath = path.join(
       mcpServersDir,
       'src',
       'mcps',
-      'workflow-manager-server',
+      serverDir,
       'index.js'
     );
   }

--- a/src/renderer/components/Sidebar.ts
+++ b/src/renderer/components/Sidebar.ts
@@ -83,6 +83,11 @@ export class Sidebar {
       items.push({ id: 'workflows', label: 'Workflows', icon: '🔧', section: 'primary' });
     }
 
+    // Only include the kanban board if the kanban plugin is installed
+    if (this.installedPlugins.has('fictionlab-kanban')) {
+      items.push({ id: 'kanban', label: 'Board', icon: '📋', section: 'primary' });
+    }
+
     items.push(
       { id: 'plugins', label: 'Plugins', icon: '🔌', section: 'primary' },
       {

--- a/src/renderer/components/ViewRouter.ts
+++ b/src/renderer/components/ViewRouter.ts
@@ -48,7 +48,8 @@ export class ViewRouter {
 
   // Plugin-dependent views
   private pluginRequiredViews: Map<string, string> = new Map([
-    ['workflows', 'fictionlab-workflow']
+    ['workflows', 'fictionlab-workflow'],
+    ['kanban', 'fictionlab-kanban']
   ]);
 
   constructor(options: ViewRouterOptions) {
@@ -282,6 +283,7 @@ export class ViewRouter {
     const titles: Record<string, string> = {
       'dashboard': 'Dashboard',
       'workflows': 'Workflows',
+      'kanban': 'Board',
       'library': 'Library',
       'plugins': 'Plugins',
       'settings-setup': 'Setup',
@@ -390,7 +392,8 @@ export class ViewRouter {
    */
   private showPluginRequiredView(viewId: string, pluginId: string): void {
     const viewNames: Record<string, string> = {
-      'workflows': 'Workflows'
+      'workflows': 'Workflows',
+      'kanban': 'Board'
     };
     const viewName = viewNames[viewId] || viewId;
 

--- a/src/renderer/components/kanban/CardDrawer.tsx
+++ b/src/renderer/components/kanban/CardDrawer.tsx
@@ -1,0 +1,437 @@
+/**
+ * CardDrawer
+ * The card detail panel (S11 §7 / issue #179 §3): title, body (markdown-ish,
+ * rendered as preformatted text), status, assignee, priority, labels, due
+ * date, review_policy (with escalate-only control), comments thread,
+ * activity log, links, and claim/move/assign controls. Also the live
+ * workflow-phase tie-in when a card carries workflow_registry_id.
+ */
+
+import * as React from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import {
+  CARD_STATUSES,
+  STATUS_LABELS,
+  type KanbanCardDetail,
+  type KanbanCardStatus,
+  type KanbanPriority,
+  type KanbanLinkType,
+} from '../../../types/kanban.js';
+import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
+
+const KANBAN_PLUGIN = 'plugin:fictionlab-kanban:';
+
+export interface CardDrawerProps {
+  cardId: string;
+  workflowPhase: ActiveWorkflowInstance | null;
+  onClose: () => void;
+  /** Called after any mutation succeeds, so the parent board can re-fetch immediately. */
+  onMutated: () => void;
+}
+
+async function invoke<T = any>(channel: string, args?: any): Promise<T> {
+  const electronAPI = (window as any).electronAPI;
+  return electronAPI.invoke(`${KANBAN_PLUGIN}${channel}`, args);
+}
+
+const panelStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: '420px',
+  maxWidth: '90vw',
+  background: 'var(--color-bg-secondary, #0D1F35)',
+  borderLeft: '1px solid var(--color-border, rgba(255,255,255,0.1))',
+  boxShadow: '-4px 0 16px rgba(0,0,0,0.35)',
+  zIndex: 2000,
+  display: 'flex',
+  flexDirection: 'column',
+  color: 'var(--color-text-primary, rgba(255,255,255,0.9))',
+};
+
+const sectionStyle: React.CSSProperties = {
+  padding: '12px 16px',
+  borderBottom: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '11px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.03em',
+  color: 'var(--color-text-tertiary, rgba(255,255,255,0.5))',
+  marginBottom: '4px',
+  display: 'block',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  padding: '6px 8px',
+  fontSize: '13px',
+  background: 'rgba(255,255,255,0.04)',
+  border: '1px solid var(--color-border, rgba(255,255,255,0.12))',
+  borderRadius: '6px',
+  color: 'inherit',
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: '5px 10px',
+  fontSize: '12px',
+  background: 'rgba(255,255,255,0.06)',
+  border: '1px solid var(--color-border, rgba(255,255,255,0.12))',
+  borderRadius: '5px',
+  color: 'inherit',
+  cursor: 'pointer',
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  background: 'var(--color-accent, #00D4AA)',
+  color: '#03110d',
+  border: 'none',
+  fontWeight: 600,
+};
+
+export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, onClose, onMutated }) => {
+  const [detail, setDetail] = useState<KanbanCardDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [titleDraft, setTitleDraft] = useState('');
+  const [bodyDraft, setBodyDraft] = useState('');
+  const [editingBody, setEditingBody] = useState(false);
+  const [priorityDraft, setPriorityDraft] = useState<KanbanPriority>('normal');
+  const [labelsDraft, setLabelsDraft] = useState('');
+  const [dueDraft, setDueDraft] = useState('');
+  const [specRefDraft, setSpecRefDraft] = useState('');
+  const [issueRefDraft, setIssueRefDraft] = useState('');
+  const [assigneeDraft, setAssigneeDraft] = useState('');
+
+  const [newComment, setNewComment] = useState('');
+  const [claimAgent, setClaimAgent] = useState('');
+  const [linkType, setLinkType] = useState<KanbanLinkType>('url');
+  const [linkRef, setLinkRef] = useState('');
+  const [linkLabel, setLinkLabel] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await invoke<KanbanCardDetail>('board:get-card', { card_id: cardId });
+      if (!result?.card) {
+        setError('Card not found');
+        setDetail(null);
+        return;
+      }
+      setDetail(result);
+      setTitleDraft(result.card.title);
+      setBodyDraft(result.card.body || '');
+      setPriorityDraft(result.card.priority);
+      setLabelsDraft(result.card.labels.join(', '));
+      setDueDraft(result.card.due_at ? result.card.due_at.slice(0, 16) : '');
+      setSpecRefDraft(result.card.spec_ref || '');
+      setIssueRefDraft(result.card.issue_ref || '');
+      setAssigneeDraft(result.card.assignee || '');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load card');
+    } finally {
+      setLoading(false);
+    }
+  }, [cardId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const runMutation = async (fn: () => Promise<any>) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await fn();
+      await load();
+      onMutated();
+    } catch (e: any) {
+      setError(e?.message || 'Action failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading && !detail) {
+    return (
+      <div style={panelStyle}>
+        <div style={sectionStyle}>Loading...</div>
+      </div>
+    );
+  }
+
+  if (!detail?.card) {
+    return (
+      <div style={panelStyle}>
+        <div style={sectionStyle}>
+          <div style={{ marginBottom: '8px' }}>{error || 'Card not found'}</div>
+          <button style={buttonStyle} onClick={onClose}>Close</button>
+        </div>
+      </div>
+    );
+  }
+
+  const card = detail.card;
+
+  const saveFieldChanges = () => {
+    const patch: Record<string, any> = { card_id: cardId, actor: 'rebecca' };
+    let dirty = false;
+    if (titleDraft !== card.title) { patch.title = titleDraft; dirty = true; }
+    if (bodyDraft !== (card.body || '')) { patch.body = bodyDraft; dirty = true; }
+    if (priorityDraft !== card.priority) { patch.priority = priorityDraft; dirty = true; }
+    const labelsArr = labelsDraft.split(',').map((l) => l.trim()).filter(Boolean);
+    if (JSON.stringify(labelsArr) !== JSON.stringify(card.labels)) { patch.labels = labelsArr; dirty = true; }
+    if (specRefDraft !== (card.spec_ref || '')) { patch.spec_ref = specRefDraft; dirty = true; }
+    if (issueRefDraft !== (card.issue_ref || '')) { patch.issue_ref = issueRefDraft; dirty = true; }
+    const dueIso = dueDraft ? new Date(dueDraft).toISOString() : '__clear__';
+    const currentDueTrimmed = card.due_at ? card.due_at.slice(0, 16) : '';
+    if (dueDraft !== currentDueTrimmed) { patch.due_at = dueIso; dirty = true; }
+    if (!dirty) return;
+    runMutation(() => invoke('board:update-card', patch));
+  };
+
+  return (
+    <div style={panelStyle}>
+      <div style={{ ...sectionStyle, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <input
+          style={{ ...inputStyle, fontSize: '15px', fontWeight: 700, border: 'none', background: 'transparent', padding: 0 }}
+          value={titleDraft}
+          onChange={(e) => setTitleDraft(e.target.value)}
+          onBlur={saveFieldChanges}
+        />
+        <button style={buttonStyle} onClick={onClose}>✕</button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {error && <div style={{ ...sectionStyle, color: '#ef4444', fontSize: '12px' }}>{error}</div>}
+
+        {/* Status / review_policy / workflow tie-in */}
+        <div style={sectionStyle}>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '10px' }}>
+            <span style={{ fontSize: '11px', padding: '3px 8px', borderRadius: '10px', background: '#374151' }}>
+              {STATUS_LABELS[card.status]}
+            </span>
+            <span
+              style={{
+                fontSize: '11px',
+                padding: '3px 8px',
+                borderRadius: '10px',
+                background: card.review_policy === 'review-required' ? '#f59e0b' : '#6b7280',
+                color: card.review_policy === 'review-required' ? '#1a1200' : 'white',
+              }}
+              title="Risk-based review policy: review-required cards land in Rebecca's review queue when moved to review; auto-done cards may reach done directly."
+            >
+              {card.review_policy}
+            </span>
+            {card.review_policy === 'auto-done' && (
+              <button
+                style={buttonStyle}
+                disabled={saving}
+                onClick={() => runMutation(() => invoke('board:update-card', { card_id: cardId, actor: 'rebecca', review_policy: 'review-required' }))}
+              >
+                Escalate to review-required
+              </button>
+            )}
+          </div>
+
+          {workflowPhase && (
+            <div style={{ fontSize: '12px', marginBottom: '8px' }}>
+              <span style={labelStyle}>Live workflow phase</span>
+              <div>{workflowPhase.currentNodeName || 'Starting...'} — {workflowPhase.progressPercent ?? 0}%
+                {' '}({workflowPhase.completedNodes}/{workflowPhase.totalNodes} nodes, {workflowPhase.status})
+              </div>
+              <div style={{ height: '4px', background: 'rgba(255,255,255,0.1)', borderRadius: '2px', marginTop: '4px' }}>
+                <div style={{ height: '100%', width: `${workflowPhase.progressPercent ?? 0}%`, background: '#3b82f6', borderRadius: '2px' }} />
+              </div>
+            </div>
+          )}
+
+          <label style={labelStyle}>Move to</label>
+          <select
+            style={inputStyle}
+            value={card.status}
+            disabled={saving}
+            onChange={(e) => runMutation(() => invoke('board:move-card', { card_id: cardId, to_status: e.target.value as KanbanCardStatus, actor: 'rebecca' }))}
+          >
+            {CARD_STATUSES.map((s) => (
+              <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Assignee / claim */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Assignee</label>
+          <div style={{ display: 'flex', gap: '6px', marginBottom: '6px' }}>
+            <input
+              style={inputStyle}
+              value={assigneeDraft}
+              onChange={(e) => setAssigneeDraft(e.target.value)}
+              placeholder="unassigned"
+            />
+            <button
+              style={buttonStyle}
+              disabled={saving}
+              onClick={() => runMutation(() => invoke('board:update-card', { card_id: cardId, actor: 'rebecca', assignee: assigneeDraft || '__clear__' }))}
+            >
+              Save
+            </button>
+          </div>
+          <div style={{ display: 'flex', gap: '6px', marginBottom: '10px' }}>
+            <button style={buttonStyle} disabled={saving} onClick={() => runMutation(() => invoke('board:update-card', { card_id: cardId, actor: 'rebecca', assignee: 'rebecca' }))}>
+              Assign to me
+            </button>
+            <button style={buttonStyle} disabled={saving} onClick={() => runMutation(() => invoke('board:update-card', { card_id: cardId, actor: 'rebecca', assignee: '__clear__' }))}>
+              Clear assignee
+            </button>
+          </div>
+
+          <label style={labelStyle}>Claim as agent (testing / manual override)</label>
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <input style={inputStyle} value={claimAgent} onChange={(e) => setClaimAgent(e.target.value)} placeholder="claude-code:session-label" />
+            <button
+              style={buttonStyle}
+              disabled={saving || !claimAgent.trim()}
+              onClick={() => runMutation(() => invoke('board:claim-card', { card_id: cardId, agent: claimAgent.trim() }))}
+            >
+              Claim
+            </button>
+          </div>
+        </div>
+
+        {/* Priority / labels / due date / refs */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Priority</label>
+          <select style={{ ...inputStyle, marginBottom: '10px' }} value={priorityDraft} onChange={(e) => setPriorityDraft(e.target.value as KanbanPriority)} onBlur={saveFieldChanges}>
+            <option value="low">low</option>
+            <option value="normal">normal</option>
+            <option value="high">high</option>
+            <option value="urgent">urgent</option>
+          </select>
+
+          <label style={labelStyle}>Labels (comma-separated)</label>
+          <input style={{ ...inputStyle, marginBottom: '10px' }} value={labelsDraft} onChange={(e) => setLabelsDraft(e.target.value)} onBlur={saveFieldChanges} />
+
+          <label style={labelStyle}>Due date</label>
+          <input
+            type="datetime-local"
+            style={{ ...inputStyle, marginBottom: '10px' }}
+            value={dueDraft}
+            onChange={(e) => setDueDraft(e.target.value)}
+            onBlur={saveFieldChanges}
+          />
+
+          <label style={labelStyle}>Spec ref</label>
+          <input style={{ ...inputStyle, marginBottom: '10px' }} value={specRefDraft} onChange={(e) => setSpecRefDraft(e.target.value)} onBlur={saveFieldChanges} />
+
+          <label style={labelStyle}>Issue ref</label>
+          <input style={inputStyle} value={issueRefDraft} onChange={(e) => setIssueRefDraft(e.target.value)} onBlur={saveFieldChanges} />
+        </div>
+
+        {/* Body */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Body (spec / plan / acceptance criteria)</label>
+          {editingBody ? (
+            <textarea
+              style={{ ...inputStyle, minHeight: '160px', fontFamily: 'inherit', resize: 'vertical' }}
+              value={bodyDraft}
+              onChange={(e) => setBodyDraft(e.target.value)}
+              onBlur={() => { setEditingBody(false); saveFieldChanges(); }}
+              autoFocus
+            />
+          ) : (
+            <div
+              style={{ whiteSpace: 'pre-wrap', fontSize: '13px', cursor: 'text', minHeight: '40px' }}
+              onClick={() => setEditingBody(true)}
+            >
+              {bodyDraft || <span style={{ color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>Click to add a body...</span>}
+            </div>
+          )}
+        </div>
+
+        {/* Links */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Links</label>
+          {detail.links.length === 0 && <div style={{ fontSize: '12px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>None</div>}
+          {detail.links.map((link) => (
+            <div key={link.id} style={{ fontSize: '12px', marginBottom: '4px' }}>
+              <span style={{ opacity: 0.6 }}>[{link.link_type}]</span> {link.label || link.ref}
+            </div>
+          ))}
+          <div style={{ display: 'flex', gap: '4px', marginTop: '6px' }}>
+            <select style={{ ...inputStyle, flex: '0 0 90px' }} value={linkType} onChange={(e) => setLinkType(e.target.value as KanbanLinkType)}>
+              <option value="url">url</option>
+              <option value="github_issue">github_issue</option>
+              <option value="spec">spec</option>
+              <option value="file">file</option>
+              <option value="workflow_run">workflow_run</option>
+              <option value="card">card</option>
+            </select>
+            <input style={inputStyle} placeholder="ref" value={linkRef} onChange={(e) => setLinkRef(e.target.value)} />
+          </div>
+          <div style={{ display: 'flex', gap: '4px', marginTop: '4px' }}>
+            <input style={inputStyle} placeholder="label (optional)" value={linkLabel} onChange={(e) => setLinkLabel(e.target.value)} />
+            <button
+              style={buttonStyle}
+              disabled={saving || !linkRef.trim()}
+              onClick={() => runMutation(async () => {
+                await invoke('board:add-card-link', { card_id: cardId, link_type: linkType, ref: linkRef.trim(), label: linkLabel.trim() || undefined });
+                setLinkRef('');
+                setLinkLabel('');
+              })}
+            >
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Comments */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Comments</label>
+          {detail.comments.length === 0 && <div style={{ fontSize: '12px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>None yet</div>}
+          {detail.comments.map((c) => (
+            <div key={c.id} style={{ marginBottom: '8px', fontSize: '12px' }}>
+              <div style={{ fontWeight: 600 }}>{c.author} <span style={{ fontWeight: 400, opacity: 0.5 }}>{new Date(c.created_at).toLocaleString()}</span></div>
+              <div style={{ whiteSpace: 'pre-wrap' }}>{c.body}</div>
+            </div>
+          ))}
+          <textarea
+            style={{ ...inputStyle, minHeight: '60px', fontFamily: 'inherit', marginTop: '6px' }}
+            placeholder="Add a comment..."
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+          />
+          <button
+            style={{ ...primaryButtonStyle, marginTop: '6px' }}
+            disabled={saving || !newComment.trim()}
+            onClick={() => runMutation(async () => {
+              await invoke('board:comment-card', { card_id: cardId, author: 'rebecca', body: newComment.trim() });
+              setNewComment('');
+            })}
+          >
+            Add comment
+          </button>
+        </div>
+
+        {/* Activity log */}
+        <div style={sectionStyle}>
+          <label style={labelStyle}>Activity</label>
+          {detail.activity.length === 0 && <div style={{ fontSize: '12px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>None</div>}
+          {detail.activity.map((a) => (
+            <div key={a.id} style={{ fontSize: '11px', marginBottom: '4px', color: 'var(--color-text-secondary, rgba(255,255,255,0.65))' }}>
+              <span style={{ opacity: 0.6 }}>{new Date(a.created_at).toLocaleString()}</span> — {a.actor} {a.action}
+              {a.from_status && a.to_status ? ` (${a.from_status} → ${a.to_status})` : ''}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardDrawer;

--- a/src/renderer/components/kanban/KanbanCardTile.tsx
+++ b/src/renderer/components/kanban/KanbanCardTile.tsx
@@ -1,0 +1,136 @@
+/**
+ * KanbanCardTile
+ * The face of a single card inside a board lane -- title, priority/labels,
+ * assignee, due-date chip, review_policy badge, and (if linked) a compact
+ * live workflow-phase chip. Draggable for lane-to-lane move.
+ */
+
+import * as React from 'react';
+import type { KanbanCard, KanbanReviewPolicy } from '../../../types/kanban.js';
+import { PRIORITY_COLORS } from '../../../types/kanban.js';
+import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
+
+export interface KanbanCardTileProps {
+  card: KanbanCard;
+  workflowPhase?: ActiveWorkflowInstance | null;
+  onSelect: (card: KanbanCard) => void;
+  onDragStart: (card: KanbanCard) => void;
+}
+
+function dueChip(due_at: string | null, status: string): { label: string; color: string } | null {
+  if (!due_at) return null;
+  if (status === 'done' || status === 'archived') return null;
+  const dueDate = new Date(due_at);
+  const now = new Date();
+  const overdue = dueDate.getTime() < now.getTime();
+  const label = dueDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return overdue
+    ? { label: `Overdue ${label}`, color: '#ef4444' }
+    : { label: `Due ${label}`, color: '#3b82f6' };
+}
+
+function reviewBadge(policy: KanbanReviewPolicy): { label: string; color: string } {
+  return policy === 'review-required'
+    ? { label: 'review-required', color: '#f59e0b' }
+    : { label: 'auto-done', color: '#6b7280' };
+}
+
+export const KanbanCardTile: React.FC<KanbanCardTileProps> = ({ card, workflowPhase, onSelect, onDragStart }) => {
+  const due = dueChip(card.due_at, card.status);
+  const review = reviewBadge(card.review_policy);
+
+  const cardStyle: React.CSSProperties = {
+    background: 'rgba(255, 255, 255, 0.05)',
+    border: '1px solid var(--color-border, rgba(255, 255, 255, 0.1))',
+    borderRadius: '8px',
+    padding: '10px',
+    marginBottom: '8px',
+    cursor: 'pointer',
+    transition: 'border-color 0.15s ease',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'var(--color-text-primary, rgba(255, 255, 255, 0.9))',
+    marginBottom: '6px',
+    wordBreak: 'break-word',
+  };
+
+  const rowStyle: React.CSSProperties = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '4px',
+    alignItems: 'center',
+    marginTop: '6px',
+  };
+
+  const chipBase: React.CSSProperties = {
+    fontSize: '10px',
+    fontWeight: 600,
+    padding: '2px 6px',
+    borderRadius: '10px',
+    color: 'white',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <div
+      style={cardStyle}
+      className="kanban-card-tile"
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/plain', card.id);
+        onDragStart(card);
+      }}
+      onClick={() => onSelect(card)}
+      onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--color-accent, #00D4AA)'; }}
+      onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--color-border, rgba(255, 255, 255, 0.1))'; }}
+      title={card.title}
+    >
+      <div style={titleStyle}>{card.title}</div>
+
+      <div style={rowStyle}>
+        <span style={{ ...chipBase, background: PRIORITY_COLORS[card.priority] }}>{card.priority}</span>
+        <span style={{ ...chipBase, background: review.color }}>{review.label}</span>
+        {due && <span style={{ ...chipBase, background: due.color }}>{due.label}</span>}
+        {card.labels.map((label) => (
+          <span key={label} style={{ ...chipBase, background: '#374151' }}>{label}</span>
+        ))}
+      </div>
+
+      {workflowPhase && (
+        <div style={{ ...rowStyle, alignItems: 'center', gap: '6px' }}>
+          <span
+            style={{
+              width: '6px',
+              height: '6px',
+              borderRadius: '50%',
+              background: workflowPhase.status === 'running' ? '#3b82f6' : '#6b7280',
+              animation: workflowPhase.status === 'running' ? 'kanban-pulse 1.5s infinite' : 'none',
+              display: 'inline-block',
+            }}
+          />
+          <span style={{ fontSize: '10px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.5))' }}>
+            {workflowPhase.currentNodeName || 'Starting...'} ({workflowPhase.progressPercent ?? 0}%)
+          </span>
+        </div>
+      )}
+
+      <div style={{ ...rowStyle, fontSize: '10px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.5))' }}>
+        {card.assignee && <span title="Assignee">👤 {card.assignee}</span>}
+        {card.comment_count > 0 && <span title="Comments">💬 {card.comment_count}</span>}
+        {card.link_count > 0 && <span title="Links">🔗 {card.link_count}</span>}
+      </div>
+
+      <style>{`
+        @keyframes kanban-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default KanbanCardTile;

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,0 +1,155 @@
+/**
+ * KanbanColumn
+ * A single lane: header (name, count, advisory WIP badge), a persistent
+ * title-only quick-add input (the low-friction ad-hoc capture requirement,
+ * S11 §7 / issue #179 §3), and the lane's card tiles. Also the drop target
+ * for drag-to-move.
+ */
+
+import * as React from 'react';
+import { useState } from 'react';
+import type { KanbanCard, KanbanColumn as KanbanColumnType } from '../../../types/kanban.js';
+import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
+import { KanbanCardTile } from './KanbanCardTile.js';
+
+export interface KanbanColumnProps {
+  column: KanbanColumnType;
+  cards: KanbanCard[];
+  workflowPhases: Map<string, ActiveWorkflowInstance>;
+  onSelectCard: (card: KanbanCard) => void;
+  onQuickAdd: (statusKey: string, title: string) => void;
+  onDropCard: (cardId: string, statusKey: string) => void;
+  quickAddInputRef?: (el: HTMLInputElement | null) => void;
+}
+
+export const KanbanColumn: React.FC<KanbanColumnProps> = ({
+  column,
+  cards,
+  workflowPhases,
+  onSelectCard,
+  onQuickAdd,
+  onDropCard,
+  quickAddInputRef,
+}) => {
+  const [quickAddValue, setQuickAddValue] = useState('');
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [draggingCardId, setDraggingCardId] = useState<string | null>(null);
+
+  const wipExceeded = column.wip_limit != null && cards.length > column.wip_limit;
+
+  const columnStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: '260px',
+    maxWidth: '280px',
+    flex: '0 0 auto',
+    background: isDragOver ? 'rgba(0, 212, 170, 0.06)' : 'transparent',
+    border: isDragOver ? '1px dashed var(--color-accent, #00D4AA)' : '1px solid transparent',
+    borderRadius: '10px',
+    padding: '8px',
+    height: '100%',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: '8px',
+    padding: '0 2px',
+  };
+
+  const nameStyle: React.CSSProperties = {
+    fontSize: '12px',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+    color: 'var(--color-text-secondary, rgba(255,255,255,0.7))',
+  };
+
+  const countStyle: React.CSSProperties = {
+    fontSize: '11px',
+    color: wipExceeded ? '#ef4444' : 'var(--color-text-tertiary, rgba(255,255,255,0.5))',
+    fontWeight: wipExceeded ? 700 : 400,
+  };
+
+  const quickAddStyle: React.CSSProperties = {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '6px 8px',
+    marginBottom: '8px',
+    fontSize: '12px',
+    background: 'rgba(255,255,255,0.04)',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.1))',
+    borderRadius: '6px',
+    color: 'var(--color-text-primary, rgba(255,255,255,0.9))',
+  };
+
+  const listStyle: React.CSSProperties = {
+    overflowY: 'auto',
+    flex: 1,
+    minHeight: '40px',
+  };
+
+  const submitQuickAdd = () => {
+    const title = quickAddValue.trim();
+    if (!title) return;
+    onQuickAdd(column.status_key, title);
+    setQuickAddValue('');
+  };
+
+  return (
+    <div
+      style={columnStyle}
+      onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setIsDragOver(false);
+        const cardId = e.dataTransfer.getData('text/plain') || draggingCardId;
+        if (cardId) onDropCard(cardId, column.status_key);
+      }}
+    >
+      <div style={headerStyle}>
+        <span style={nameStyle}>{column.name}</span>
+        <span style={countStyle}>
+          {cards.length}
+          {column.wip_limit != null ? ` / ${column.wip_limit}` : ''}
+        </span>
+      </div>
+
+      <input
+        ref={quickAddInputRef}
+        type="text"
+        placeholder="+ Quick add..."
+        style={quickAddStyle}
+        value={quickAddValue}
+        onChange={(e) => setQuickAddValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            submitQuickAdd();
+          }
+        }}
+      />
+
+      <div style={listStyle}>
+        {cards.map((card) => (
+          <KanbanCardTile
+            key={card.id}
+            card={card}
+            workflowPhase={card.workflow_registry_id ? workflowPhases.get(card.workflow_registry_id) : null}
+            onSelect={onSelectCard}
+            onDragStart={(c) => setDraggingCardId(c.id)}
+          />
+        ))}
+        {cards.length === 0 && (
+          <div style={{ fontSize: '11px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.35))', padding: '8px 2px' }}>
+            No cards
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default KanbanColumn;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -12,6 +12,7 @@ import { Sidebar } from './components/Sidebar.js';
 import { TopBar } from './components/TopBar.js';
 import { ViewRouter } from './components/ViewRouter.js';
 import { WorkflowsViewReact } from './views/WorkflowsViewReact.js';
+import { KanbanViewReact } from './views/KanbanViewReact.js';
 // Legacy imports (still used by view wrappers)
 import { initializeSetupTab } from './components/SetupTab.js';
 // import { createDashboardTab } from './components/DashboardTab.js'; // No longer used with new ViewRouter
@@ -980,6 +981,14 @@ async function init(): Promise<void> {
     console.log('[Renderer] WorkflowsViewReact not registered (plugin not installed)');
   }
 
+  // KanbanViewReact requires fictionlab-kanban plugin
+  if (sidebar.isPluginInstalled('fictionlab-kanban')) {
+    viewRouter.registerView('kanban', KanbanViewReact);
+    console.log('[Renderer] KanbanViewReact registered (plugin installed)');
+  } else {
+    console.log('[Renderer] KanbanViewReact not registered (plugin not installed)');
+  }
+
   // Listen for plugin state changes and update navigation
   const electronAPI = (window as any).electronAPI;
   if (electronAPI?.on) {
@@ -1008,6 +1017,27 @@ async function init(): Promise<void> {
       } else {
         // Remove workflows view if plugin was uninstalled
         viewRouter.clearCache('workflows');
+      }
+
+      // Re-register plugin-dependent views
+      if (sidebar.isPluginInstalled('fictionlab-kanban')) {
+        const wasRegistered = viewRouter['viewClasses'].has('kanban');
+        if (!wasRegistered) {
+          viewRouter.registerView('kanban', KanbanViewReact);
+          console.log('[Renderer] KanbanViewReact registered after plugin install');
+        }
+
+        // If we're currently trying to view the board but it was showing
+        // "Plugin Required", re-navigate now that the plugin is ready
+        const currentViewId = viewRouter['currentViewId'];
+        const savedView = localStorage.getItem('fictionlab-active-view');
+        if (savedView === 'kanban' && (!currentViewId || currentViewId !== 'kanban' || !wasRegistered)) {
+          console.log('[Renderer] Re-navigating to kanban after plugin activation');
+          await viewRouter.navigateTo('kanban');
+        }
+      } else {
+        // Remove kanban view if plugin was uninstalled
+        viewRouter.clearCache('kanban');
       }
     });
   }
@@ -1126,6 +1156,12 @@ async function init(): Promise<void> {
       viewRouter.registerView('workflows', WorkflowsViewReact);
       console.log('[Renderer] WorkflowsViewReact registered after plugin installation');
     }
+
+    // Register kanban view if the kanban plugin was installed
+    if (pluginId === 'fictionlab-kanban' && sidebar.isPluginInstalled('fictionlab-kanban')) {
+      viewRouter.registerView('kanban', KanbanViewReact);
+      console.log('[Renderer] KanbanViewReact registered after plugin installation');
+    }
   });
 
   // Listen for plugin uninstallation events to update the UI
@@ -1139,6 +1175,11 @@ async function init(): Promise<void> {
 
     // If workflow plugin was uninstalled and user is on workflows view, navigate away
     if (pluginId === 'fictionlab-workflow' && viewRouter.getCurrentViewId() === 'workflows') {
+      await viewRouter.navigateTo('dashboard');
+    }
+
+    // If kanban plugin was uninstalled and user is on the board view, navigate away
+    if (pluginId === 'fictionlab-kanban' && viewRouter.getCurrentViewId() === 'kanban') {
       await viewRouter.navigateTo('dashboard');
     }
   });

--- a/src/renderer/views/KanbanViewReact.tsx
+++ b/src/renderer/views/KanbanViewReact.tsx
@@ -1,0 +1,313 @@
+/**
+ * KanbanViewReact
+ * S11 Kanban board — host-bundled React view gated on the `fictionlab-kanban`
+ * plugin (the same idiom as WorkflowsViewReact / `fictionlab-workflow`, per
+ * the resolved Option A decision, GH issue #179).
+ *
+ * Board with columns, "mine"-default assignee filter (+ due/overdue filter,
+ * the S14 fold-in minimum), quick-add, drag-to-move, and a card detail
+ * drawer. Live refresh: primary is the `kanban:card-updated` push channel
+ * (fired both by this view's own mutations AND by the plugin's Postgres
+ * LISTEN on `kanban_changed`, which catches externally-driven mutations --
+ * see packages/kanban-plugin/src/index.ts in fictionlab-workflow); a 5s
+ * poll is the backstop; window-focus and every user-initiated mutation
+ * additionally force an immediate re-fetch (issue #179 §4 hard requirement,
+ * independent of push/poll -- the board must never sit stale the way the
+ * Active Workflows panel does per issue #178).
+ */
+
+import * as React from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import type { View } from '../components/ViewRouter.js';
+import type { TopBarConfig } from '../components/TopBar.js';
+import { KanbanColumn } from '../components/kanban/KanbanColumn.js';
+import { CardDrawer } from '../components/kanban/CardDrawer.js';
+import type {
+  KanbanBoard,
+  KanbanColumn as KanbanColumnType,
+  KanbanCard,
+  KanbanAssigneeFilter,
+  KanbanDueFilter,
+  KanbanUpdate,
+} from '../../types/kanban.js';
+import type { ActiveWorkflowInstance, WorkflowUpdate } from '../../types/workflow.js';
+
+const KANBAN_PLUGIN = 'plugin:fictionlab-kanban:';
+const BOARD_KEY = 'dev-backlog';
+const POLL_INTERVAL_MS = 5000;
+
+let activeKanbanAppActions: { refresh: () => void; focusQuickAdd: () => void } | null = null;
+
+async function invoke<T = any>(channel: string, args?: any): Promise<T> {
+  const electronAPI = (window as any).electronAPI;
+  if (!electronAPI?.invoke) throw new Error('Electron API not available');
+  return electronAPI.invoke(`${KANBAN_PLUGIN}${channel}`, args);
+}
+
+const filterBarStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '8px',
+  alignItems: 'center',
+  padding: '10px 16px',
+  borderBottom: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+  flexWrap: 'wrap',
+};
+
+const filterButtonStyle = (active: boolean): React.CSSProperties => ({
+  padding: '5px 12px',
+  fontSize: '12px',
+  borderRadius: '14px',
+  border: `1px solid ${active ? 'var(--color-accent, #00D4AA)' : 'var(--color-border, rgba(255,255,255,0.15))'}`,
+  background: active ? 'rgba(0, 212, 170, 0.12)' : 'transparent',
+  color: active ? 'var(--color-accent, #00D4AA)' : 'var(--color-text-secondary, rgba(255,255,255,0.7))',
+  cursor: 'pointer',
+});
+
+const boardStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '12px',
+  padding: '12px 16px',
+  overflowX: 'auto',
+  height: '100%',
+  boxSizing: 'border-box',
+};
+
+const KanbanApp: React.FC = () => {
+  const [board, setBoard] = useState<KanbanBoard | null>(null);
+  const [columns, setColumns] = useState<KanbanColumnType[]>([]);
+  const [cards, setCards] = useState<KanbanCard[]>([]);
+  const [assigneeFilter, setAssigneeFilter] = useState<KanbanAssigneeFilter>('mine');
+  const [dueFilter, setDueFilter] = useState<KanbanDueFilter | 'none'>('none');
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [workflowPhases, setWorkflowPhases] = useState<Map<string, ActiveWorkflowInstance>>(new Map());
+
+  const quickAddRef = useRef<HTMLInputElement | null>(null);
+  const assigneeFilterRef = useRef(assigneeFilter);
+  const dueFilterRef = useRef(dueFilter);
+  assigneeFilterRef.current = assigneeFilter;
+  dueFilterRef.current = dueFilter;
+
+  const resolveAssigneeParam = (filter: KanbanAssigneeFilter): string | undefined => {
+    if (filter === 'mine') return 'rebecca';
+    if (filter === 'all') return undefined;
+    if (filter === 'unassigned') return '__unassigned__';
+    return filter; // a specific agent id
+  };
+
+  const loadBoard = useCallback(async () => {
+    try {
+      const result = await invoke<{ board: KanbanBoard; columns: KanbanColumnType[] }>('board:get-board', { board_key: BOARD_KEY });
+      if (result?.board) {
+        setBoard(result.board);
+        setColumns([...(result.columns || [])].sort((a, b) => a.position - b.position));
+      }
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load board');
+    }
+  }, []);
+
+  const loadCards = useCallback(async () => {
+    try {
+      const args: Record<string, any> = { board_key: BOARD_KEY, limit: 500 };
+      const assignee = resolveAssigneeParam(assigneeFilterRef.current);
+      if (assignee !== undefined) args.assignee = assignee;
+      if (dueFilterRef.current !== 'none') args.due_filter = dueFilterRef.current;
+      args.include_workflow_phase = true;
+      const result = await invoke<{ cards: KanbanCard[] }>('board:list-cards', args);
+      setCards(result?.cards || []);
+      setError(null);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load cards');
+    }
+  }, []);
+
+  const loadWorkflowPhases = useCallback(async () => {
+    try {
+      const electronAPI = (window as any).electronAPI;
+      if (!electronAPI?.invoke) return;
+      // Host-owned channel (un-prefixed), same one WorkflowManagerPanel uses --
+      // zero new workflow-side plumbing, per S11 §7's workflow tie-in requirement.
+      const result = await electronAPI.invoke('workflow:list-active');
+      if (Array.isArray(result)) {
+        setWorkflowPhases(new Map(result.map((w: ActiveWorkflowInstance) => [w.id, w])));
+      }
+    } catch {
+      // Non-fatal -- the board still works without live workflow phases.
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    loadBoard();
+    loadCards();
+    loadWorkflowPhases();
+  }, [loadBoard, loadCards, loadWorkflowPhases]);
+
+  // Initial load + re-load when filters change.
+  useEffect(() => { loadBoard(); }, [loadBoard]);
+  useEffect(() => { loadCards(); }, [loadCards, assigneeFilter, dueFilter]);
+  useEffect(() => { loadWorkflowPhases(); }, [loadWorkflowPhases]);
+
+  // Live refresh: kanban:card-updated push (primary, fed by LISTEN + this
+  // view's own mutations), 5s poll (backstop), window-focus (hard
+  // requirement independent of mechanism, issue #179 §4).
+  useEffect(() => {
+    const electronAPI = (window as any).electronAPI;
+    if (!electronAPI?.on || !electronAPI?.off) return;
+
+    const handleKanbanUpdate = (_update: KanbanUpdate) => {
+      loadCards();
+      loadBoard();
+    };
+    const handleWorkflowUpdate = (_update: WorkflowUpdate) => {
+      loadWorkflowPhases();
+    };
+    const handleFocus = () => refresh();
+
+    electronAPI.on('kanban:card-updated', handleKanbanUpdate);
+    electronAPI.on('workflow:instance-updated', handleWorkflowUpdate);
+    window.addEventListener('focus', handleFocus);
+
+    const pollInterval = setInterval(refresh, POLL_INTERVAL_MS);
+
+    return () => {
+      electronAPI.off('kanban:card-updated', handleKanbanUpdate);
+      electronAPI.off('workflow:instance-updated', handleWorkflowUpdate);
+      window.removeEventListener('focus', handleFocus);
+      clearInterval(pollInterval);
+    };
+  }, [loadCards, loadBoard, loadWorkflowPhases, refresh]);
+
+  useEffect(() => {
+    activeKanbanAppActions = {
+      refresh,
+      focusQuickAdd: () => quickAddRef.current?.focus(),
+    };
+    return () => { activeKanbanAppActions = null; };
+  }, [refresh]);
+
+  const handleQuickAdd = useCallback((statusKey: string, title: string) => {
+    invoke('board:create-card', { board_key: BOARD_KEY, title, status: statusKey })
+      .then(refresh)
+      .catch((e: any) => setError(e?.message || 'Failed to create card'));
+  }, [refresh]);
+
+  const handleDropCard = useCallback((cardId: string, statusKey: string) => {
+    invoke('board:move-card', { card_id: cardId, to_status: statusKey, actor: 'rebecca' })
+      .then(refresh)
+      .catch((e: any) => setError(e?.message || 'Failed to move card'));
+  }, [refresh]);
+
+  const selectedCard = selectedCardId ? cards.find((c) => c.id === selectedCardId) || null : null;
+
+  const agentOptions = Array.from(
+    new Set(cards.map((c) => c.assignee).filter((a): a is string => !!a && a !== 'rebecca'))
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={filterBarStyle}>
+        <span style={{ fontSize: '11px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.5))', marginRight: '4px' }}>
+          {board?.name || 'Board'}
+        </span>
+        <button style={filterButtonStyle(assigneeFilter === 'mine')} onClick={() => setAssigneeFilter('mine')}>Mine (rebecca)</button>
+        <button style={filterButtonStyle(assigneeFilter === 'all')} onClick={() => setAssigneeFilter('all')}>All</button>
+        <button style={filterButtonStyle(assigneeFilter === 'unassigned')} onClick={() => setAssigneeFilter('unassigned')}>Unassigned</button>
+        {agentOptions.map((agent) => (
+          <button key={agent} style={filterButtonStyle(assigneeFilter === agent)} onClick={() => setAssigneeFilter(agent)}>{agent}</button>
+        ))}
+
+        <span style={{ width: '1px', height: '18px', background: 'var(--color-border, rgba(255,255,255,0.15))', margin: '0 4px' }} />
+
+        <button style={filterButtonStyle(dueFilter === 'none')} onClick={() => setDueFilter('none')}>Any due date</button>
+        <button style={filterButtonStyle(dueFilter === 'overdue')} onClick={() => setDueFilter('overdue')}>Overdue</button>
+        <button style={filterButtonStyle(dueFilter === 'upcoming')} onClick={() => setDueFilter('upcoming')}>Due soon</button>
+
+        {error && <span style={{ fontSize: '11px', color: '#ef4444', marginLeft: 'auto' }}>{error}</span>}
+      </div>
+
+      <div style={boardStyle}>
+        {columns.map((column, index) => (
+          <KanbanColumn
+            key={column.id}
+            column={column}
+            cards={cards.filter((c) => c.status === column.status_key)}
+            workflowPhases={workflowPhases}
+            onSelectCard={(card) => setSelectedCardId(card.id)}
+            onQuickAdd={handleQuickAdd}
+            onDropCard={handleDropCard}
+            quickAddInputRef={index === 0 ? (el) => { quickAddRef.current = el; } : undefined}
+          />
+        ))}
+        {columns.length === 0 && (
+          <div style={{ padding: '24px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.5))' }}>
+            {error ? 'Could not load the board.' : 'Loading board...'}
+          </div>
+        )}
+      </div>
+
+      {selectedCard && (
+        <CardDrawer
+          cardId={selectedCard.id}
+          workflowPhase={selectedCard.workflow_registry_id ? workflowPhases.get(selectedCard.workflow_registry_id) || null : null}
+          onClose={() => setSelectedCardId(null)}
+          onMutated={refresh}
+        />
+      )}
+    </div>
+  );
+};
+
+// View class wrapper for ViewRouter
+export class KanbanViewReact implements View {
+  private container: HTMLElement | null = null;
+  private root: ReactDOM.Root | null = null;
+
+  async mount(container: HTMLElement): Promise<void> {
+    this.container = container;
+    this.root = ReactDOM.createRoot(container);
+    this.root.render(<KanbanApp />);
+    console.log('[KanbanViewReact] Mounted');
+  }
+
+  async unmount(): Promise<void> {
+    if (this.root) {
+      this.root.unmount();
+      this.root = null;
+    }
+    this.container = null;
+    console.log('[KanbanViewReact] Unmounted');
+  }
+
+  getTopBarConfig(): TopBarConfig {
+    return {
+      title: 'Board',
+      actions: [
+        { id: 'new-card', label: 'New Card', icon: '➕' },
+        { id: 'refresh', label: 'Refresh', icon: '🔄' },
+      ],
+      global: {
+        projectSelector: false,
+        environmentIndicator: true,
+      },
+    };
+  }
+
+  handleAction(actionId: string): void {
+    if (!activeKanbanAppActions) {
+      console.warn('[KanbanViewReact] Action dispatched but no mounted app instance to handle it:', actionId);
+      return;
+    }
+    switch (actionId) {
+      case 'refresh':
+        activeKanbanAppActions.refresh();
+        break;
+      case 'new-card':
+        activeKanbanAppActions.focusQuickAdd();
+        break;
+      default:
+        console.warn('[KanbanViewReact] Unknown action:', actionId);
+    }
+  }
+}

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -1,0 +1,154 @@
+/**
+ * Kanban board types (S11)
+ *
+ * Mirrors the response shapes of the `kanban` MCP server's tools exactly
+ * (see MCP-Writing-Servers `src/mcps/kanban-server/handlers/*.js`) --
+ * snake_case, matching the raw Postgres rows the handlers RETURNING * /
+ * SELECT * through unmodified (unlike the workflow-manager client, kanban
+ * does not remap to camelCase).
+ */
+
+export const CARD_STATUSES = [
+  'backlog',
+  'ready',
+  'claimed',
+  'in_progress',
+  'review',
+  'blocked',
+  'done',
+  'archived',
+] as const;
+export type KanbanCardStatus = (typeof CARD_STATUSES)[number];
+
+export type KanbanPriority = 'low' | 'normal' | 'high' | 'urgent';
+export type KanbanReviewPolicy = 'auto-done' | 'review-required';
+export type KanbanLinkType = 'spec' | 'github_issue' | 'workflow_run' | 'file' | 'url' | 'card';
+
+export interface KanbanBoard {
+  id: string;
+  board_key: string;
+  name: string;
+  description: string | null;
+  is_archived: boolean;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  metadata: Record<string, any>;
+}
+
+export interface KanbanColumn {
+  id: string;
+  board_id: string;
+  status_key: KanbanCardStatus;
+  name: string;
+  position: number;
+  color: string | null;
+  wip_limit: number | null;
+  is_agent_pickup: boolean;
+  created_at: string;
+  card_count?: number;
+}
+
+export interface KanbanCard {
+  id: string;
+  board_id: string;
+  title: string;
+  body: string | null;
+  status: KanbanCardStatus;
+  assignee: string | null;
+  agent_claimable: boolean;
+  priority: KanbanPriority;
+  labels: string[];
+  position: number;
+  claimed_by: string | null;
+  claimed_at: string | null;
+  workflow_registry_id: string | null;
+  spec_ref: string | null;
+  issue_ref: string | null;
+  review_policy: KanbanReviewPolicy;
+  due_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  metadata: Record<string, any>;
+  comment_count: number;
+  link_count: number;
+  // Present only when include_workflow_phase / get_card joins active_workflows
+  workflow_phase?: string | null;
+  workflow_progress_percent?: number | null;
+  workflow_status?: string | null;
+  workflow_current_node_name?: string | null;
+}
+
+export interface KanbanComment {
+  id: string;
+  card_id: string;
+  author: string;
+  body: string;
+  created_at: string;
+  metadata: Record<string, any>;
+}
+
+export interface KanbanCardLink {
+  id: string;
+  card_id: string;
+  link_type: KanbanLinkType;
+  ref: string;
+  label: string | null;
+  created_at: string;
+}
+
+export interface KanbanActivity {
+  id: number;
+  board_id: string | null;
+  card_id: string | null;
+  actor: string;
+  action: string;
+  from_status: string | null;
+  to_status: string | null;
+  detail: Record<string, any>;
+  created_at: string;
+}
+
+export interface KanbanCardDetail {
+  card: KanbanCard;
+  comments: KanbanComment[];
+  links: KanbanCardLink[];
+  activity: KanbanActivity[];
+}
+
+export interface KanbanClaimResult {
+  claimed: boolean;
+  card?: KanbanCard;
+  reason?: 'not_found' | 'reserved_for_human' | 'already_claimed' | 'wrong_status';
+}
+
+/** Payload broadcast on the `kanban:card-updated` channel (main -> renderer). */
+export interface KanbanUpdate {
+  cardId: string | null;
+  source: 'ipc' | 'listen';
+  timestamp: string;
+}
+
+export const DUE_FILTER_OPTIONS = ['overdue', 'upcoming'] as const;
+export type KanbanDueFilter = (typeof DUE_FILTER_OPTIONS)[number];
+
+export type KanbanAssigneeFilter = 'mine' | 'all' | 'unassigned' | string;
+
+export const STATUS_LABELS: Record<KanbanCardStatus, string> = {
+  backlog: 'Backlog',
+  ready: 'Ready to work',
+  claimed: 'Claimed',
+  in_progress: 'In progress',
+  review: 'In review',
+  blocked: 'Blocked / decision',
+  done: 'Done',
+  archived: 'Archived',
+};
+
+export const PRIORITY_COLORS: Record<KanbanPriority, string> = {
+  urgent: '#ef4444',
+  high: '#f59e0b',
+  normal: '#3b82f6',
+  low: '#6b7280',
+};


### PR DESCRIPTION
Closes #179.

## Summary
Implements this repo's portion of S11 (the host-side Electron board view + plugin registration, per issue #179). The companion MCP-Writing-Servers server work (migration 042 + `kanban-server` MCP, port 3015) was already merged in PR #60 before this issue was picked up; the `fictionlab-kanban` plugin package itself (the install-target this view is gated on) ships in a separate `fictionlab-workflow` PR on the same branch name. A small `due_at` fold-in from S14 (see below) also went into a third companion PR.

**Host wiring:**
- `src/main/workflow/persistent-mcp-client.ts` — `PersistentMCPClient`'s constructor now takes an optional `serverDir` (default `workflow-manager-server`, unchanged for existing callers) instead of hardcoding the spawned server.
- `src/main/plugin-context.ts` — `kanban -> 3015` added to the serverId→port map; a second `PersistentMCPClient` singleton (`getKanbanMCPClient()`, mirroring `getWorkflowMCPClient()`) gives `'kanban'` the same stdio-first treatment as `workflow-manager` in `callTool`/`isServerRunning`/`getServerInfo`, per issue #179 §2's explicit recommendation (the "minimally-duplicated second instance" v1 shortcut it calls out as acceptable).

**Sidebar / router / renderer gating** (mirrors the `fictionlab-workflow` / `workflows` pattern exactly, all 4 renderer.ts call sites):
- `Sidebar.ts` — "Board" nav item gated on `installedPlugins.has('fictionlab-kanban')`.
- `ViewRouter.ts` — `'kanban' -> 'fictionlab-kanban'` added to `pluginRequiredViews`, plus title / plugin-required-view-name entries.
- `renderer.ts` — `KanbanViewReact` registered at initial load (gated), on `plugin-state-changed`, and on the `plugin-installed` window event; unregistered/navigated-away-from on `plugin-uninstalled`.

**The view itself:**
- `src/types/kanban.ts` — types mirroring `kanban-server`'s tool response shapes verbatim (snake_case, unmapped).
- `src/renderer/components/kanban/{KanbanCardTile,KanbanColumn,CardDrawer}.tsx` + `src/renderer/views/KanbanViewReact.tsx` — board with lanes rendered from `get_board`, default **"Mine (rebecca)"** assignee filter (+ All / Unassigned / per-agent), a due/overdue filter (S14 fold-in minimum), title-only quick-add per lane (no modal), HTML5 drag-to-move calling `move_card`, and a detail drawer (body, status, assignee, priority, labels, due date, `review_policy` with an escalate-only control, comments, activity log, links, and a claim control). Cards linked to a workflow run show a compact live-phase chip (face) / full progress bar (drawer), fed by the existing `workflow:list-active` / `workflow:instance-updated` channels — no new workflow-side plumbing.

**Refresh (issue #179 §4):** primary is the `kanban:card-updated` push channel (fed by the plugin's own IPC mutations **and** its Postgres `LISTEN kanban_changed`, so externally-driven mutations are covered too — see #178's finding that the workflow panel's IPC-only push never fires for those); a 5s poll is the backstop; window-focus and every user-initiated mutation additionally force an immediate re-fetch, independent of push/poll.

**Transport:** stdio (matching `workflow-manager`'s proven path), documented per issue #179 §2/§8.

## Spec discrepancies found
- The S11 spec's own migration-number placeholder (042) and the actual merged PR #60 already diverged slightly from the original spec text in judgment calls that PR documents (`review_policy` escalate-only guard added; `mcp-config.json` entry added for literal acceptance-criteria compliance) — noted there, not re-litigated here.
- S14-broadquill-dashboard-plugin.md's Status header (retargeted 2026-07-07) folds its business panel into this plugin; per the task's scope note, only the minimum (`due_at` + assignee filter, both now supported) was built here. The full "Business" panel (`bq_deadlines`/`bq_pipeline_items` UI, needs-attention band, 14-day alert window, notifier) is explicitly **not** built — see follow-up note below.

## What remains for the S14 business-panel follow-up
Per S14 §4–§8 (not built in this PR, by design):
- `bq_deadlines` / `bq_pipeline_items` schema + quick-add presets (LLC/domain renewal deadlines, book pipeline stages).
- A "Business" panel/section in this same kanban view: needs-attention band, next-14-days list, pipeline strip, mail counts (soft dependency on a future `broadquill-mail` plugin).
- The recurrence-rolling / snooze semantics (S14 §5) as a query/mutation module (no HTTP routes — S14 was retargeted off the standalone Express host).
- The `notify-alerts` push notifier (Postgres-direct, no HTTP) and its Scheduled Task registration.
- One-off business setup steps (LLC chain etc.) becoming due-dated kanban cards assigned to Rebecca — recurring compliance items stay in `bq_deadlines` (cards are wrong for recurrence, per S14's Status header).

## Test plan
- [x] `npm run build` (tsc renderer + main + asset copy) — zero errors.
- [x] `npx jest` — 123 failed / 173 passed / 3 skipped, matching the documented pre-existing baseline (issue #176) exactly; **no new failures introduced**.
- [x] `kanban-server` MCP tool surface exercised directly (52/52 smoke-test assertions, including the new due_at/due_filter coverage) against the live DB — see the companion MCP-Writing-Servers PR.
- [ ] Live board UI (sidebar gating, quick-add, drag-to-move, drawer) — **not exercised**, see note below.

### On UI verification
I built and installed a `fictionlab-kanban` plugin bundle into `%APPDATA%\fictionlab\plugins\fictionlab-kanban\` and attempted to launch the built Electron app to screenshot the board. This session's environment has `ELECTRON_RUN_AS_NODE=1` set, which forces `electron.exe` into plain-Node mode (`electron_1.app` is `undefined` — a sandbox characteristic, not a bug in this change) — no GUI window could be opened here to capture a screenshot. Everything short of an actual rendered screenshot has been verified (clean compile, gating logic read against the exact `Sidebar.ts`/`ViewRouter.ts` mechanisms it mirrors, and the full MCP tool surface it calls proven live). Recommend a manual pass in an environment without that env var before merge, or via `/run-skill-generator` to capture a repeatable driver for next time.

Companion PRs (same branch name, cross-linked):
- RLRyals/MCP-Writing-Servers#61 — `due_at` column + due/overdue filter on `kanban-server`
- RLRyals/fictionlab-workflow#6 — new `fictionlab-kanban` plugin package (this PR's install-target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)