### PR TITLE
Plugin update-in-place: one Update action instead of uninstall/reinstall/restart×2

### DIFF
--- a/src/main/__tests__/plugin-update-swap.test.ts
+++ b/src/main/__tests__/plugin-update-swap.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for the plugin update swap/rollback/validation logic
+ * (GitHub issue #182).
+ *
+ * These exercise real temp directories on disk (no Electron, no mocked
+ * fs-extra) since the whole point of this module is to be correct about
+ * actual filesystem rename/copy semantics.
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  validatePluginUpdateSource,
+  performPluginSwap,
+  updatePluginInPlace,
+  recoverPluginsDirectory,
+  readPluginManifestSafe,
+  PluginUpdateError,
+} from '../plugin-update-swap';
+
+let workDir: string;
+let pluginsDir: string;
+
+beforeEach(async () => {
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-update-swap-'));
+  pluginsDir = path.join(workDir, 'plugins');
+  await fs.ensureDir(pluginsDir);
+});
+
+afterEach(async () => {
+  await fs.remove(workDir);
+});
+
+/** Write a minimal installed plugin directory `<pluginsDir>/<id>`. */
+async function writeInstalledPlugin(
+  id: string,
+  version: string,
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  const dir = path.join(pluginsDir, id);
+  await fs.ensureDir(dir);
+  await fs.writeJson(path.join(dir, 'plugin.json'), {
+    id,
+    name: `Plugin ${id}`,
+    version,
+    description: 'test plugin',
+    author: 'test',
+    fictionLabVersion: '*',
+    pluginType: 'utility',
+    entry: { main: 'index.js' },
+    permissions: [],
+    ...overrides,
+  });
+  await fs.writeFile(path.join(dir, 'index.js'), 'module.exports = {};');
+  return dir;
+}
+
+/** Write a candidate update bundle in its own temp source directory. */
+async function writeSourceBundle(
+  id: string,
+  version: string,
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-update-source-'));
+  await fs.writeJson(path.join(dir, 'plugin.json'), {
+    id,
+    name: `Plugin ${id}`,
+    version,
+    description: 'test plugin',
+    author: 'test',
+    fictionLabVersion: '*',
+    pluginType: 'utility',
+    entry: { main: 'index.js' },
+    permissions: [],
+    ...overrides,
+  });
+  await fs.writeFile(path.join(dir, 'index.js'), `module.exports = { version: '${version}' };`);
+  return dir;
+}
+
+describe('validatePluginUpdateSource', () => {
+  it('refuses when the plugin is not currently installed', async () => {
+    const source = await writeSourceBundle('kanban', '1.1.0');
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'NOT_INSTALLED' });
+  });
+
+  it('refuses an id mismatch before touching any files', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('other-plugin', '2.0.0');
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'ID_MISMATCH' });
+
+    // Nothing should have been touched.
+    const installed = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(installed?.version).toBe('1.0.0');
+  });
+
+  it('refuses a downgrade', async () => {
+    await writeInstalledPlugin('kanban', '2.0.0');
+    const source = await writeSourceBundle('kanban', '1.9.0');
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'DOWNGRADE' });
+  });
+
+  it('refuses a same-version "update"', async () => {
+    await writeInstalledPlugin('kanban', '2.0.0');
+    const source = await writeSourceBundle('kanban', '2.0.0');
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'DOWNGRADE' });
+  });
+
+  it('refuses an invalid semver version in the new bundle', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', 'not-a-version');
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'INVALID_MANIFEST' });
+  });
+
+  it('refuses a bundle missing its entry point', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+    await fs.remove(path.join(source, 'index.js'));
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'INVALID_MANIFEST' });
+  });
+
+  it('refuses a bundle with no plugin.json at all', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-update-empty-'));
+
+    await expect(
+      validatePluginUpdateSource(pluginsDir, 'kanban', source)
+    ).rejects.toMatchObject({ code: 'INVALID_MANIFEST' });
+
+    await fs.remove(source);
+  });
+
+  it('accepts a strictly greater version and reports current -> new', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+
+    const result = await validatePluginUpdateSource(pluginsDir, 'kanban', source);
+
+    expect(result.currentVersion).toBe('1.0.0');
+    expect(result.manifest.version).toBe('1.1.0');
+  });
+});
+
+describe('performPluginSwap', () => {
+  it('replaces the plugin directory contents and keeps a .bak of the old version', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+
+    await performPluginSwap(pluginsDir, 'kanban', source);
+
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('1.1.0');
+
+    const bak = await readPluginManifestSafe(path.join(pluginsDir, 'kanban.bak'));
+    expect(bak?.version).toBe('1.0.0');
+  });
+
+  it('never leaves the plugin directory missing, even if the final rename fails', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+    const pluginPath = path.join(pluginsDir, 'kanban');
+
+    // Inject a rename that fails only for the second (staging -> live) step,
+    // simulating a crash/error right in the middle of the swap.
+    const fakeRename = jest.fn(async (src: string, dest: string) => {
+      if (dest === pluginPath && src.includes('.staging')) {
+        throw new Error('simulated crash during swap-in');
+      }
+      await fs.rename(src, dest);
+    });
+
+    await expect(
+      performPluginSwap(pluginsDir, 'kanban', source, { rename: fakeRename })
+    ).rejects.toThrow('simulated crash during swap-in');
+
+    // Rolled back: the old version must still be there and loadable.
+    const live = await readPluginManifestSafe(pluginPath);
+    expect(live?.version).toBe('1.0.0');
+  });
+
+  it('installs cleanly when there is no pre-existing plugin directory', async () => {
+    const source = await writeSourceBundle('brand-new', '1.0.0');
+
+    await performPluginSwap(pluginsDir, 'brand-new', source);
+
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'brand-new'));
+    expect(live?.version).toBe('1.0.0');
+    expect(await fs.pathExists(path.join(pluginsDir, 'brand-new.bak'))).toBe(false);
+  });
+});
+
+describe('updatePluginInPlace', () => {
+  it('validates then swaps in one call', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '3.0.0');
+
+    const result = await updatePluginInPlace(pluginsDir, 'kanban', source);
+
+    expect(result.currentVersion).toBe('1.0.0');
+    expect(result.manifest.version).toBe('3.0.0');
+
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('3.0.0');
+  });
+
+  it('touches nothing when validation fails', async () => {
+    await writeInstalledPlugin('kanban', '2.0.0');
+    const source = await writeSourceBundle('kanban', '1.0.0'); // downgrade
+
+    await expect(
+      updatePluginInPlace(pluginsDir, 'kanban', source)
+    ).rejects.toBeInstanceOf(PluginUpdateError);
+
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('2.0.0');
+    expect(await fs.pathExists(path.join(pluginsDir, 'kanban.bak'))).toBe(false);
+  });
+});
+
+describe('recoverPluginsDirectory', () => {
+  it('is a no-op when there is nothing to recover', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report).toEqual({ completed: [], rolledBack: [], cleaned: [] });
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('1.0.0');
+  });
+
+  it('cleans up a stale .bak after a successful swap (the "next successful launch")', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+    await performPluginSwap(pluginsDir, 'kanban', source);
+
+    expect(await fs.pathExists(path.join(pluginsDir, 'kanban.bak'))).toBe(true);
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report.cleaned).toEqual(['kanban']);
+    expect(await fs.pathExists(path.join(pluginsDir, 'kanban.bak'))).toBe(false);
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('1.1.0');
+  });
+
+  it('completes an interrupted forward swap: live missing, staging present', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '2.0.0');
+
+    // Simulate a crash between "old -> .bak" and "staging -> live":
+    // manually reproduce that intermediate disk state instead of calling
+    // performPluginSwap (which would complete normally).
+    const pluginPath = path.join(pluginsDir, 'kanban');
+    const bakPath = path.join(pluginsDir, 'kanban.bak');
+    const stagingPath = path.join(pluginsDir, 'kanban.staging');
+    await fs.copy(source, stagingPath);
+    await fs.rename(pluginPath, bakPath);
+    // pluginPath now does not exist -- exactly the crash window.
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report.completed).toEqual(['kanban']);
+    const live = await readPluginManifestSafe(pluginPath);
+    expect(live?.version).toBe('2.0.0');
+    // .bak is left for cleanup on the *next* successful launch, not this one.
+    expect(await fs.pathExists(bakPath)).toBe(true);
+    expect(await fs.pathExists(stagingPath)).toBe(false);
+
+    // And the launch after that finishes the job.
+    const secondReport = await recoverPluginsDirectory(pluginsDir);
+    expect(secondReport.cleaned).toEqual(['kanban']);
+    expect(await fs.pathExists(bakPath)).toBe(false);
+  });
+
+  it('rolls back when live is missing and there is no usable staging copy', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const pluginPath = path.join(pluginsDir, 'kanban');
+    const bakPath = path.join(pluginsDir, 'kanban.bak');
+
+    // Simulate a crash right after "old -> .bak" with no staging ever
+    // having been produced (e.g. the copy step itself never completed).
+    await fs.rename(pluginPath, bakPath);
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report.rolledBack).toEqual(['kanban']);
+    const live = await readPluginManifestSafe(pluginPath);
+    expect(live?.version).toBe('1.0.0');
+    expect(await fs.pathExists(bakPath)).toBe(false);
+  });
+
+  it('rolls back when the live directory is corrupt but .bak is healthy', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const pluginPath = path.join(pluginsDir, 'kanban');
+    const bakPath = path.join(pluginsDir, 'kanban.bak');
+
+    // Corrupt the live plugin.json, and leave a healthy .bak beside it.
+    await fs.copy(pluginPath, bakPath);
+    await fs.writeFile(path.join(pluginPath, 'plugin.json'), '{ this is not json');
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report.rolledBack).toEqual(['kanban']);
+    const live = await readPluginManifestSafe(pluginPath);
+    expect(live?.version).toBe('1.0.0');
+  });
+
+  it('discards a stale staging directory left over from a validation that never swapped', async () => {
+    await writeInstalledPlugin('kanban', '1.0.0');
+    const source = await writeSourceBundle('kanban', '1.1.0');
+    const stagingPath = path.join(pluginsDir, 'kanban.staging');
+    await fs.copy(source, stagingPath);
+    // No .bak, live is untouched and healthy.
+
+    const report = await recoverPluginsDirectory(pluginsDir);
+
+    expect(report).toEqual({ completed: [], rolledBack: [], cleaned: [] });
+    expect(await fs.pathExists(stagingPath)).toBe(false);
+    const live = await readPluginManifestSafe(path.join(pluginsDir, 'kanban'));
+    expect(live?.version).toBe('1.0.0');
+  });
+
+  it('is safe to call on an empty or missing plugins directory', async () => {
+    const missingDir = path.join(workDir, 'does-not-exist');
+    await expect(recoverPluginsDirectory(missingDir)).resolves.toEqual({
+      completed: [],
+      rolledBack: [],
+      cleaned: [],
+    });
+
+    await expect(recoverPluginsDirectory(pluginsDir)).resolves.toEqual({
+      completed: [],
+      rolledBack: [],
+      cleaned: [],
+    });
+  });
+});

--- a/src/main/handlers/plugin-update-handlers.ts
+++ b/src/main/handlers/plugin-update-handlers.ts
@@ -4,11 +4,16 @@
  * IPC handlers for managing and updating plugins from local folders.
  */
 
-import { ipcMain, app, dialog, shell } from 'electron';
+import { ipcMain, app, dialog, shell, BrowserWindow } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { logWithCategory, LogCategory } from '../logger';
 import { pluginManager } from '../plugin-manager';
+import {
+  updatePluginInPlace,
+  validatePluginUpdateSource,
+  PluginUpdateError,
+} from '../plugin-update-swap';
 
 interface PluginInfo {
   id: string;
@@ -54,6 +59,21 @@ async function safeRemoveDir(dirPath: string): Promise<void> {
 }
 
 /**
+ * Show a message box, with or without an owning window.
+ *
+ * Electron's `dialog.showMessageBox` has distinct 1-arg and 2-arg
+ * overloads; calling the 2-arg form with `undefined` as the window is not
+ * the same as calling the 1-arg form, so this picks the right one instead
+ * of just casting `window as any`.
+ */
+function showMessageBox(
+  window: Electron.BrowserWindow | undefined,
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  return window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options);
+}
+
+/**
  * Extract a zip file
  */
 async function extractZip(zipPath: string, destPath: string): Promise<void> {
@@ -94,7 +114,14 @@ export function registerPluginUpdateHandlers() {
 
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
-        if (entry.name.includes('.backup-')) continue;
+        // Skip update-swap bookkeeping directories (see plugin-update-swap.ts).
+        if (
+          entry.name.endsWith('.bak') ||
+          entry.name.endsWith('.staging') ||
+          entry.name.includes('.backup-')
+        ) {
+          continue;
+        }
 
         const pluginPath = path.join(pluginsDir, entry.name);
         const manifestPath = path.join(pluginPath, 'plugin.json');
@@ -123,18 +150,24 @@ export function registerPluginUpdateHandlers() {
     }
   });
 
-  // Update plugin from a local folder
-  ipcMain.handle('plugin:update-from-folder', async (_event, pluginId: string, folderPath?: string) => {
+  // Update an already-installed plugin from a local folder (issue #182).
+  //
+  // v1 boundary: this never hot-reloads the running plugin -- it only
+  // validates + atomically swaps the files on disk (with .bak rollback on
+  // failure), then offers a single prompted restart. If the user declines
+  // the restart, the new files are on disk but the old code stays running
+  // in memory until FictionLab is restarted (same as before this handler
+  // ran, just without the old uninstall/reinstall dance).
+  ipcMain.handle('plugin:update-from-folder', async (event, pluginId: string, folderPath?: string) => {
     logWithCategory('info', LogCategory.SYSTEM, `IPC: Update plugin ${pluginId} from folder`);
     try {
       const pluginsDir = getPluginsDirectory();
-      const pluginPath = path.join(pluginsDir, pluginId);
 
       let sourcePath = folderPath;
       if (!sourcePath) {
         const result = await dialog.showOpenDialog({
-          title: `Select ${pluginId} Plugin Folder`,
-          message: 'Select the plugin folder (containing plugin.json)',
+          title: `Select Updated ${pluginId} Plugin Folder`,
+          message: 'Select the folder containing the updated plugin.json',
           properties: ['openDirectory'],
         });
 
@@ -144,43 +177,71 @@ export function registerPluginUpdateHandlers() {
         sourcePath = result.filePaths[0];
       }
 
-      const manifestPath = path.join(sourcePath, 'plugin.json');
-      if (!await fs.pathExists(manifestPath)) {
-        throw new Error('Selected folder does not contain plugin.json');
-      }
+      const window = BrowserWindow.fromWebContents(event.sender) ?? undefined;
 
-      const manifest = await fs.readJson(manifestPath);
-      if (manifest.id !== pluginId) {
-        throw new Error(`Plugin ID mismatch: expected "${pluginId}", found "${manifest.id}"`);
-      }
-
+      // Validate before touching anything: id must match, version must be
+      // strictly greater (semver). Refuse with a clear message otherwise.
+      let manifest: { id: string; name?: string; version: string };
+      let currentVersion: string | null;
       try {
-        await pluginManager.deactivatePlugin(pluginId);
-      } catch (e) {
-        // Plugin might not be active
+        const validation = await validatePluginUpdateSource(pluginsDir, pluginId, sourcePath);
+        manifest = validation.manifest;
+        currentVersion = validation.currentVersion;
+      } catch (error: any) {
+        if (error instanceof PluginUpdateError) {
+          logWithCategory('warn', LogCategory.SYSTEM, `Update refused for ${pluginId}: ${error.message}`);
+          return { success: false, refused: true, code: error.code, message: error.message };
+        }
+        throw error;
       }
 
-      const backupPath = path.join(pluginsDir, `${pluginId}.backup-${Date.now()}`);
-      if (await fs.pathExists(pluginPath)) {
-        await fs.move(pluginPath, backupPath);
+      // Confirm with the user, showing current -> new version.
+      const confirmation = await showMessageBox(window, {
+        type: 'question',
+        buttons: ['Update', 'Cancel'],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'Confirm Plugin Update',
+        message: `Update ${manifest.name || pluginId}?`,
+        detail: `${currentVersion ?? 'unknown'}  →  ${manifest.version}`,
+      });
+
+      if (confirmation.response !== 0) {
+        return { success: false, cancelled: true };
       }
 
-      await fs.copy(sourcePath, pluginPath, { overwrite: true });
-      await setupBundledDependencies(pluginPath);
+      // Atomic swap: extract already happened (folder select), verify
+      // structure already happened (validation above); now swap the
+      // directory in with a .bak of the previous version for rollback.
+      await updatePluginInPlace(pluginsDir, pluginId, sourcePath);
 
-      try {
-        await safeRemoveDir(backupPath);
-      } catch (e) {
-        // Non-fatal
+      logWithCategory('info', LogCategory.SYSTEM, `Plugin ${pluginId} updated ${currentVersion ?? 'unknown'} -> ${manifest.version}`);
+
+      // One restart, prompted -- no uninstall step, no double restart.
+      const restart = await showMessageBox(window, {
+        type: 'info',
+        buttons: ['Restart Now', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'Update Complete',
+        message: `Restart FictionLab to load ${manifest.name || pluginId} v${manifest.version}`,
+      });
+
+      if (restart.response === 0) {
+        app.relaunch();
+        app.exit(0);
       }
 
-      try {
-        await pluginManager.reloadPlugin(pluginId);
-      } catch (e: any) {
-        logWithCategory('warn', LogCategory.SYSTEM, 'Failed to reload plugin', { error: e.message });
-      }
-
-      return { success: true, message: 'Plugin updated. Restart FictionLab to apply changes.', version: manifest.version };
+      return {
+        success: true,
+        version: manifest.version,
+        previousVersion: currentVersion,
+        restarting: restart.response === 0,
+        message:
+          restart.response === 0
+            ? `Updated to v${manifest.version}. Restarting FictionLab...`
+            : `Updated to v${manifest.version}. Restart FictionLab whenever you're ready to load it.`,
+      };
     } catch (error: any) {
       logWithCategory('error', LogCategory.SYSTEM, `Failed to update plugin ${pluginId} from folder`, { error: error.message });
       throw error;

--- a/src/main/plugin-loader.ts
+++ b/src/main/plugin-loader.ts
@@ -64,6 +64,22 @@ export class PluginLoader {
           continue;
         }
 
+        // Skip update-swap bookkeeping directories (see plugin-update-swap.ts,
+        // issue #182): a `.bak` is the pre-update copy of a plugin kept around
+        // for crash rollback, and `.staging` is a not-yet-swapped-in update.
+        // Both are full copies of a real plugin (same id, own plugin.json),
+        // so without this guard they'd be "discovered" as duplicate plugins.
+        // Also skip the older ad-hoc `.backup-<timestamp>` naming in case any
+        // are still on disk from before this change.
+        if (
+          entry.name.endsWith('.bak') ||
+          entry.name.endsWith('.staging') ||
+          entry.name.includes('.backup-')
+        ) {
+          logWithCategory('debug', LogCategory.SYSTEM, `Skipping update-swap directory: ${entry.name}`);
+          continue;
+        }
+
         const pluginPath = path.join(this.pluginsDirectory, entry.name);
         const manifestPath = path.join(pluginPath, 'plugin.json');
 

--- a/src/main/plugin-manager.ts
+++ b/src/main/plugin-manager.ts
@@ -6,10 +6,12 @@
  */
 
 import { app, BrowserWindow, Menu, MenuItem as ElectronMenuItem, dialog } from 'electron';
+import * as path from 'path';
 import { logWithCategory, LogCategory } from './logger';
 import { PluginRegistry } from './plugin-registry';
 import { getDatabasePool, initializeDatabasePool } from './database-connection';
 import { getBaseMenuTemplate } from './index';
+import { recoverPluginsDirectory } from './plugin-update-swap';
 import {
   PluginState,
   PluginNotification,
@@ -41,6 +43,20 @@ class PluginManager {
     logWithCategory('info', LogCategory.SYSTEM, 'Initializing plugin manager...');
 
     try {
+      // Repair any plugin update swap interrupted by a crash/kill (issue
+      // #182), and clean up `.bak` copies left over from an update that
+      // completed successfully on a previous run. Must run before
+      // discovery so the loader never sees a half-swapped plugin.
+      const pluginsDir = path.join(app.getPath('userData'), 'plugins');
+      try {
+        const recovery = await recoverPluginsDirectory(pluginsDir);
+        if (recovery.completed.length || recovery.rolledBack.length || recovery.cleaned.length) {
+          logWithCategory('info', LogCategory.SYSTEM, 'Plugin update recovery pass:', recovery);
+        }
+      } catch (error: any) {
+        logWithCategory('warn', LogCategory.SYSTEM, 'Plugin update recovery pass failed (continuing):', error);
+      }
+
       // Ensure database pool is initialized
       await initializeDatabasePool();
       const dbPool = getDatabasePool();

--- a/src/main/plugin-update-swap.ts
+++ b/src/main/plugin-update-swap.ts
@@ -1,0 +1,393 @@
+/**
+ * Plugin Update Swap (issue #182)
+ *
+ * Pure filesystem logic for updating an already-installed plugin in place:
+ * validate -> atomic swap with .bak rollback -> (caller prompts for restart).
+ *
+ * Deliberately has NO dependency on Electron (no `app`, `dialog`, `ipcMain`)
+ * so it can be unit tested against real temp directories without mocking
+ * the whole Electron module. The IPC handler in
+ * `handlers/plugin-update-handlers.ts` is a thin wrapper around this module
+ * that adds the file-picker, confirm dialog, and restart prompt.
+ *
+ * v1 boundaries (see GitHub issue #182):
+ * - No hot reload of main-process plugin code. A successful swap only
+ *   updates the files on disk; the running process keeps using whatever it
+ *   already loaded into memory until the user restarts.
+ * - At most one prompted restart (handled by the caller, not here).
+ * - Downgrade or id-mismatch is refused before any file is touched.
+ * - A crash mid-swap must leave a working plugin (old or new, never a
+ *   corrupt half) -- see `recoverPluginsDirectory()`.
+ *
+ * v2 candidates (do not build now): checking a configured GitHub-releases
+ * feed per plugin id for one-click updates; renderer-only hot-swap.
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as semver from 'semver';
+
+/** Suffix used for the pre-swap backup of the previous plugin directory. */
+const BAK_SUFFIX = '.bak';
+/** Suffix used for the staged copy of the new plugin bundle before swap-in. */
+const STAGING_SUFFIX = '.staging';
+
+export type PluginUpdateErrorCode =
+  | 'NOT_INSTALLED'
+  | 'INVALID_MANIFEST'
+  | 'ID_MISMATCH'
+  | 'DOWNGRADE';
+
+/**
+ * Thrown when an update is refused before any file has been touched.
+ */
+export class PluginUpdateError extends Error {
+  code: PluginUpdateErrorCode;
+
+  constructor(code: PluginUpdateErrorCode, message: string) {
+    super(message);
+    this.name = 'PluginUpdateError';
+    this.code = code;
+  }
+}
+
+export interface MinimalPluginManifest {
+  id: string;
+  name?: string;
+  version: string;
+  entry?: { main?: string };
+  [key: string]: unknown;
+}
+
+export interface PluginUpdateValidation {
+  /** Manifest read from the new bundle (sourcePath). */
+  manifest: MinimalPluginManifest;
+  /** Version currently installed, or null if it couldn't be read/parsed. */
+  currentVersion: string | null;
+}
+
+function pluginDirPath(pluginsDir: string, pluginId: string): string {
+  return path.join(pluginsDir, pluginId);
+}
+
+function bakDirPath(pluginsDir: string, pluginId: string): string {
+  return path.join(pluginsDir, `${pluginId}${BAK_SUFFIX}`);
+}
+
+function stagingDirPath(pluginsDir: string, pluginId: string): string {
+  return path.join(pluginsDir, `${pluginId}${STAGING_SUFFIX}`);
+}
+
+/**
+ * Read and lightly validate a plugin manifest from a directory. Returns
+ * null (never throws) if the directory doesn't exist or the manifest is
+ * missing/unreadable/unparsable/missing an id -- used for health checks
+ * where "not a valid plugin" just means "not usable", not an error.
+ */
+export async function readPluginManifestSafe(
+  dirPath: string
+): Promise<MinimalPluginManifest | null> {
+  try {
+    const manifestPath = path.join(dirPath, 'plugin.json');
+    if (!(await fs.pathExists(manifestPath))) {
+      return null;
+    }
+    const manifest = await fs.readJson(manifestPath);
+    if (!manifest || typeof manifest.id !== 'string' || !manifest.id) {
+      return null;
+    }
+    return manifest as MinimalPluginManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a candidate update bundle against the currently installed
+ * plugin. Refuses (throws PluginUpdateError) before any file on disk is
+ * touched when:
+ * - the plugin isn't currently installed (use Install instead of Update)
+ * - the new bundle has no readable plugin.json / id / valid semver version
+ * - the new bundle's id doesn't match the installed plugin's id
+ * - the new bundle's entry point is missing
+ * - the new bundle's version is not strictly greater than the installed one
+ */
+export async function validatePluginUpdateSource(
+  pluginsDir: string,
+  pluginId: string,
+  sourcePath: string
+): Promise<PluginUpdateValidation> {
+  const installedManifest = await readPluginManifestSafe(
+    pluginDirPath(pluginsDir, pluginId)
+  );
+  if (!installedManifest) {
+    throw new PluginUpdateError(
+      'NOT_INSTALLED',
+      `Plugin "${pluginId}" is not currently installed. Use Install instead of Update.`
+    );
+  }
+
+  const manifestPath = path.join(sourcePath, 'plugin.json');
+  if (!(await fs.pathExists(manifestPath))) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      'Selected folder does not contain a plugin.json manifest.'
+    );
+  }
+
+  let newManifest: MinimalPluginManifest;
+  try {
+    newManifest = await fs.readJson(manifestPath);
+  } catch (error: any) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      `plugin.json could not be parsed: ${error.message}`
+    );
+  }
+
+  if (!newManifest || !newManifest.id) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      'plugin.json is missing a required "id" field.'
+    );
+  }
+
+  if (newManifest.id !== pluginId) {
+    throw new PluginUpdateError(
+      'ID_MISMATCH',
+      `Plugin id mismatch: installed plugin is "${pluginId}", selected bundle is "${newManifest.id}". Refusing to update.`
+    );
+  }
+
+  if (!newManifest.version || !semver.valid(newManifest.version)) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      `plugin.json has an invalid "version" (must be semver): ${newManifest.version}`
+    );
+  }
+
+  if (!newManifest.entry || !newManifest.entry.main) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      'plugin.json is missing a required "entry.main" field.'
+    );
+  }
+
+  const entryPath = path.join(sourcePath, newManifest.entry.main);
+  if (!(await fs.pathExists(entryPath))) {
+    throw new PluginUpdateError(
+      'INVALID_MANIFEST',
+      `Selected bundle is missing its entry point: ${newManifest.entry.main}`
+    );
+  }
+
+  const currentVersion =
+    installedManifest.version && semver.valid(installedManifest.version)
+      ? installedManifest.version
+      : null;
+
+  if (currentVersion && !semver.gt(newManifest.version, currentVersion)) {
+    throw new PluginUpdateError(
+      'DOWNGRADE',
+      `Refusing to update: installed version ${currentVersion} is not older than selected version ${newManifest.version}.`
+    );
+  }
+
+  return { manifest: newManifest, currentVersion };
+}
+
+/**
+ * Filesystem operations `performPluginSwap` depends on, overridable for
+ * fault-injection tests (e.g. simulating a crash between the two renames
+ * that make up the swap). Defaults to the real fs-extra implementations.
+ */
+export interface SwapFsDeps {
+  rename?: (src: string, dest: string) => Promise<void>;
+}
+
+/**
+ * Perform the atomic swap. Assumes validation has already passed (or the
+ * caller has otherwise decided the swap should proceed).
+ *
+ * Sequence:
+ * 1. Copy sourcePath into a staging directory next to the plugin (same
+ *    volume as pluginsDir, so the swap renames below are atomic).
+ * 2. Remove any stale `.bak` directory from a previous run.
+ * 3. Rename the current plugin directory to `.bak` (atomic).
+ * 4. Rename the staging directory into place as the new plugin directory
+ *    (atomic). If this fails, the `.bak` is renamed back so the previous
+ *    version keeps working -- a failed update rolls back automatically.
+ *
+ * The `.bak` directory is intentionally NOT deleted here; per issue #182
+ * it's cleaned up by `recoverPluginsDirectory()` on the next successful
+ * app launch, so a working plugin (old or new) is always recoverable if
+ * the process is killed mid-swap.
+ */
+export async function performPluginSwap(
+  pluginsDir: string,
+  pluginId: string,
+  sourcePath: string,
+  deps: SwapFsDeps = {}
+): Promise<void> {
+  const rename = deps.rename ?? ((src: string, dest: string) => fs.rename(src, dest));
+  const pluginPath = pluginDirPath(pluginsDir, pluginId);
+  const bakPath = bakDirPath(pluginsDir, pluginId);
+  const stagingPath = stagingDirPath(pluginsDir, pluginId);
+
+  await fs.remove(stagingPath);
+  await fs.copy(sourcePath, stagingPath);
+
+  await fs.remove(bakPath);
+
+  const hadExisting = await fs.pathExists(pluginPath);
+  if (hadExisting) {
+    await rename(pluginPath, bakPath);
+  }
+
+  try {
+    await rename(stagingPath, pluginPath);
+  } catch (error) {
+    // Roll back: restore the previous version so we never leave the
+    // plugin directory missing or corrupt.
+    if (hadExisting) {
+      await fs.rename(bakPath, pluginPath).catch(() => {
+        /* best effort -- recoverPluginsDirectory() will retry on next launch */
+      });
+    }
+    throw error;
+  }
+}
+
+/**
+ * Validate then atomically swap in one call. Convenience wrapper used by
+ * the IPC handler.
+ */
+export async function updatePluginInPlace(
+  pluginsDir: string,
+  pluginId: string,
+  sourcePath: string
+): Promise<PluginUpdateValidation> {
+  const validation = await validatePluginUpdateSource(
+    pluginsDir,
+    pluginId,
+    sourcePath
+  );
+  await performPluginSwap(pluginsDir, pluginId, sourcePath);
+  return validation;
+}
+
+export interface RecoveryReport {
+  /** Plugin ids whose swap was completed (staging -> live) on this pass. */
+  completed: string[];
+  /** Plugin ids whose swap was rolled back (.bak -> live) on this pass. */
+  rolledBack: string[];
+  /** Plugin ids whose stale .bak was cleaned up after a healthy launch. */
+  cleaned: string[];
+}
+
+/**
+ * Repair any interrupted swap and clean up backups from completed ones.
+ * Meant to run once at app startup, before plugin discovery/loading.
+ *
+ * For every `<id>` with a `.bak` and/or `.staging` sibling directory:
+ * - live missing, staging healthy            -> complete the swap forward
+ * - live missing, staging missing/unhealthy, bak healthy -> roll back
+ * - live healthy, bak present                -> swap already succeeded on
+ *   a previous run; this is "the next successful launch" -- clean up .bak
+ *   (and any stale staging left over)
+ * - live unhealthy (corrupt), bak healthy     -> roll back
+ *
+ * Never throws; this must not block startup. Best-effort logging is left
+ * to the caller (this module doesn't depend on the app logger).
+ */
+export async function recoverPluginsDirectory(
+  pluginsDir: string
+): Promise<RecoveryReport> {
+  const report: RecoveryReport = { completed: [], rolledBack: [], cleaned: [] };
+
+  if (!(await fs.pathExists(pluginsDir))) {
+    return report;
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(pluginsDir, { withFileTypes: true });
+  } catch {
+    return report;
+  }
+
+  const pluginIds = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.endsWith(BAK_SUFFIX)) {
+      pluginIds.add(entry.name.slice(0, -BAK_SUFFIX.length));
+    } else if (entry.name.endsWith(STAGING_SUFFIX)) {
+      pluginIds.add(entry.name.slice(0, -STAGING_SUFFIX.length));
+    }
+  }
+
+  for (const pluginId of pluginIds) {
+    try {
+      await recoverOnePlugin(pluginsDir, pluginId, report);
+    } catch {
+      // Best-effort: leave this plugin's directories untouched rather than
+      // risk making things worse; a future launch can retry.
+    }
+  }
+
+  return report;
+}
+
+async function recoverOnePlugin(
+  pluginsDir: string,
+  pluginId: string,
+  report: RecoveryReport
+): Promise<void> {
+  const pluginPath = pluginDirPath(pluginsDir, pluginId);
+  const bakPath = bakDirPath(pluginsDir, pluginId);
+  const stagingPath = stagingDirPath(pluginsDir, pluginId);
+
+  const liveManifest = await readPluginManifestSafe(pluginPath);
+  const stagingManifest = await readPluginManifestSafe(stagingPath);
+  const bakManifest = await readPluginManifestSafe(bakPath);
+
+  if (!liveManifest) {
+    // Live plugin directory is missing or corrupt -- try to recover it.
+    if (stagingManifest) {
+      // Crash happened between "move old -> .bak" and "move staging -> live".
+      // Finish the forward swap; leave .bak for cleanup on the launch after this one.
+      await fs.remove(pluginPath).catch(() => {});
+      await fs.rename(stagingPath, pluginPath);
+      report.completed.push(pluginId);
+      return;
+    }
+    if (bakManifest) {
+      // No usable staging copy -- roll back to the last known-good version.
+      await fs.remove(pluginPath).catch(() => {});
+      await fs.rename(bakPath, pluginPath);
+      report.rolledBack.push(pluginId);
+      return;
+    }
+    // Neither staging nor bak is usable; nothing safe to do.
+    return;
+  }
+
+  // Live plugin directory is healthy.
+  if (bakManifest) {
+    // The swap that produced this live directory already succeeded (on this
+    // run or an earlier one) -- this is "the next successful launch".
+    await fs.remove(bakPath).catch(() => {});
+    report.cleaned.push(pluginId);
+  } else if (await fs.pathExists(bakPath)) {
+    // Unhealthy leftover .bak (shouldn't normally happen) -- clear it too.
+    await fs.remove(bakPath).catch(() => {});
+    report.cleaned.push(pluginId);
+  }
+
+  if (stagingManifest || (await fs.pathExists(stagingPath))) {
+    // Stale staging dir from a validation that never reached the swap, or a
+    // swap that already completed -- safe to discard either way since live
+    // is healthy.
+    await fs.remove(stagingPath).catch(() => {});
+  }
+}

--- a/src/renderer/views/PluginsLauncher.ts
+++ b/src/renderer/views/PluginsLauncher.ts
@@ -494,7 +494,7 @@ export class PluginsLauncher implements View {
               </div>
             </div>
             <div style="display: flex; gap: 8px; flex-shrink: 0; flex-wrap: wrap;">
-              <button class="plugin-folder-btn" data-plugin-id="${this.escapeHtml(plugin.id)}" title="Update from a local plugin folder" style="
+              <button class="plugin-folder-btn" data-plugin-id="${this.escapeHtml(plugin.id)}" title="Update this plugin in place from a local plugin folder" style="
                 background: var(--bg-quaternary, #3a3a3a);
                 color: var(--text-primary, #fff);
                 border: none;
@@ -502,7 +502,7 @@ export class PluginsLauncher implements View {
                 border-radius: 6px;
                 cursor: pointer;
                 font-size: 13px;
-              ">From Folder</button>
+              ">Update…</button>
               <button class="plugin-open-btn" data-plugin-id="${this.escapeHtml(plugin.id)}" title="Open plugin folder in file explorer" style="
                 background: var(--bg-quaternary, #3a3a3a);
                 color: var(--text-primary, #fff);
@@ -529,7 +529,12 @@ export class PluginsLauncher implements View {
         container.appendChild(card);
       }
 
-      // Add event listeners for "Update from Folder" buttons
+      // Add event listeners for "Update…" buttons.
+      // Flow lives in the main process (src/main/handlers/plugin-update-handlers.ts):
+      // pick folder -> validate (id + strictly-greater semver, refused before
+      // any file is touched) -> native confirm (current -> new version) ->
+      // atomic swap with .bak rollback -> native "Restart Now / Later" prompt.
+      // This handler just reflects whatever the main process reports back.
       container.querySelectorAll('.plugin-folder-btn').forEach(btn => {
         btn.addEventListener('click', async (e) => {
           const pluginId = (e.target as HTMLElement).getAttribute('data-plugin-id');
@@ -544,29 +549,46 @@ export class PluginsLauncher implements View {
           if (statusEl) {
             statusEl.style.display = 'block';
             statusEl.style.color = 'var(--text-secondary, #888)';
-            statusEl.textContent = 'Select the plugin folder containing plugin.json...';
+            statusEl.textContent = 'Select the updated plugin folder containing plugin.json...';
           }
 
           try {
             const result = await (window as any).electronAPI.plugins.updateFromFolder(pluginId);
+
             if (result.cancelled) {
               button.disabled = false;
-              button.textContent = 'Update from Folder';
+              button.textContent = 'Update…';
               if (statusEl) statusEl.style.display = 'none';
               return;
             }
+
+            if (result.refused) {
+              // Refused before any file was touched: id mismatch, downgrade,
+              // or an invalid bundle. Nothing changed on disk.
+              if (statusEl) {
+                statusEl.style.color = 'var(--danger-color, #d32f2f)';
+                statusEl.textContent = result.message || 'Update refused.';
+              }
+              button.disabled = false;
+              button.textContent = 'Update…';
+              return;
+            }
+
             if (statusEl) {
               statusEl.style.color = 'var(--success-color, #4caf50)';
-              statusEl.textContent = result.message || 'Update successful! Restart FictionLab to apply changes.';
+              statusEl.textContent = result.message || 'Update successful.';
             }
-            button.textContent = 'Updated';
+            button.textContent = result.restarting ? 'Restarting…' : 'Updated';
+            // Leave the button disabled: either FictionLab is about to
+            // relaunch, or the swap is done and re-running it against the
+            // now-current version would just be refused as "not an upgrade".
           } catch (error: any) {
             if (statusEl) {
               statusEl.style.color = 'var(--danger-color, #d32f2f)';
               statusEl.textContent = `Update failed: ${error.message}`;
             }
             button.disabled = false;
-            button.textContent = 'Update from Folder';
+            button.textContent = 'Update…';
           }
         });
       });


### PR DESCRIPTION
## Summary

Implements #182: updating an installed plugin now goes through the existing "Manage Plugins" dialog's **Update…** button (previously "From Folder") as a single flow — pick the updated plugin folder, confirm the version bump, one prompted restart. No uninstall, no double restart.

- **New pure fs module** `src/main/plugin-update-swap.ts` (no Electron imports, so it's directly unit-testable): `validatePluginUpdateSource` (id match + strictly-greater semver, refuses before touching any file), `performPluginSwap` (copy to staging → rename old→`.bak` → rename staging→live, with automatic rollback if the final rename fails), `updatePluginInPlace` (validate+swap in one call), and `recoverPluginsDirectory` (startup repair pass: finishes an interrupted swap, rolls back to `.bak` if the new copy isn't usable, and cleans up a stale `.bak` on the next successful launch).
- **`src/main/handlers/plugin-update-handlers.ts`**: `plugin:update-from-folder` now runs validate → native confirm dialog (current → new version) → atomic swap → native "Restart Now / Later" prompt, instead of the old ad-hoc `.backup-<timestamp>` copy + attempted in-process hot reload. Refused updates return `{ refused: true, code, message }` without touching any files. `plugin:list-installed`'s directory scan skips `.bak`/`.staging` so they never show up as separate plugins.
- **`src/main/plugin-loader.ts`**: `discoverPlugins()` also skips `.bak`/`.staging`/`.backup-*` directories — they're full copies of a real plugin sharing its id, so without this guard a crash-window leftover would surface as a duplicate-id "phantom" plugin.
- **`src/main/plugin-manager.ts`**: runs `recoverPluginsDirectory()` before plugin discovery on every launch.
- **`src/renderer/views/PluginsLauncher.ts`**: relabeled the existing folder-update button to "Update…" and updated its status handling for the new refused/restarting result shape. Same handler wiring as before — no new UI subsystem.

## v1 boundaries honored (per issue)

- No hot reload of main-process plugin code — the old handler's `pluginManager.reloadPlugin()` call is removed; a successful swap only changes files on disk, the running process keeps whatever it already loaded until restart.
- At most one prompted restart, no uninstall step.
- Downgrade or id-mismatch refused before any file is touched (`PluginUpdateError` with a `code`).
- Crash mid-swap always leaves a working plugin (old or new), never a corrupt half — see `recoverPluginsDirectory()` and its tests.
- v2 candidates (GitHub-releases feed check, renderer-only hot-swap) noted in the module doc comment, not built.

## Test coverage

`src/main/__tests__/plugin-update-swap.test.ts` — 20 tests against real temp directories (no mocked fs-extra), covering:
- validation refusals (not installed, id mismatch, downgrade, same-version, invalid semver, missing entry point, missing plugin.json) and that nothing is touched on refusal
- the atomic swap replacing contents and leaving a `.bak`
- rollback when the final rename fails (fault-injected via a `rename` dependency-injection seam on `performPluginSwap`, not by monkeypatching fs-extra's frozen exports)
- fresh install with no pre-existing directory (no `.bak` created)
- recovery: no-op when healthy, completing an interrupted forward swap, rolling back when there's no usable staging copy, rolling back when live is corrupt but `.bak` is healthy, discarding a stale staging dir, and safety on a missing/empty plugins directory

## Gates

- `npm run build` — clean, no errors.
- `npx jest` — **123 failed / 193 passed / 3 skipped** (was 123 failed / 173 passed / 3 skipped before this branch — the pre-existing baseline from #176 is unchanged; all 20 new tests pass, zero new failures).

## Manual verification still needed

I can't open the Electron GUI in this environment (`ELECTRON_RUN_AS_NODE=1`), so someone needs to manually exercise, in a real FictionLab build:
1. Open Manage Plugins → Update… on an installed plugin, pick a folder with a higher version → confirm dialog shows current → new version → swap → Restart Now/Later prompt appears and both buttons work.
2. Downgrade or wrong-id folder is refused with a clear message and the installed plugin is untouched.
3. Kill the app mid-update (or simulate via the `.bak`/`.staging` directory states covered by the unit tests) and confirm the next launch still loads a working plugin.
4. Plugins list shows the new version after the restart.

## Note on scope

Another branch (issue #181) is concurrently editing `src/renderer/views/KanbanViewReact.tsx` and `src/renderer/components/kanban/*`. This PR does not touch any kanban files — diff surface is limited to plugin update/loader/manager code and the existing Manage Plugins dialog markup in `PluginsLauncher.ts`.

`package-lock.json` has unrelated `npm install`-generated `"peer": true` metadata churn (different local npm version) that was left uncommitted to keep this diff focused.