### PR TITLE
fix: renderer boot crash from dual-compiled shared type modules (#186)

### DIFF
--- a/src/main/__tests__/plugin-loader-backup-dir-skip.test.ts
+++ b/src/main/__tests__/plugin-loader-backup-dir-skip.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for the "stale backup plugin shadows the real install"
+ * failure mode reported alongside the renderer boot crash: a machine whose
+ * `%APPDATA%/fictionlab/plugins` directory contained both the real
+ * `fictionlab-workflow` install and a leftover
+ * `fictionlab-workflow.backup-<timestamp>` directory (the old, pre-#182
+ * ad-hoc backup naming, predating `plugin-update-swap.ts`'s `.bak`/
+ * `.staging` convention) reportedly had discovery pick the STALE backup
+ * over the real install.
+ *
+ * Status as of this test: `PluginLoader.discoverPlugins()` (src/main/
+ * plugin-loader.ts) already skips `.bak`, `.staging`, AND the older
+ * `.backup-<timestamp>` naming -- see the guard added in commit 3577e6a
+ * ("feat(plugins): wire update-in-place into the Update button and startup
+ * (#182)"), which predates and is unrelated to the renderer-boot-crash fix
+ * in this same PR. This test did not exist before; it locks in that
+ * already-correct behavior with a concrete repro of the exact reported
+ * layout (a `fictionlab-workflow` dir plus a `fictionlab-workflow.backup-
+ * 1769903090229` sibling) so a future change can't silently regress it.
+ *
+ * If this test ever fails, the failure is in `discoverPlugins()`'s skip
+ * list, not in the renderer boot path fixed elsewhere in this PR.
+ */
+
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => (global as any).__testUserDataDir),
+    getVersion: jest.fn(() => '1.0.0'),
+  },
+}));
+
+// Imported after the electron mock so the constructor's `app.getPath('userData')`
+// call resolves to our temp directory.
+import { PluginLoader } from '../plugin-loader';
+
+function writeManifest(dir: string, id: string, version: string): void {
+  fs.ensureDirSync(dir);
+  fs.writeJsonSync(path.join(dir, 'plugin.json'), {
+    id,
+    name: id,
+    version,
+    description: 'test fixture',
+    author: 'test',
+    fictionLabVersion: '^1.0.0',
+    pluginType: 'feature',
+    entry: { main: 'index.js' },
+    permissions: [],
+  });
+  fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = {};');
+}
+
+describe('PluginLoader.discoverPlugins skips update-swap bookkeeping directories', () => {
+  let tmpRoot: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fictionlab-plugin-discovery-'));
+    (global as any).__testUserDataDir = tmpRoot;
+    pluginsDir = path.join(tmpRoot, 'plugins');
+    fs.ensureDirSync(pluginsDir);
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpRoot);
+    delete (global as any).__testUserDataDir;
+  });
+
+  it('discovers the real install and ignores a stale `.backup-<timestamp>` sibling (the exact reported layout)', async () => {
+    writeManifest(path.join(pluginsDir, 'fictionlab-workflow'), 'fictionlab-workflow', '1.2.0');
+    writeManifest(
+      path.join(pluginsDir, 'fictionlab-workflow.backup-1769903090229'),
+      'fictionlab-workflow',
+      '1.1.0'
+    );
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].manifest.id).toBe('fictionlab-workflow');
+    expect(results[0].manifest.version).toBe('1.2.0');
+    expect(results[0].path).not.toMatch(/\.backup-/);
+  });
+
+  it('also ignores `.bak` and `.staging` swap-bookkeeping directories', async () => {
+    writeManifest(path.join(pluginsDir, 'fictionlab-kanban'), 'fictionlab-kanban', '2.0.0');
+    writeManifest(path.join(pluginsDir, 'fictionlab-kanban.bak'), 'fictionlab-kanban', '1.0.0');
+    writeManifest(path.join(pluginsDir, 'fictionlab-kanban.staging'), 'fictionlab-kanban', '2.1.0');
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].manifest.version).toBe('2.0.0');
+  });
+
+  it('does not discover a plugin at all when only a backup copy exists (no phantom fallback)', async () => {
+    writeManifest(
+      path.join(pluginsDir, 'fictionlab-workflow.backup-1769903090229'),
+      'fictionlab-workflow',
+      '1.1.0'
+    );
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/src/main/__tests__/renderer-build-module-format.test.ts
+++ b/src/main/__tests__/renderer-build-module-format.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression test for the renderer boot crash (blank blue window, empty
+ * sidebar, "no components mount"):
+ *
+ *   Uncaught SyntaxError: The requested module '../../../types/kanban.js'
+ *   does not provide an export named 'PRIORITY_COLORS'
+ *     (at KanbanCardTile.tsx:10:10)
+ *
+ * Root cause: `npm run build` runs two separate `tsc` programs into the SAME
+ * `dist/` output directory:
+ *   - tsconfig.renderer.json (module: ES2020) -- compiles src/renderer/**,
+ *     which transitively pulls in shared `src/types/*.ts` files and emits
+ *     them as real ES modules (`export const X = ...`), because that's what
+ *     the renderer needs: it's loaded by Chromium as literal
+ *     `<script type="module">` / `import` graphs, no bundler.
+ *   - tsconfig.main.json (module: commonjs) -- compiles src/main/**,
+ *     src/preload/**, src/services/**, and (transitively) whichever
+ *     `src/types/*.ts` files THOSE actually import by value. It emits
+ *     CommonJS (`exports.X = ...`).
+ *
+ * Both passes write to `dist/types/<name>.js` for any shared type file
+ * consumed by both sides, and the build script runs main.json SECOND, so its
+ * CommonJs output always wins on disk. A real browser ES module loader (no
+ * bundler, no cjs-module-lexer interop like Node's `require`/`import` has)
+ * then finds zero `export` bindings in that file and throws a link-time
+ * SyntaxError before any renderer code -- including the vanilla-DOM sidebar
+ * -- ever executes. `tsc` typechecks happily on both passes individually
+ * (there's no missing export in the source), so this class of bug is
+ * invisible to typechecking; it only shows up in the built artifact.
+ *
+ * `src/types/kanban.ts` is the first shared type file with runtime
+ * (non-type-only) exports consumed by value from the renderer
+ * (`CARD_STATUSES`, `STATUS_LABELS`, `PRIORITY_COLORS`) that main/preload/
+ * services never reference at all -- so the fix removed the blanket
+ * `"src/types/**\/*"` entry from tsconfig.main.json's `include` (it was
+ * force-compiling files main never needed, per commit c2a5440) and left
+ * kanban.ts to transitive resolution, which only tsconfig.renderer.json ever
+ * triggers for it.
+ *
+ * `src/types/identity.ts`'s `DEFAULT_CURRENT_USER` IS needed by value on
+ * both sides (src/main/app-settings.ts and, until this fix,
+ * KanbanViewReact.tsx), so it can never safely be "renderer wins" or "main
+ * wins" by include-list surgery alone -- the renderer instead stopped
+ * importing it by value (kept only the erasure-safe `import type
+ * { CurrentUserSetting }`) and defines its own transient placeholder.
+ *
+ * This test builds the project (if `dist/` isn't already fresh) and asserts
+ * the built artifacts have the module format each runtime actually needs.
+ * It fails on the pre-fix source (kanban.ts ends up CommonJS in dist/,
+ * because main.json's blanket types include recompiles it last) and passes
+ * after.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const repoRoot = path.join(__dirname, '..', '..', '..');
+const distTypesKanban = path.join(repoRoot, 'dist', 'types', 'kanban.js');
+const distTypesIdentity = path.join(repoRoot, 'dist', 'types', 'identity.js');
+const distKanbanCardTile = path.join(
+  repoRoot,
+  'dist',
+  'renderer',
+  'components',
+  'kanban',
+  'KanbanCardTile.js'
+);
+const distKanbanViewReact = path.join(
+  repoRoot,
+  'dist',
+  'renderer',
+  'views',
+  'KanbanViewReact.js'
+);
+const distAppSettings = path.join(repoRoot, 'dist', 'main', 'app-settings.js');
+
+function ensureBuilt(): void {
+  if (fs.existsSync(distTypesKanban) && fs.existsSync(distAppSettings)) {
+    return;
+  }
+  execSync('npm run build', { cwd: repoRoot, stdio: 'inherit' });
+}
+
+describe('renderer/main shared-type build output (GH issue: renderer boot crash)', () => {
+  beforeAll(() => {
+    ensureBuilt();
+  }, 180_000);
+
+  it('compiles dist/types/kanban.js as a real ES module (renderer-only consumer)', () => {
+    const source = fs.readFileSync(distTypesKanban, 'utf8');
+
+    // Real ESM: has literal `export const` bindings the browser's module
+    // loader can see statically.
+    expect(source).toMatch(/export const PRIORITY_COLORS/);
+    expect(source).toMatch(/export const CARD_STATUSES/);
+    expect(source).toMatch(/export const STATUS_LABELS/);
+
+    // Must NOT have been clobbered by a later CommonJS compile pass.
+    expect(source).not.toMatch(/exports\.PRIORITY_COLORS/);
+    expect(source).not.toMatch(/Object\.defineProperty\(exports, "__esModule"/);
+  });
+
+  it('compiles dist/types/identity.js as CommonJS (main-process consumer)', () => {
+    // src/main/app-settings.ts does `require('../types/identity')` at
+    // runtime under Node -- it needs the CommonJS emit, unlike kanban.ts.
+    const source = fs.readFileSync(distTypesIdentity, 'utf8');
+    expect(source).toMatch(/exports\.DEFAULT_CURRENT_USER/);
+  });
+
+  it('dist/main/app-settings.js can still require dist/types/identity.js', () => {
+    // Guards against "fix" #1 (narrowing tsconfig.main.json's include)
+    // accidentally breaking the main process' own real need for this file.
+    expect(() => {
+      delete require.cache[require.resolve(distAppSettings)];
+      require(distAppSettings);
+    }).not.toThrow();
+  });
+
+  it('the compiled KanbanCardTile.js imports PRIORITY_COLORS from the (now ESM-safe) kanban.js', () => {
+    const source = fs.readFileSync(distKanbanCardTile, 'utf8');
+    expect(source).toMatch(
+      /import\s*\{\s*PRIORITY_COLORS\s*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/types\/kanban\.js['"]/
+    );
+  });
+
+  it('the compiled KanbanViewReact.js no longer imports a runtime value from identity.js', () => {
+    // The renderer must never import a *value* (only `import type`, which
+    // tsc erases entirely) from a shared types file that main also needs by
+    // value in CommonJS form -- there is no way to make one dist/types/*.js
+    // path satisfy both a browser ES module loader and Node's `require()`
+    // at the same time.
+    const source = fs.readFileSync(distKanbanViewReact, 'utf8');
+    expect(source).not.toMatch(/from ['"]\.\.\/\.\.\/types\/identity\.js['"]/);
+  });
+});

--- a/src/renderer/views/KanbanViewReact.tsx
+++ b/src/renderer/views/KanbanViewReact.tsx
@@ -34,11 +34,25 @@ import type {
 } from '../../types/kanban.js';
 import type { ActiveWorkflowInstance, WorkflowUpdate } from '../../types/workflow.js';
 import type { CurrentUserSetting } from '../../types/identity.js';
-import { DEFAULT_CURRENT_USER } from '../../types/identity.js';
 
 const KANBAN_PLUGIN = 'plugin:fictionlab-kanban:';
 const BOARD_KEY = 'dev-backlog';
 const POLL_INTERVAL_MS = 5000;
+
+// Transient placeholder for the brief window before loadCurrentUser() resolves
+// the real value via `app-settings:get-current-user`. Deliberately NOT the
+// shared `DEFAULT_CURRENT_USER` value from src/types/identity.ts -- that
+// module has a real runtime consumer on the main-process side too
+// (src/main/app-settings.ts), which needs it compiled as CommonJS, while this
+// renderer file is loaded as a real browser ES module. Both tsc project
+// configs (tsconfig.renderer.json, tsconfig.main.json) emit into the same
+// dist/types/ output path, so whichever compiles last on disk wins the
+// format war -- importing this by VALUE from the renderer is what caused
+// "does not provide an export named 'DEFAULT_CURRENT_USER'" the same way
+// KanbanCardTile.tsx's `PRIORITY_COLORS` import broke (see GH issue for the
+// renderer boot crash). The `CurrentUserSetting` type import above is
+// erasure-safe (no runtime import is emitted for `import type`) and stays.
+const UNINITIALIZED_CURRENT_USER: CurrentUserSetting = { id: '', displayName: '...' };
 
 let activeKanbanAppActions: { refresh: () => void; focusQuickAdd: () => void } | null = null;
 
@@ -85,7 +99,7 @@ const KanbanApp: React.FC = () => {
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [workflowPhases, setWorkflowPhases] = useState<Map<string, ActiveWorkflowInstance>>(new Map());
-  const [currentUser, setCurrentUser] = useState<CurrentUserSetting>(DEFAULT_CURRENT_USER);
+  const [currentUser, setCurrentUser] = useState<CurrentUserSetting>(UNINITIALIZED_CURRENT_USER);
   const [identities, setIdentities] = useState<KanbanIdentity[]>([]);
   const [identityEditorOpen, setIdentityEditorOpen] = useState(false);
   const [identityIdDraft, setIdentityIdDraft] = useState('');

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -7,8 +7,7 @@
   "include": [
     "src/main/**/*",
     "src/preload/**/*",
-    "src/services/**/*",
-    "src/types/**/*"
+    "src/services/**/*"
   ],
   "exclude": [
     "**/__tests__/**",


### PR DESCRIPTION
## Summary

Fixes #186 -- the live "blank blue window, empty sidebar, no components
mount" incident on fresh/updated `develop` installs.

- **Root cause**: `npm run build` runs `tsc -p tsconfig.renderer.json` then
  `tsc -p tsconfig.main.json` into the *same* `dist/` directory. The
  renderer pass compiles shared `src/types/*.ts` files as real ES modules
  (needed -- the renderer has no bundler, Chromium loads it as literal
  `import` graphs). The main pass, because of a blanket `"src/types/**/*"`
  entry in `tsconfig.main.json`'s `include` (added in `c2a5440`,
  predates #180/#183/#184 by ~7 months -- this is a pre-existing
  build-pipeline defect, not a merge conflict between those PRs), then
  recompiles the *same files* to CommonJS and clobbers the renderer's ESM
  copies on disk. `tsc` typechecks both passes cleanly (no missing export
  in source), so this is invisible to typechecking -- it only breaks in the
  built artifact, and only once a renderer file imports a runtime value
  (not just a type) from `src/types/*`. `kanban.ts` (#180) and
  `identity.ts` (#183) are the first shared type files with real
  by-value renderer consumers, so they're the first to trip it.
- **Fix 1** (`tsconfig.main.json`): drop the blanket `src/types/**/*`
  include. Main/preload/services still transitively compile whatever they
  actually import by value; `kanban.ts` is never referenced by any of them,
  so it's now compiled exactly once (ESM, by the renderer pass) and never
  clobbered.
- **Fix 2** (`KanbanViewReact.tsx`): stop importing `DEFAULT_CURRENT_USER`
  *by value* from `identity.ts` -- `src/main/app-settings.ts` also needs
  that file's runtime value in CommonJS form, so it can never safely be
  ESM-only the way `kanban.ts` now is. Kept the erasure-safe
  `import type { CurrentUserSetting }` and used a local placeholder.

Also includes (separate commit, cherry-pickable): a regression test for the
*other* symptom described alongside this incident -- a plugins directory
with both a real `fictionlab-workflow` install and a stale
`fictionlab-workflow.backup-<timestamp>` copy, where the main log showed
discovery loading from the backup path. **That is already fixed** in this
repo (`PluginLoader.discoverPlugins()` has skipped `.bak`/`.staging`/
`.backup-<timestamp>` directories since commit `3577e6a`, merged ahead of
this branch point) -- no code change was needed, only a test locking in the
current (correct) behavior against the exact reported directory layout.

Filed #187 as a follow-up: neither CI workflow (`build.yml`/`release.yml`)
runs the test suite at all, so even a red test for this exact bug wouldn't
currently block packaging/release.

## Root cause, file:line

- `tsconfig.main.json` (pre-fix line 11): blanket `"src/types/**/*"` in
  `include`, forcing every shared type file to also compile as CommonJS on
  the second (main-process) `tsc` pass, clobbering `dist/types/kanban.js`'s
  ESM output from the first (renderer) pass.
- `src/renderer/components/kanban/KanbanCardTile.tsx:10` --
  `import { PRIORITY_COLORS } from '../../../types/kanban.js';` -- the
  by-value import that broke once `dist/types/kanban.js` became CommonJS.
- `src/renderer/views/KanbanViewReact.tsx:37` (pre-fix) --
  `import { DEFAULT_CURRENT_USER } from '../../types/identity.js';` -- same
  bug class, latent (identity.ts's CJS form is unavoidable since
  `src/main/app-settings.ts:20` needs it), fixed by dropping the by-value
  import.

## Test plan

- [x] `npm install`
- [x] `rm -rf dist && npm run build` -- clean, no tsc errors
- [x] Confirmed the reported error reproduces from source: reverted the fix,
      rebuilt, and `dist/types/kanban.js` compiled to CommonJS
      (`Object.defineProperty(exports, "__esModule"...)`, no
      `export const PRIORITY_COLORS`) -- exactly the reported console error's
      cause.
- [x] New test `src/main/__tests__/renderer-build-module-format.test.ts`:
      2 of 5 assertions FAIL against the pre-fix source, all 5 PASS after
      the fix.
- [x] New test `src/main/__tests__/plugin-loader-backup-dir-skip.test.ts`:
      3/3 pass against current `develop` (confirms the backup-shadowing bug
      is already fixed, unrelated to this PR's changes).
- [x] `npx jest` (full suite): 123 failed / 198 (then 201 with both new
      files) passed -- **identical failure count to the pre-existing
      baseline (issue #176, ~123)**, only new tests added, all passing. No
      new failures.
- [ ] **Could not verify visually** -- I cannot open the Electron GUI
      (`ELECTRON_RUN_AS_NODE=1` in this environment blocks the actual
      window). Rebecca: please do the visual pass (launch the packaged app
      with only `fictionlab-workflow` installed and `fictionlab-kanban`
      absent, confirm the dashboard/sidebar render normally instead of a
      blank blue window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
