### PR TITLE
fix: mock child_process in repository-manager tests to stop real git clone hangs

### DIFF
--- a/src/main/repository-manager.ts
+++ b/src/main/repository-manager.ts
@@ -609,8 +609,13 @@ export class RepositoryManager {
 
   /**
    * Validate URL format
+   *
+   * Public so tests can assert validation behavior directly without going
+   * through cloneRepository() -- which would otherwise spawn a real `git`
+   * process against the (possibly network-reachable) URL just to prove the
+   * format check passed. See tests/main/repository-manager.test.ts (#185).
    */
-  private validateUrl(url: string): void {
+  public validateUrl(url: string): void {
     if (!url || url.trim().length === 0) {
       throw new RepositoryError(
         RepositoryErrorType.INVALID_URL,

--- a/tests/main/repository-manager.test.ts
+++ b/tests/main/repository-manager.test.ts
@@ -14,6 +14,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { EventEmitter } from 'events';
 import { RepositoryManager } from '../../src/main/repository-manager';
 import {
   RepositoryError,
@@ -21,6 +22,62 @@ import {
   CloneOptions,
   RepoStatus,
 } from '../../src/types/repository';
+
+/**
+ * Issue #185: `cloneRepository()` shells out to a real `git` binary via
+ * `child_process.spawn`. Several tests below call it with syntactically
+ * valid but non-existent remote URLs (github.com/gitlab.com placeholders).
+ * Unmocked, that spawns a real `git clone` against those hosts -- against
+ * gitlab.com in particular, Git Credential Manager pops an interactive
+ * "Connect to GitLab" OS dialog with nothing in the test to dismiss it,
+ * hanging the run indefinitely and leaving orphaned git/GCM processes.
+ *
+ * Mocking `spawn` here means no test in this file ever touches the network
+ * or spawns a real `git clone`. `exec` is mocked too (used for the
+ * `git --version` / disk-space prerequisite checks that run before every
+ * clone attempt) so no real `git` process is spawned at all. Everything
+ * else -- including `execSync`, used only for an unrelated one-time Docker
+ * CLI PATH lookup -- is left as the real implementation via requireActual.
+ *
+ * The mocked failure is phrased as an authentication error so it classifies
+ * as a non-retryable error (see ErrorHandler/RetryStrategy); a message that
+ * classified as retryable would make RepositoryManager's built-in retry
+ * logic sleep for several real seconds per test.
+ */
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  exec: jest.fn(
+    (
+      _command: string,
+      optionsOrCallback: any,
+      callback?: (error: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => {
+      const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+      process.nextTick(() => cb?.(null, { stdout: 'git version 2.42.0', stderr: '' }));
+    }
+  ),
+  spawn: jest.fn(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: jest.Mock;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = jest.fn();
+
+    // Fail fast on the next tick -- no real process, no network, no prompt.
+    process.nextTick(() => {
+      child.stderr.emit(
+        'data',
+        Buffer.from("fatal: Authentication failed (mocked - no network access in tests)\n")
+      );
+      child.emit('close', 128);
+    });
+
+    return child;
+  }),
+}));
 
 describe('RepositoryManager', () => {
   let repoManager: RepositoryManager;
@@ -56,39 +113,31 @@ describe('RepositoryManager', () => {
       }
     });
 
-    test('should accept valid HTTPS URLs', async () => {
+    test('should accept valid HTTPS URLs', () => {
       const validUrls = [
         'https://github.com/user/repo.git',
         'http://github.com/user/repo.git',
         'https://gitlab.com/user/repo.git',
       ];
 
-      // Note: This test validates URL format only, actual cloning would require network
+      // Assert URL validation alone passes. Deliberately does NOT call
+      // cloneRepository() -- even though these hosts/paths don't resolve to
+      // a real repo, they are well-formed URLs that would sail past
+      // validateUrl() into a real `git clone` subprocess (see the
+      // child_process mock comment above for why that hung the suite).
       for (const url of validUrls) {
-        // This will fail at the Git check or network stage, but URL validation should pass
-        try {
-          await repoManager.cloneRepository(url, path.join(testDir, 'repo'));
-        } catch (error) {
-          // URL validation should pass, error should be from Git or network
-          expect(error).not.toBeInstanceOf(RepositoryError);
-        }
+        expect(() => repoManager.validateUrl(url)).not.toThrow();
       }
     });
 
-    test('should accept valid SSH URLs', async () => {
+    test('should accept valid SSH URLs', () => {
       const validUrls = [
         'git@github.com:user/repo.git',
         'git@gitlab.com:user/repo.git',
       ];
 
       for (const url of validUrls) {
-        // This will fail at the Git check or network stage, but URL validation should pass
-        try {
-          await repoManager.cloneRepository(url, path.join(testDir, 'repo'));
-        } catch (error) {
-          // URL validation should pass, error should be from Git or network
-          expect(error).not.toBeInstanceOf(RepositoryError);
-        }
+        expect(() => repoManager.validateUrl(url)).not.toThrow();
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes #185. `RepositoryManager.cloneRepository()` (`src/main/repository-manager.ts`) shells out to a real `git` binary via `child_process.spawn`/`exec`. Two tests in `tests/main/repository-manager.test.ts` called it with syntactically valid but non-existent placeholder URLs (`github.com`/`gitlab.com`), which sailed past `validateUrl()` into a real `git clone` against those hosts. Against `gitlab.com` in particular, Git Credential Manager popped an interactive "Connect to GitLab" OS dialog with nothing in the test to dismiss it, hanging the run indefinitely and leaving orphaned `git`/GCM processes behind — worse when multiple worktrees ran the suite at the same time.

**Changes:**
- Made `RepositoryManager.validateUrl()` `public` so `should accept valid HTTPS URLs` / `should accept valid SSH URLs` can assert validation passes directly, without ever invoking `cloneRepository()` (and therefore never reaching the real git subprocess).
- Added a `jest.mock('child_process', ...)` in the test file (mocking `spawn` + `exec`, real `execSync`/everything else via `requireActual`) so every *other* test in the file that calls `cloneRepository()` with a plausible-looking URL also can't reach a real git process or the network. The mocked failure is phrased as an auth error so it classifies as non-retryable — otherwise `RepositoryManager`'s built-in retry/backoff would add several seconds of real `setTimeout` sleep per test.

## Acceptance criteria (from #185)

- [x] `should accept valid HTTPS URLs` / `should accept valid SSH URLs` still correctly assert well-formed URLs pass validation (now via a direct `validateUrl()` call), and `should validate URL format` is untouched (still rejects malformed URLs the same way it always did).
- [x] No test in `tests/main/repository-manager.test.ts` calls `cloneRepository()` (or `checkoutVersion`/`sparseCheckout`) against a real, unmocked URL — confirmed no other file in the repo calls `cloneRepository(` either (`grep -rl "cloneRepository(" **/*.test.ts` → only this file).
- [x] Verified empirically: ran the suite with `GIT_TERMINAL_PROMPT=0`/`GCM_INTERACTIVE=never` and confirmed via `Get-Process` that no `git`/credential-manager process was spawned or left running afterward.
- [x] `npm run build` (tsc, both projects) passes clean.

## Caveats / out of scope (tracked under #176)

Running `tests/main/repository-manager.test.ts` still shows 6 pre-existing failures unrelated to this hang bug (confirmed by reverting this fix and re-running just those tests against unmodified `develop` — identical failures reproduce):
- `should validate URL format`, `should reject empty target path`, and both `checkoutVersion` "should reject" tests time out at Jest's 5000ms default. Root cause: `ErrorHandler.classify()` has no registry entry for several `BuildErrorCode`s (e.g. validation-type errors), so it falls back to `SYSTEM_UNKNOWN_ERROR`, whose `retryBehavior` is `RETRY` — so `RetryStrategy` retries even permanently-failing synchronous validation errors 3x with real exponential-backoff sleeps, exceeding Jest's timeout. This never reaches `spawn`/`exec` at all, so it's orthogonal to the network/credential-prompt bug this PR fixes.
- `should reject if target path already exists` and `should handle network errors gracefully` expect `instanceof RepositoryError`, but `executeClone()`'s catch block funnels every error (including `RepositoryError`) through `ErrorHandler.classify()`, which returns a `BuildError` (a sibling class, not a subclass of `RepositoryError`) for anything that isn't already a `BuildError`. Pre-existing type-identity mismatch, not introduced here.

Left both alone per the issue's explicit scope note (don't fix unrelated pre-existing failures — issue #176 tracks the broader 123-failure triage).

## Test plan

- [x] `GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never npx jest --selectProjects main --testPathPattern="repository-manager\.test\.ts"` — runs to completion (~23s) with no hang.
- [x] Confirmed no orphaned `git`/credential-manager process via `Get-Process` after the run.
- [x] `npm run build` passes.
- [x] `grep -rl "cloneRepository(" **/*.test.ts` confirms no other test file needs the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)