### PR TITLE
fix: Active Workflows canvas never auto-refreshes for externally-driven workflows (#178)

### DIFF
--- a/src/main/handlers/workflow-handlers.ts
+++ b/src/main/handlers/workflow-handlers.ts
@@ -737,6 +737,24 @@ export function registerWorkflowHandlers() {
     });
   }
 
+  /**
+   * Surface a workflow:list-active failure to every renderer window.
+   *
+   * Without this, a broken/never-started workflow-manager-server child
+   * process (e.g. its repo hasn't been cloned into userData/repositories
+   * yet on a fresh install, or DATABASE_URL is unreachable) is invisible:
+   * listActiveWorkflows() and this handler both swallow the error and
+   * resolve to [], which looks identical to "no active workflows" in the
+   * UI (see issue #178). Broadcasting lets the renderer distinguish
+   * "genuinely idle" from "can't reach the workflow server" instead of
+   * silently showing a stale/empty list forever.
+   */
+  function broadcastListActiveError(message: string) {
+    BrowserWindow.getAllWindows().forEach(win => {
+      win.webContents.send('workflow:list-active-error', { message, timestamp: new Date().toISOString() });
+    });
+  }
+
   // List all active workflows
   registerHandler('workflow:list-active', "List active workflow instances", async () => {
     logWithCategory('info', LogCategory.WORKFLOW, 'IPC: List active workflows');
@@ -748,6 +766,7 @@ export function registerWorkflowHandlers() {
       return (result || []).map(mapActiveWorkflow);
     } catch (error: any) {
       logWithCategory('error', LogCategory.WORKFLOW, 'IPC: List active workflows failed', { error: error.message });
+      broadcastListActiveError(error.message || 'Unknown error');
       // Return empty array on error - MCP tools may not be implemented yet
       return [];
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -378,6 +378,14 @@ function createWindow(): void {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      // Chromium throttles timers (setInterval/setTimeout) in backgrounded
+      // renderers. The Active Workflows panel's 5s refresh poll and the
+      // workflow canvas's poll fallback (issue #178) both rely on a renderer
+      // setInterval; without this, minimizing the window or leaving it
+      // unfocused while a workflow runs elsewhere (e.g. driven by an
+      // external Claude Code session) can silently stall those polls until
+      // the window regains focus.
+      backgroundThrottling: false,
     },
     show: false, // Don't show until ready
   });

--- a/src/renderer/components/WorkflowManagerPanel.tsx
+++ b/src/renderer/components/WorkflowManagerPanel.tsx
@@ -40,6 +40,9 @@ export const WorkflowManagerPanel: React.FC<WorkflowManagerPanelProps> = ({
 }) => {
   const [activeWorkflows, setActiveWorkflows] = useState<ActiveWorkflowInstance[]>([]);
   const [selectedActiveWorkflow, setSelectedActiveWorkflow] = useState<ActiveWorkflowInstance | null>(null);
+  // Tracks whether the last workflow:list-active call failed (see issue #178) -
+  // surfaces MCP/connection failures instead of silently showing a stale/empty list.
+  const [hasConnectionError, setHasConnectionError] = useState(false);
   const [sectionsExpanded, setSectionsExpanded] = useState({
     available: true,
     active: true,
@@ -93,6 +96,7 @@ export const WorkflowManagerPanel: React.FC<WorkflowManagerPanelProps> = ({
 
       if (Array.isArray(result)) {
         setActiveWorkflows(result);
+        setHasConnectionError(false);
       }
     } catch (error) {
       console.error('[WorkflowManagerPanel] Failed to load active workflows:', error);
@@ -138,11 +142,19 @@ export const WorkflowManagerPanel: React.FC<WorkflowManagerPanelProps> = ({
 
     electronAPI.on('workflow:instance-updated', handleWorkflowUpdate);
 
+    // Surface workflow:list-active failures (see issue #178) instead of
+    // leaving a broken MCP connection indistinguishable from "nothing running"
+    const handleListActiveError = () => {
+      setHasConnectionError(true);
+    };
+    electronAPI.on('workflow:list-active-error', handleListActiveError);
+
     // Poll every 5 seconds as backup
     const pollInterval = setInterval(loadActiveWorkflows, 5000);
 
     return () => {
       electronAPI.off('workflow:instance-updated', handleWorkflowUpdate);
+      electronAPI.off('workflow:list-active-error', handleListActiveError);
       clearInterval(pollInterval);
     };
   }, [isOpen, loadActiveWorkflows]);
@@ -354,6 +366,20 @@ export const WorkflowManagerPanel: React.FC<WorkflowManagerPanelProps> = ({
           isExpanded={sectionsExpanded.active}
           onToggle={() => toggleSection('active')}
         >
+          {hasConnectionError && (
+            <div
+              style={{
+                ...emptyStateStyle,
+                color: '#f87171',
+                textAlign: 'left',
+                padding: '6px 12px',
+                fontSize: '11px',
+              }}
+              title="workflow:list-active failed - the workflow server may be unreachable or still starting. Active workflow status may be stale. See the main-process log for details."
+            >
+              Connection issue — status may be stale
+            </div>
+          )}
           {activeWorkflows.length === 0 ? (
             <div style={emptyStateStyle}>
               No active workflows

--- a/src/renderer/views/WorkflowsViewReact.tsx
+++ b/src/renderer/views/WorkflowsViewReact.tsx
@@ -23,7 +23,7 @@ import { WorkflowCreateDialog } from '../components/WorkflowCreateDialog.js';
 import { ProjectCreationDialog } from '../components/ProjectCreationDialog.js';
 import { WorkflowManagerPanel } from '../components/WorkflowManagerPanel.js';
 import { getActiveSeriesId, appState } from '../store/app-state.js';
-import type { WorkflowUpdate, NodeStatusInfo } from '../../types/workflow.js';
+import type { WorkflowUpdate, NodeStatusInfo, ActiveWorkflowInstance } from '../../types/workflow.js';
 import type { Project } from '../../types/project.js';
 
 // Plugin IPC channel prefix for workflow plugin
@@ -343,6 +343,78 @@ const WorkflowsApp: React.FC = () => {
     return () => {
       electronAPI.off('workflow:instance-updated', handleInstanceUpdated);
     };
+  }, []);
+
+  // Poll fallback for canvas sync (issue #178).
+  //
+  // The push channel above (workflow:instance-updated) only fires from
+  // broadcastWorkflowUpdate(), which is only called by the Electron-IPC
+  // workflow:pause/resume/cancel/jump-to-node/register-active/update-progress/
+  // mark-node-started/mark-node-completed handlers in workflow-handlers.ts.
+  // A workflow driven by an external Claude Code session (the common case -
+  // see persistent-mcp-client.ts's registerActiveWorkflow() 'claude_code'
+  // source, and the run-workflow skill) calls the workflow-manager-server MCP
+  // tools directly and never goes through those IPC handlers, so the push
+  // channel never fires for it. The canvas then never moves on its own -
+  // only clicking an active-workflow card (handleSelectActiveWorkflow above)
+  // re-derives activeNodeId/executionStatus from data the sidebar's 5s poll
+  // already fetched. This effect gives the canvas that same poll, on the
+  // same cadence, so it doesn't depend on a click to catch up.
+  useEffect(() => {
+    const electronAPI = (window as any).electronAPI;
+    if (!electronAPI || !electronAPI.invoke) return;
+
+    const applyProgress = (match: ActiveWorkflowInstance) => {
+      setActiveNodeId(match.currentNodeId || null);
+      setExecutionStatus(prev => {
+        const newMap = new Map(prev);
+        for (const nodeId of match.completedNodeIds || []) {
+          newMap.set(nodeId, { status: 'completed' });
+        }
+        if (match.currentNodeId) {
+          newMap.set(match.currentNodeId, { status: 'in_progress' });
+        }
+        return newMap;
+      });
+    };
+
+    const pollCanvasProgress = async () => {
+      try {
+        const result = await electronAPI.invoke('workflow:list-active');
+        if (!Array.isArray(result)) return;
+
+        if (activeRegistryIdRef.current) {
+          // Already connected to an instance - refresh its progress from the poll,
+          // same as the push handler would if it had fired.
+          const match = result.find((w: ActiveWorkflowInstance) => w.id === activeRegistryIdRef.current);
+          if (match) applyProgress(match);
+          return;
+        }
+
+        // Not connected yet - auto-connect to a running root instance of the
+        // selected workflow definition, mirroring handleInstanceUpdated's
+        // push-based auto-connect match rule (status running, no parent).
+        const selected = selectedWorkflowRef.current;
+        if (!selected) return;
+
+        const match = result.find((w: ActiveWorkflowInstance) =>
+          w.status === 'running' && !w.parentWorkflowId && w.workflowId === selected.id
+        );
+        if (!match) return;
+
+        activeRegistryIdRef.current = match.id;
+        trackedRegistryIdsRef.current = new Set([match.id]);
+        setActiveRegistryId(match.id);
+        applyProgress(match);
+      } catch (error) {
+        console.error('[WorkflowsViewReact] Canvas progress poll failed:', error);
+      }
+    };
+
+    pollCanvasProgress();
+    const pollInterval = setInterval(pollCanvasProgress, 5000);
+
+    return () => clearInterval(pollInterval);
   }, []);
 
   const handleSelectWorkflow = async (workflowId: string) => {


### PR DESCRIPTION
## Summary

- The Active Workflows sidebar list already has a 5s `workflow:list-active` poll fallback alongside the push channel — its underlying data does refresh on its own. The **canvas** visualization (`WorkflowsViewReact`), however, only ever updated via the push channel (`workflow:instance-updated`), which is emitted only by `broadcastWorkflowUpdate()` from 8 Electron-IPC handlers in `workflow-handlers.ts`. A workflow driven by an external Claude Code session (the normal case — see `persistent-mcp-client.ts`'s `source: 'claude_code'`, and the `run-workflow` skill) calls the workflow-manager-server MCP tools directly and never touches those IPC handlers, so the push channel never fires for it. The only thing that ever moved the canvas was clicking a card, which just re-renders from data the sidebar's poll had already fetched — that's the "click-only" behavior reported in #178.
- Added the same 5s poll fallback to the canvas, matching by `activeRegistryId` (auto-connecting the same way the push handler does when nothing is connected yet).
- Set `backgroundThrottling: false` on the main window so Chromium can't silently stall these renderer-side polls while the window is minimized/unfocused (closes the acceptance-criteria gap around surviving window blur/minimize).
- `workflow:list-active` failures now broadcast a `workflow:list-active-error` IPC event instead of only logging server-side and silently resolving to `[]`; the panel shows a small inline "Connection issue — status may be stale" indicator instead of looking indistinguishable from "genuinely idle."

Full diagnosis (re-verified against current `develop`) posted as a comment on the issue: https://github.com/RLRyals/MCP-Electron-App/issues/178#issuecomment-4920942770

Fixes #178

## Files changed
- `src/renderer/views/WorkflowsViewReact.tsx` — canvas poll fallback (primary fix)
- `src/main/index.ts` — `backgroundThrottling: false` on the main window
- `src/main/handlers/workflow-handlers.ts` — broadcast `workflow:list-active-error` on failure
- `src/renderer/components/WorkflowManagerPanel.tsx` — surface the connection-error indicator

## Test plan
- [x] `npm run build` (tsc, renderer + main projects) — clean
- [x] Ran the workflow-adjacent jest suites (`create-workflow.test.ts` passes; `multi-node-workflow.test.ts` / `workflow-executor-integration.test.ts` fail pre-existing on `develop` with `Cannot find module '../workflow-executor'` — that module doesn't exist in the repo at all, unrelated to this change, matches the known pre-existing failures tracked in #176)
- [ ] Manual runtime verification on the actual new-laptop install (not possible from this environment — see caveat in the issue comment). Recommend a quick spot-check before closing #178: run an externally-driven (Claude-Code) workflow, leave the canvas open, and confirm it now advances without clicking, including after minimizing the window for a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)