### PR TITLE
fix: remove orphaned Plugin Selection wizard step

### DIFF
--- a/src/main/setup-wizard.ts
+++ b/src/main/setup-wizard.ts
@@ -206,7 +206,6 @@ export async function markWizardComplete(): Promise<{ success: boolean; error?: 
       WizardStep.WELCOME,
       WizardStep.PREREQUISITES,
       WizardStep.ENVIRONMENT,
-      WizardStep.PLUGINS,
       WizardStep.DOWNLOAD_SETUP,
       WizardStep.SYSTEM_STARTUP,
       WizardStep.COMPLETE
@@ -254,8 +253,8 @@ export async function getWizardProgress(): Promise<number> {
     return 100;
   }
 
-  // Calculate based on current step (7 total steps)
-  const totalSteps = 7;
+  // Calculate based on current step (6 total steps)
+  const totalSteps = 6;
   const progress = ((state.currentStep - 1) / totalSteps) * 100;
 
   return Math.round(progress);
@@ -284,7 +283,6 @@ export function getStepName(step: WizardStep): string {
     [WizardStep.WELCOME]: 'Welcome',
     [WizardStep.PREREQUISITES]: 'Prerequisites Check',
     [WizardStep.ENVIRONMENT]: 'Environment Configuration',
-    [WizardStep.PLUGINS]: 'Plugin Selection',
     [WizardStep.DOWNLOAD_SETUP]: 'Download & Setup',
     [WizardStep.SYSTEM_STARTUP]: 'System Startup',
     [WizardStep.COMPLETE]: 'Setup Complete'
@@ -301,7 +299,6 @@ export function getStepDescription(step: WizardStep): string {
     [WizardStep.WELCOME]: 'Welcome to MCP Writing System setup',
     [WizardStep.PREREQUISITES]: 'Checking system requirements',
     [WizardStep.ENVIRONMENT]: 'Configuring database and services',
-    [WizardStep.PLUGINS]: 'Choose optional plugins',
     [WizardStep.DOWNLOAD_SETUP]: 'Downloading and preparing components',
     [WizardStep.SYSTEM_STARTUP]: 'Starting MCP services',
     [WizardStep.COMPLETE]: 'Setup complete!'
@@ -344,13 +341,9 @@ export async function canProceedToNextStep(currentStep: WizardStep): Promise<{
       }
       return { canProceed: true };
 
-    case WizardStep.PLUGINS:
-      // Plugins are optional, can always proceed
-      return { canProceed: true };
-
     case WizardStep.DOWNLOAD_SETUP:
       // Check that build pipeline and downloads are complete
-      logWithCategory('debug', LogCategory.SYSTEM, `Validating DOWNLOAD_SETUP: plugins=${JSON.stringify(state.data.plugins)}, buildPipeline=${JSON.stringify(state.data.buildPipeline)}, downloads=${JSON.stringify(state.data.downloads)}`);
+      logWithCategory('debug', LogCategory.SYSTEM, `Validating DOWNLOAD_SETUP: buildPipeline=${JSON.stringify(state.data.buildPipeline)}, downloads=${JSON.stringify(state.data.downloads)}`);
 
       // If build pipeline is marked as completed, allow proceeding
       // This is the primary indicator that the build has finished successfully

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -480,10 +480,9 @@ enum WizardStep {
   WELCOME = 1,
   PREREQUISITES = 2,
   ENVIRONMENT = 3,
-  PLUGINS = 4,
-  DOWNLOAD_SETUP = 5,
-  SYSTEM_STARTUP = 6,
-  COMPLETE = 7
+  DOWNLOAD_SETUP = 4,
+  SYSTEM_STARTUP = 5,
+  COMPLETE = 6
 }
 
 /**
@@ -498,9 +497,6 @@ interface WizardStepData {
   environment?: {
     saved: boolean;
     configPath?: string;
-  };
-  plugins?: {
-    workflow: boolean;
   };
   downloads?: {
     dockerImagesCompleted: boolean;
@@ -2048,10 +2044,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       WELCOME: 1,
       PREREQUISITES: 2,
       ENVIRONMENT: 3,
-      PLUGINS: 4,
-      DOWNLOAD_SETUP: 5,
-      SYSTEM_STARTUP: 6,
-      COMPLETE: 7
+      DOWNLOAD_SETUP: 4,
+      SYSTEM_STARTUP: 5,
+      COMPLETE: 6
     }
   },
 

--- a/src/types/wizard.ts
+++ b/src/types/wizard.ts
@@ -10,10 +10,9 @@ export enum WizardStep {
   WELCOME = 1,
   PREREQUISITES = 2,
   ENVIRONMENT = 3,
-  PLUGINS = 4,
-  DOWNLOAD_SETUP = 5,
-  SYSTEM_STARTUP = 6,
-  COMPLETE = 7
+  DOWNLOAD_SETUP = 4,
+  SYSTEM_STARTUP = 5,
+  COMPLETE = 6
 }
 
 /**
@@ -33,12 +32,7 @@ export interface WizardStepData {
     configPath?: string;
   };
 
-  // Step 4: Plugins
-  plugins?: {
-    workflow: boolean;
-  };
-
-  // Step 5: Download & setup
+  // Step 4: Download & setup
   buildPipeline?: {
     completed: boolean;
     clonedRepositories?: string[];
@@ -50,7 +44,7 @@ export interface WizardStepData {
     dockerImagesCompleted: boolean;
   };
 
-  // Step 6: System startup
+  // Step 5: System startup
   systemStartup?: {
     started: boolean;
     healthy: boolean;


### PR DESCRIPTION
## Summary
- The setup wizard's backend step model (`WizardStep` enum in `src/types/wizard.ts`, duplicated in `src/preload/preload.ts`) still had a 7-step flow with step 4 = `PLUGINS` ("Plugin Selection"), added by `a5de84c` (2025-12-31).
- Commit `85fc975` (2026-01-31) deleted the renderer's Plugin Selection UI entirely and collapsed the renderer back to a 6-step flow, but never updated the main-process model to match.
- Net effect: the wizard's step-4 header called `getStepName(4)`/`getStepDescription(4)` and showed **"Plugin Selection" / "Choose optional plugins"** above what is actually the Build & Setup Progress (download pipeline) screen — the bug reported in #155. It also broke `canProceedToNextStep` validation for steps 4 and 5 (each checked against the wrong case) and made `getWizardProgress()` divide by 7 instead of 6, capping the progress bar around 71%.
- Fix renumbers `WizardStep` back to 6 steps (`DOWNLOAD_SETUP=4, SYSTEM_STARTUP=5, COMPLETE=6`) to match the renderer, removes the dead `plugins` field from `WizardStepData`, and strips the `PLUGINS` references from `src/main/setup-wizard.ts`. Full diagnosis posted as a comment on #155 before implementing.

Fixes #155

## Test plan
- [x] `npm run build` — clean (tsc renderer + main + asset copy)
- [x] `npx jest` before and after the fix — identical results (116 failed / 208 passed / 3 skipped); failures are pre-existing `repository-manager` git-clone-hang tests, unrelated to the wizard
- [x] Grepped repo for any remaining `WizardStep.PLUGINS` / `data.plugins` references — none
- [x] Confirmed no migrations or tests reference the removed step numerically

🤖 Generated with [Claude Code](https://claude.com/claude-code)