### PR TITLE
Kanban: make card links, issue_ref, and body URLs clickable

### DIFF
--- a/src/main/handlers/__tests__/link-handlers.test.ts
+++ b/src/main/handlers/__tests__/link-handlers.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the app:open-external / app:reveal-in-folder handlers
+ * (issue #198 -- Kanban card links, issue_ref, and body URLs).
+ *
+ * The security requirements from the issue are hard requirements, so the
+ * bulk of this suite is adversarial: confirm every non-http(s) shape
+ * (file://, javascript:, data:, bare paths, garbage strings, non-string
+ * input) is rejected BEFORE the injected opener/reveal function is ever
+ * called, and that `revealFileInFolder` never reveals a path that doesn't
+ * exist on disk.
+ */
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn() },
+  shell: {
+    openExternal: jest.fn().mockResolvedValue(undefined),
+    showItemInFolder: jest.fn(),
+  },
+}));
+
+jest.mock('../../logger', () => ({
+  LogCategory: { SYSTEM: 'SYSTEM' },
+  logWithCategory: jest.fn(),
+}));
+
+import { ipcMain } from 'electron';
+import {
+  isAllowedExternalUrl,
+  openExternalLink,
+  revealFileInFolder,
+  registerLinkHandlers,
+} from '../link-handlers';
+
+describe('isAllowedExternalUrl', () => {
+  it.each([
+    ['http://example.com', true],
+    ['https://example.com/path?q=1#frag', true],
+    ['https://github.com/RLRyals/MCP-Electron-App/issues/198', true],
+    ['  https://example.com  ', true], // trims before validating
+  ])('%s -> %s', (value, expected) => {
+    expect(isAllowedExternalUrl(value)).toBe(expected);
+  });
+
+  it.each([
+    ['file:///etc/passwd'],
+    ['javascript:alert(1)'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['C:\\Users\\rebecca\\file.txt'],
+    ['/etc/passwd'],
+    ['not a url'],
+    [''],
+    [null],
+    [undefined],
+    [42],
+    [{}],
+  ])('rejects %p', (value) => {
+    expect(isAllowedExternalUrl(value as any)).toBe(false);
+  });
+});
+
+describe('openExternalLink', () => {
+  it('calls the opener and resolves { success: true } for an http(s) URL', async () => {
+    const opener = jest.fn().mockResolvedValue(undefined);
+    const result = await openExternalLink('https://example.com/foo', opener);
+    expect(opener).toHaveBeenCalledWith('https://example.com/foo');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('trims whitespace before handing the URL to the opener', async () => {
+    const opener = jest.fn().mockResolvedValue(undefined);
+    await openExternalLink('  https://example.com/foo  ', opener);
+    expect(opener).toHaveBeenCalledWith('https://example.com/foo');
+  });
+
+  it.each([
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'not-a-url',
+    '',
+  ])('rejects %p without ever calling the opener', async (value) => {
+    const opener = jest.fn().mockResolvedValue(undefined);
+    await expect(openExternalLink(value, opener)).rejects.toThrow(/non-http\(s\)/i);
+    expect(opener).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string input without calling the opener', async () => {
+    const opener = jest.fn().mockResolvedValue(undefined);
+    await expect(openExternalLink(42 as any, opener)).rejects.toThrow();
+    expect(opener).not.toHaveBeenCalled();
+  });
+});
+
+describe('revealFileInFolder', () => {
+  it('reveals a file that exists', async () => {
+    const exists = jest.fn().mockReturnValue(true);
+    const reveal = jest.fn();
+    const result = await revealFileInFolder('C:/repo/file.txt', exists, reveal);
+    expect(exists).toHaveBeenCalledWith('C:/repo/file.txt');
+    expect(reveal).toHaveBeenCalledWith('C:/repo/file.txt');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('throws and never reveals when the file does not exist', async () => {
+    const exists = jest.fn().mockReturnValue(false);
+    const reveal = jest.fn();
+    await expect(revealFileInFolder('C:/repo/missing.txt', exists, reveal)).rejects.toThrow(/does not exist/i);
+    expect(reveal).not.toHaveBeenCalled();
+  });
+
+  it('throws on empty/non-string paths without calling exists or reveal', async () => {
+    const exists = jest.fn().mockReturnValue(true);
+    const reveal = jest.fn();
+    await expect(revealFileInFolder('', exists, reveal)).rejects.toThrow();
+    await expect(revealFileInFolder(undefined as any, exists, reveal)).rejects.toThrow();
+    expect(exists).not.toHaveBeenCalled();
+    expect(reveal).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerLinkHandlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers both app:open-external and app:reveal-in-folder', () => {
+    registerLinkHandlers();
+    const registeredChannels = (ipcMain.handle as jest.Mock).mock.calls.map((call) => call[0]);
+    expect(registeredChannels).toEqual(
+      expect.arrayContaining(['app:open-external', 'app:reveal-in-folder'])
+    );
+  });
+
+  it('the registered app:open-external handler rejects a non-http(s) URL end to end', async () => {
+    registerLinkHandlers();
+    const call = (ipcMain.handle as jest.Mock).mock.calls.find((c) => c[0] === 'app:open-external');
+    const handler = call![1];
+    await expect(handler({} as any, 'file:///etc/passwd')).rejects.toThrow(/non-http\(s\)/i);
+  });
+
+  it('the registered app:reveal-in-folder handler rejects a nonexistent path end to end', async () => {
+    registerLinkHandlers();
+    const call = (ipcMain.handle as jest.Mock).mock.calls.find((c) => c[0] === 'app:reveal-in-folder');
+    const handler = call![1];
+    await expect(handler({} as any, 'C:/definitely/does/not/exist-198.txt')).rejects.toThrow(/does not exist/i);
+  });
+});

--- a/src/main/handlers/link-handlers.ts
+++ b/src/main/handlers/link-handlers.ts
@@ -1,0 +1,107 @@
+/**
+ * Kanban card link handlers (issue #198).
+ *
+ * The Kanban card drawer's Links section, `issue_ref` field, and body
+ * linkify all funnel through these two host-owned IPC channels rather than
+ * calling Electron's `shell` module from the renderer directly -- the
+ * renderer has no Node/Electron access (context isolation), so every
+ * external-URL open or file reveal has to cross into the main process, and
+ * this is the one narrow gate it crosses through.
+ *
+ * Security requirements (hard, per issue #198):
+ *   - Only http/https URLs are ever allowed to reach `shell.openExternal`.
+ *     Anything else (file:, javascript:, data:, a bare path, garbage) is
+ *     rejected before Electron ever sees it.
+ *   - `file`-type refs are NEVER opened/executed -- only revealed in the
+ *     system file manager (`shell.showItemInFolder`), and only after
+ *     confirming the path exists on disk, so a stale/garbage ref just
+ *     fails cleanly instead of revealing an unrelated path or throwing a
+ *     native dialog.
+ *
+ * Both exported functions take their side-effecting dependency as an
+ * injectable parameter (default = the real `shell` method) so they can be
+ * unit tested without spinning up Electron.
+ */
+import { shell, ipcMain } from 'electron';
+import * as fs from 'fs';
+import { logWithCategory, LogCategory } from '../logger';
+
+export interface LinkHandlerResult {
+  success: boolean;
+}
+
+/**
+ * True when `value` parses as a well-formed http or https URL. Used both to
+ * gate `app:open-external` here and (mirrored, renderer-side, in
+ * `src/renderer/components/kanban/link-utils.ts`) to decide whether a card
+ * link is even rendered as clickable in the first place -- this is the
+ * authoritative check since it runs in the process that actually calls
+ * `shell.openExternal`.
+ */
+export function isAllowedExternalUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
+
+/**
+ * Open an http(s) URL in the system's default browser. Throws (rather than
+ * silently no-op'ing) on anything that isn't a well-formed http/https URL,
+ * so the renderer can surface the rejection instead of the click silently
+ * doing nothing.
+ */
+export async function openExternalLink(
+  url: unknown,
+  opener: (url: string) => Promise<void> = shell.openExternal
+): Promise<LinkHandlerResult> {
+  if (!isAllowedExternalUrl(url)) {
+    throw new Error(`Refusing to open non-http(s) URL: ${String(url)}`);
+  }
+  await opener(url.trim());
+  return { success: true };
+}
+
+/**
+ * Reveal a file in the system file manager, after confirming it exists.
+ * Deliberately uses `shell.showItemInFolder` (reveal), never
+ * `shell.openPath` (which would execute/open the file) -- `file`-type card
+ * links must never execute arbitrary local paths from renderer input.
+ */
+export async function revealFileInFolder(
+  filePath: unknown,
+  exists: (p: string) => boolean = fs.existsSync,
+  reveal: (p: string) => void = shell.showItemInFolder
+): Promise<LinkHandlerResult> {
+  if (typeof filePath !== 'string' || !filePath.trim()) {
+    throw new Error('File path must be a non-empty string');
+  }
+  const trimmed = filePath.trim();
+  if (!exists(trimmed)) {
+    throw new Error(`File does not exist: ${trimmed}`);
+  }
+  reveal(trimmed);
+  return { success: true };
+}
+
+/**
+ * Register the `app:open-external` and `app:reveal-in-folder` IPC handlers.
+ * Host-owned (un-prefixed) channels -- called directly via the renderer's
+ * generic `electronAPI.invoke`, same idiom as `app-settings:get-current-user`
+ * (see KanbanViewReact.tsx), not routed through the kanban plugin prefix.
+ */
+export function registerLinkHandlers(): void {
+  ipcMain.handle('app:open-external', async (_event, url: unknown) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: app:open-external requested for ${String(url)}`);
+    return openExternalLink(url);
+  });
+
+  ipcMain.handle('app:reveal-in-folder', async (_event, filePath: unknown) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: app:reveal-in-folder requested for ${String(filePath)}`);
+    return revealFileInFolder(filePath);
+  });
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -432,6 +432,7 @@ import { registerBundledPluginsHandlers } from './handlers/bundled-plugins-handl
 import { registerWorkflowHandlers } from './handlers/workflow-handlers';
 import { registerPluginUpdateHandlers } from './handlers/plugin-update-handlers';
 import { registerGenrePackHandlers } from './handlers/genre-pack-handlers';
+import { registerLinkHandlers } from './handlers/link-handlers';
 
 /**
  * Build the README.md dropped into a newly-initialized project root
@@ -499,6 +500,10 @@ function setupIPC(): void {
 
   // Register genre pack handlers
   registerGenrePackHandlers();
+
+  // Register app:open-external / app:reveal-in-folder (issue #198 --
+  // Kanban card links, issue_ref, and body URLs)
+  registerLinkHandlers();
 
   // Example IPC handler - ping/pong
   registerHandler('ping', "Health-check ping/pong", async () => {

--- a/src/renderer/components/kanban/CardDrawer.tsx
+++ b/src/renderer/components/kanban/CardDrawer.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../types/kanban.js';
 import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
 import type { CurrentUserSetting } from '../../../types/identity.js';
+import { parseGithubIssueRef, resolveLinkUrl, linkifyBody } from './link-utils.js';
 
 const KANBAN_PLUGIN = 'plugin:fictionlab-kanban:';
 
@@ -39,11 +40,42 @@ export interface CardDrawerProps {
   onClose: () => void;
   /** Called after any mutation succeeds, so the parent board can re-fetch immediately. */
   onMutated: () => void;
+  /**
+   * Swap the drawer to a different card id (issue #198 -- `card`-type
+   * links). Optional so existing embeddings of CardDrawer that don't wire
+   * this up keep working; `card` links just render as plain text without it.
+   */
+  onNavigateToCard?: (cardId: string) => void;
 }
 
 async function invoke<T = any>(channel: string, args?: any): Promise<T> {
   const electronAPI = (window as any).electronAPI;
   return electronAPI.invoke(`${KANBAN_PLUGIN}${channel}`, args);
+}
+
+/**
+ * Open an http(s) URL in the system default browser (issue #198). This is a
+ * host-owned (un-prefixed) channel -- same idiom as
+ * `app-settings:get-current-user` in KanbanViewReact.tsx -- handled by
+ * `src/main/handlers/link-handlers.ts`, which is the ONLY thing that
+ * actually calls `shell.openExternal` and rejects anything that isn't a
+ * well-formed http/https URL. Throws on rejection so callers can surface it.
+ */
+async function openExternal(url: string): Promise<void> {
+  const electronAPI = (window as any).electronAPI;
+  if (!electronAPI?.invoke) throw new Error('Electron API not available');
+  await electronAPI.invoke('app:open-external', url);
+}
+
+/**
+ * Reveal a file in the system file manager (issue #198 -- `file`-type
+ * links). Handled by the same main-process module, which confirms the path
+ * exists before calling `shell.showItemInFolder` -- never opens/executes it.
+ */
+async function revealInFolder(path: string): Promise<void> {
+  const electronAPI = (window as any).electronAPI;
+  if (!electronAPI?.invoke) throw new Error('Electron API not available');
+  await electronAPI.invoke('app:reveal-in-folder', path);
 }
 
 const panelStyle: React.CSSProperties = {
@@ -105,10 +137,23 @@ const primaryButtonStyle: React.CSSProperties = {
   fontWeight: 600,
 };
 
-export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, currentUser, identities, onClose, onMutated }) => {
+/** Clickable card link / linkified-body-URL style (issue #198). */
+const linkStyle: React.CSSProperties = {
+  color: 'var(--color-accent, #00D4AA)',
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  wordBreak: 'break-all',
+};
+
+export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, currentUser, identities, onClose, onMutated, onNavigateToCard }) => {
   const [detail, setDetail] = useState<KanbanCardDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Existence check for `card`-type links (issue #198 plan §1): a link whose
+  // referenced card was since deleted/archived-away falls back to plain
+  // text instead of a dead-end click. `undefined` = not checked yet (link
+  // renders as clickable optimistically while the check is in flight).
+  const [cardLinkExists, setCardLinkExists] = useState<Record<string, boolean>>({});
 
   const [titleDraft, setTitleDraft] = useState('');
   const [bodyDraft, setBodyDraft] = useState('');
@@ -130,6 +175,7 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setCardLinkExists({});
     try {
       const result = await invoke<KanbanCardDetail>('board:get-card', { card_id: cardId });
       if (!result?.card) {
@@ -154,6 +200,52 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
   }, [cardId]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Resolve `card`-type link existence (issue #198 plan §1) so a link to a
+  // since-deleted card falls back to plain text rather than a dead click.
+  // Best-effort: any lookup failure is treated as "doesn't exist" so the
+  // link never dangles silently clickable.
+  useEffect(() => {
+    const cardLinks = (detail?.links || []).filter((l) => l.link_type === 'card');
+    const unchecked = cardLinks.filter((l) => !(l.ref in cardLinkExists));
+    if (unchecked.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const results = await Promise.all(
+        unchecked.map(async (link) => {
+          try {
+            const result = await invoke<KanbanCardDetail>('board:get-card', { card_id: link.ref });
+            return [link.ref, !!result?.card] as const;
+          } catch {
+            return [link.ref, false] as const;
+          }
+        })
+      );
+      if (cancelled) return;
+      setCardLinkExists((prev) => {
+        const next = { ...prev };
+        for (const [ref, exists] of results) next[ref] = exists;
+        return next;
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [detail?.links, cardLinkExists]);
+
+  const handleOpenExternal = useCallback(async (url: string) => {
+    try {
+      await openExternal(url);
+    } catch (e: any) {
+      setError(e?.message || `Failed to open ${url}`);
+    }
+  }, []);
+
+  const handleRevealFile = useCallback(async (path: string) => {
+    try {
+      await revealInFolder(path);
+    } catch (e: any) {
+      setError(e?.message || `Failed to reveal ${path}`);
+    }
+  }, []);
 
   const runMutation = async (fn: () => Promise<any>) => {
     setSaving(true);
@@ -189,6 +281,10 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
   }
 
   const card = detail.card;
+  // The "Open" affordance next to Issue ref (issue #198 plan §2): shown only
+  // when the current draft value parses as `owner/repo#123` or a full
+  // GitHub issue/PR URL.
+  const issueRefUrl = parseGithubIssueRef(issueRefDraft);
   const assigneeIdentityKind = card.assignee
     ? identities.find((i) => i.id === card.assignee)?.kind
     : undefined;
@@ -391,7 +487,23 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
           <input style={{ ...inputStyle, marginBottom: '10px' }} value={specRefDraft} onChange={(e) => setSpecRefDraft(e.target.value)} onBlur={saveFieldChanges} />
 
           <label style={labelStyle}>Issue ref</label>
-          <input style={inputStyle} value={issueRefDraft} onChange={(e) => setIssueRefDraft(e.target.value)} onBlur={saveFieldChanges} />
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <input
+              style={inputStyle}
+              value={issueRefDraft}
+              onChange={(e) => setIssueRefDraft(e.target.value)}
+              onBlur={saveFieldChanges}
+            />
+            {issueRefUrl && (
+              <button
+                style={buttonStyle}
+                onClick={() => handleOpenExternal(issueRefUrl)}
+                title={issueRefUrl}
+              >
+                Open
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Body */}
@@ -410,7 +522,24 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
               style={{ whiteSpace: 'pre-wrap', fontSize: '13px', cursor: 'text', minHeight: '40px' }}
               onClick={() => setEditingBody(true)}
             >
-              {bodyDraft || <span style={{ color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>Click to add a body...</span>}
+              {bodyDraft ? (
+                linkifyBody(bodyDraft).map((segment, i) =>
+                  segment.type === 'url' ? (
+                    <a
+                      key={i}
+                      href="#"
+                      style={linkStyle}
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleOpenExternal(segment.value); }}
+                    >
+                      {segment.value}
+                    </a>
+                  ) : (
+                    <React.Fragment key={i}>{segment.value}</React.Fragment>
+                  )
+                )
+              ) : (
+                <span style={{ color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>Click to add a body...</span>
+              )}
             </div>
           )}
         </div>
@@ -419,11 +548,53 @@ export const CardDrawer: React.FC<CardDrawerProps> = ({ cardId, workflowPhase, c
         <div style={sectionStyle}>
           <label style={labelStyle}>Links</label>
           {detail.links.length === 0 && <div style={{ fontSize: '12px', color: 'var(--color-text-tertiary, rgba(255,255,255,0.4))' }}>None</div>}
-          {detail.links.map((link) => (
-            <div key={link.id} style={{ fontSize: '12px', marginBottom: '4px' }}>
-              <span style={{ opacity: 0.6 }}>[{link.link_type}]</span> {link.label || link.ref}
-            </div>
-          ))}
+          {detail.links.map((link) => {
+            const displayText = link.label || link.ref;
+            const url = resolveLinkUrl(link.link_type, link.ref);
+            let content: React.ReactNode;
+            if (link.link_type === 'card') {
+              const exists = cardLinkExists[link.ref];
+              content = exists === false ? (
+                <span title="This card no longer exists">{displayText}</span>
+              ) : (
+                <a
+                  href="#"
+                  style={linkStyle}
+                  onClick={(e) => { e.preventDefault(); onNavigateToCard?.(link.ref); }}
+                >
+                  {displayText}
+                </a>
+              );
+            } else if (link.link_type === 'file') {
+              content = (
+                <a
+                  href="#"
+                  style={linkStyle}
+                  title="Reveal in folder"
+                  onClick={(e) => { e.preventDefault(); handleRevealFile(link.ref); }}
+                >
+                  {displayText}
+                </a>
+              );
+            } else if (url) {
+              content = (
+                <a
+                  href="#"
+                  style={linkStyle}
+                  onClick={(e) => { e.preventDefault(); handleOpenExternal(url); }}
+                >
+                  {displayText}
+                </a>
+              );
+            } else {
+              content = <span>{displayText}</span>;
+            }
+            return (
+              <div key={link.id} style={{ fontSize: '12px', marginBottom: '4px' }}>
+                <span style={{ opacity: 0.6 }}>[{link.link_type}]</span> {content}
+              </div>
+            );
+          })}
           <div style={{ display: 'flex', gap: '4px', marginTop: '6px' }}>
             <select style={{ ...inputStyle, flex: '0 0 90px' }} value={linkType} onChange={(e) => setLinkType(e.target.value as KanbanLinkType)}>
               <option value="url">url</option>

--- a/src/renderer/components/kanban/__tests__/CardDrawer.links.test.tsx
+++ b/src/renderer/components/kanban/__tests__/CardDrawer.links.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * CardDrawer link-rendering tests (issue #198).
+ *
+ * Covers the acceptance criteria that are exercisable at the component
+ * level: `url`/`github_issue`/`card`/`file` links render clickable (or fall
+ * back to plain text when a `card` link's target no longer exists), the
+ * `issue_ref` open affordance, body linkify, and that the pre-existing
+ * add-link form still submits the same payload it always did.
+ *
+ * window.electronAPI.invoke is a single jest.fn() that routes by channel --
+ * same shape the real preload exposes -- so each test only needs to stub
+ * the responses it cares about.
+ */
+import * as React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CardDrawer } from '../CardDrawer';
+import type { KanbanCardDetail, KanbanIdentity } from '../../../../types/kanban';
+import type { CurrentUserSetting } from '../../../../types/identity';
+
+const KANBAN_PLUGIN = 'plugin:fictionlab-kanban:';
+
+const currentUser: CurrentUserSetting = { id: 'rebecca', displayName: 'Rebecca' };
+const identities: KanbanIdentity[] = [];
+
+function baseCard(overrides: Record<string, any> = {}) {
+  return {
+    id: 'card-1',
+    board_id: 'board-1',
+    title: 'Fix the thing',
+    body: '',
+    status: 'in_progress',
+    assignee: null,
+    agent_claimable: false,
+    priority: 'normal',
+    labels: [],
+    position: 0,
+    claimed_by: null,
+    claimed_at: null,
+    workflow_registry_id: null,
+    spec_ref: null,
+    issue_ref: null,
+    review_policy: 'auto-done',
+    due_at: null,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    created_by: 'rebecca',
+    metadata: {},
+    comment_count: 0,
+    link_count: 0,
+    ...overrides,
+  };
+}
+
+function detailFor(cardOverrides: Record<string, any>, links: any[] = []): KanbanCardDetail {
+  return {
+    card: baseCard(cardOverrides),
+    comments: [],
+    links,
+    activity: [],
+  } as any;
+}
+
+/** Builds the routed invoke() mock and returns it plus a spy for assertions. */
+function setupInvoke(detail: KanbanCardDetail, opts: { knownCardIds?: string[] } = {}) {
+  const knownCardIds = new Set(opts.knownCardIds || []);
+  const invoke = jest.fn(async (channel: string, args?: any) => {
+    if (channel === `${KANBAN_PLUGIN}board:get-card`) {
+      const id = args?.card_id;
+      if (id === detail.card.id) return detail;
+      if (knownCardIds.has(id)) return { card: { id, title: `Card ${id}` }, comments: [], links: [], activity: [] };
+      return { card: null };
+    }
+    if (channel === `${KANBAN_PLUGIN}board:add-card-link`) {
+      return { id: 'new-link', card_id: args?.card_id, link_type: args?.link_type, ref: args?.ref, label: args?.label };
+    }
+    if (channel === `${KANBAN_PLUGIN}board:update-card`) {
+      return { ...detail.card, ...args };
+    }
+    if (channel === 'app:open-external') {
+      return { success: true };
+    }
+    if (channel === 'app:reveal-in-folder') {
+      return { success: true };
+    }
+    return undefined;
+  });
+  (window as any).electronAPI.invoke = invoke;
+  return invoke;
+}
+
+const renderDrawer = (props: Partial<React.ComponentProps<typeof CardDrawer>> = {}) => {
+  return render(
+    <CardDrawer
+      cardId="card-1"
+      workflowPhase={null}
+      currentUser={currentUser}
+      identities={identities}
+      onClose={jest.fn()}
+      onMutated={jest.fn()}
+      {...props}
+    />
+  );
+};
+
+describe('CardDrawer -- Links section (issue #198)', () => {
+  it('renders a url link as a clickable anchor that opens via app:open-external', async () => {
+    const detail = detailFor({}, [
+      { id: 'l1', card_id: 'card-1', link_type: 'url', ref: 'https://example.com/dashboard', label: null, created_at: '' },
+    ]);
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    const link = await screen.findByRole('link', { name: 'https://example.com/dashboard' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(invoke).toHaveBeenCalledWith('app:open-external', 'https://example.com/dashboard');
+  });
+
+  it('renders a github_issue shorthand link and opens the canonical GitHub URL', async () => {
+    const detail = detailFor({}, [
+      { id: 'l2', card_id: 'card-1', link_type: 'github_issue', ref: 'RLRyals/MCP-Electron-App#190', label: 'PR #190', created_at: '' },
+    ]);
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    const link = await screen.findByRole('link', { name: 'PR #190' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(invoke).toHaveBeenCalledWith('app:open-external', 'https://github.com/RLRyals/MCP-Electron-App/issues/190');
+  });
+
+  it('renders a github_issue full-URL link and opens it as-is', async () => {
+    const detail = detailFor({}, [
+      { id: 'l2b', card_id: 'card-1', link_type: 'github_issue', ref: 'https://github.com/RLRyals/MCP-Electron-App/pull/197', label: null, created_at: '' },
+    ]);
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    const link = await screen.findByRole('link', { name: 'https://github.com/RLRyals/MCP-Electron-App/pull/197' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(invoke).toHaveBeenCalledWith('app:open-external', 'https://github.com/RLRyals/MCP-Electron-App/issues/197');
+  });
+
+  it('renders a card link to an existing card as clickable and navigates via onNavigateToCard', async () => {
+    const detail = detailFor({}, [
+      { id: 'l3', card_id: 'card-1', link_type: 'card', ref: 'card-2', label: 'Related card', created_at: '' },
+    ]);
+    setupInvoke(detail, { knownCardIds: ['card-2'] });
+    const onNavigateToCard = jest.fn();
+    renderDrawer({ onNavigateToCard });
+
+    const link = await screen.findByRole('link', { name: 'Related card' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(onNavigateToCard).toHaveBeenCalledWith('card-2');
+  });
+
+  it('falls back to plain text for a card link whose target no longer exists', async () => {
+    const detail = detailFor({}, [
+      { id: 'l4', card_id: 'card-1', link_type: 'card', ref: 'deleted-card', label: 'Gone card', created_at: '' },
+    ]);
+    setupInvoke(detail, { knownCardIds: [] }); // deleted-card resolves to { card: null }
+    const onNavigateToCard = jest.fn();
+    renderDrawer({ onNavigateToCard });
+
+    await screen.findByText('Gone card');
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Gone card' })).not.toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Gone card'));
+    expect(onNavigateToCard).not.toHaveBeenCalled();
+  });
+
+  it('renders a file link that reveals in folder rather than opening/executing it', async () => {
+    const detail = detailFor({}, [
+      { id: 'l5', card_id: 'card-1', link_type: 'file', ref: 'C:/repo/outputs/book_1/spec.md', label: null, created_at: '' },
+    ]);
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    const link = await screen.findByRole('link', { name: 'C:/repo/outputs/book_1/spec.md' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(invoke).toHaveBeenCalledWith('app:reveal-in-folder', 'C:/repo/outputs/book_1/spec.md');
+    expect(invoke).not.toHaveBeenCalledWith('app:open-external', expect.anything());
+  });
+
+  it('renders a non-URL spec ref as plain text (not clickable)', async () => {
+    const detail = detailFor({}, [
+      { id: 'l6', card_id: 'card-1', link_type: 'spec', ref: 'outputs/book_1/spec.md', label: null, created_at: '' },
+    ]);
+    setupInvoke(detail);
+    renderDrawer();
+
+    await screen.findByText('outputs/book_1/spec.md');
+    expect(screen.queryByRole('link', { name: 'outputs/book_1/spec.md' })).not.toBeInTheDocument();
+  });
+
+  it('the existing add-link form still submits the same board:add-card-link payload', async () => {
+    const detail = detailFor({}, []);
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    await screen.findByDisplayValue('Fix the thing'); // card finished loading
+
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('ref'), 'https://example.com/new-link');
+    await user.type(screen.getByPlaceholderText('label (optional)'), 'New link');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(`${KANBAN_PLUGIN}board:add-card-link`, {
+        card_id: 'card-1',
+        link_type: 'url',
+        ref: 'https://example.com/new-link',
+        label: 'New link',
+      });
+    });
+  });
+});
+
+describe('CardDrawer -- issue_ref open affordance (issue #198)', () => {
+  it('shows no Open button when issue_ref is empty', async () => {
+    const detail = detailFor({ issue_ref: null });
+    setupInvoke(detail);
+    renderDrawer();
+
+    await screen.findByDisplayValue('Fix the thing');
+    expect(screen.queryByRole('button', { name: 'Open' })).not.toBeInTheDocument();
+  });
+
+  it('shows an Open button when issue_ref parses as owner/repo#N, and it opens the canonical URL', async () => {
+    const detail = detailFor({ issue_ref: 'RLRyals/MCP-Electron-App#198' });
+    const invoke = setupInvoke(detail);
+    renderDrawer();
+
+    const openButton = await screen.findByRole('button', { name: 'Open' });
+    const user = userEvent.setup();
+    await user.click(openButton);
+
+    expect(invoke).toHaveBeenCalledWith('app:open-external', 'https://github.com/RLRyals/MCP-Electron-App/issues/198');
+  });
+});
+
+describe('CardDrawer -- body linkify (issue #198)', () => {
+  it('renders a bare URL in the body as a clickable link without entering edit mode', async () => {
+    const detail = detailFor({ body: 'See https://example.com/notes for context.' });
+    const invoke = setupInvoke(detail);
+    const { container } = renderDrawer();
+
+    const link = await screen.findByRole('link', { name: 'https://example.com/notes' });
+    const user = userEvent.setup();
+    await user.click(link);
+
+    expect(invoke).toHaveBeenCalledWith('app:open-external', 'https://example.com/notes');
+    // Clicking the link must not have bubbled up to the body's own onClick
+    // (which would swap it into the editable textarea). The body editor is
+    // the only <textarea> in the drawer without a placeholder.
+    const unplaceholderedTextareas = Array.from(container.querySelectorAll('textarea')).filter(
+      (t) => !t.getAttribute('placeholder')
+    );
+    expect(unplaceholderedTextareas).toHaveLength(0);
+  });
+});

--- a/src/renderer/components/kanban/__tests__/link-utils.test.ts
+++ b/src/renderer/components/kanban/__tests__/link-utils.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the Kanban card-link parsing/rendering helpers (issue #198).
+ */
+import { isHttpUrl, parseGithubIssueRef, resolveLinkUrl, linkifyBody } from '../link-utils';
+
+describe('isHttpUrl', () => {
+  it.each([
+    ['http://example.com', true],
+    ['https://example.com/path?q=1', true],
+    ['  https://example.com  ', true],
+  ])('%s -> %s', (value, expected) => {
+    expect(isHttpUrl(value)).toBe(expected);
+  });
+
+  it.each([
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'owner/repo#123',
+    'not a url',
+    '',
+    null,
+    undefined,
+  ])('rejects %p', (value) => {
+    expect(isHttpUrl(value as any)).toBe(false);
+  });
+});
+
+describe('parseGithubIssueRef', () => {
+  it('parses the owner/repo#123 shorthand into a canonical issues URL', () => {
+    expect(parseGithubIssueRef('RLRyals/MCP-Electron-App#198')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/198'
+    );
+  });
+
+  it('parses a full GitHub issue URL', () => {
+    expect(parseGithubIssueRef('https://github.com/RLRyals/MCP-Electron-App/issues/198')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/198'
+    );
+  });
+
+  it('parses a full GitHub PR URL onto the canonical /issues/ path (GitHub redirects issues<->pulls)', () => {
+    expect(parseGithubIssueRef('https://github.com/RLRyals/MCP-Electron-App/pull/190')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/190'
+    );
+  });
+
+  it('parses a full GitHub URL with a trailing fragment/query', () => {
+    expect(parseGithubIssueRef('https://github.com/RLRyals/MCP-Electron-App/issues/198#issuecomment-1')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/198'
+    );
+  });
+
+  it('returns null for values that are neither shorthand nor a GitHub issue/PR URL', () => {
+    expect(parseGithubIssueRef('just some text')).toBeNull();
+    expect(parseGithubIssueRef('https://example.com/not-github')).toBeNull();
+    expect(parseGithubIssueRef('https://github.com/RLRyals/MCP-Electron-App')).toBeNull();
+    expect(parseGithubIssueRef('')).toBeNull();
+    expect(parseGithubIssueRef(null)).toBeNull();
+    expect(parseGithubIssueRef(undefined)).toBeNull();
+  });
+});
+
+describe('resolveLinkUrl', () => {
+  it('resolves url-type refs that are http(s)', () => {
+    expect(resolveLinkUrl('url', 'https://example.com')).toBe('https://example.com');
+  });
+
+  it('does not resolve url-type refs that are not http(s)', () => {
+    expect(resolveLinkUrl('url', 'not-a-url')).toBeNull();
+  });
+
+  it('resolves spec-type refs only when the ref itself is a URL', () => {
+    expect(resolveLinkUrl('spec', 'https://example.com/spec.md')).toBe('https://example.com/spec.md');
+    expect(resolveLinkUrl('spec', 'outputs/book_1/spec.md')).toBeNull();
+  });
+
+  it('resolves github_issue-type refs via parseGithubIssueRef (shorthand and full URL)', () => {
+    expect(resolveLinkUrl('github_issue', 'RLRyals/MCP-Electron-App#198')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/198'
+    );
+    expect(resolveLinkUrl('github_issue', 'https://github.com/RLRyals/MCP-Electron-App/issues/198')).toBe(
+      'https://github.com/RLRyals/MCP-Electron-App/issues/198'
+    );
+    expect(resolveLinkUrl('github_issue', 'not parseable')).toBeNull();
+  });
+
+  it('never resolves card or file refs (handled separately by the caller)', () => {
+    expect(resolveLinkUrl('card', 'https://example.com')).toBeNull();
+    expect(resolveLinkUrl('file', 'https://example.com')).toBeNull();
+  });
+
+  it('returns null for a null/empty ref', () => {
+    expect(resolveLinkUrl('url', null)).toBeNull();
+    expect(resolveLinkUrl('url', '')).toBeNull();
+  });
+});
+
+describe('linkifyBody', () => {
+  it('returns [] for empty/null/undefined text', () => {
+    expect(linkifyBody('')).toEqual([]);
+    expect(linkifyBody(null)).toEqual([]);
+    expect(linkifyBody(undefined)).toEqual([]);
+  });
+
+  it('returns a single text segment when there are no URLs', () => {
+    expect(linkifyBody('just plain text, no links here')).toEqual([
+      { type: 'text', value: 'just plain text, no links here' },
+    ]);
+  });
+
+  it('splits out a single bare URL', () => {
+    expect(linkifyBody('see https://example.com/foo for details')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com/foo' },
+      { type: 'text', value: ' for details' },
+    ]);
+  });
+
+  it('trims trailing sentence punctuation off the URL', () => {
+    expect(linkifyBody('see https://example.com/foo.')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com/foo' },
+      { type: 'text', value: '.' },
+    ]);
+  });
+
+  it('handles multiple URLs in the same body', () => {
+    const result = linkifyBody('PR https://github.com/o/r/pull/1 fixes https://github.com/o/r/issues/2');
+    expect(result.filter((s) => s.type === 'url').map((s) => s.value)).toEqual([
+      'https://github.com/o/r/pull/1',
+      'https://github.com/o/r/issues/2',
+    ]);
+  });
+
+  it('handles a URL that is the entire body (no surrounding text)', () => {
+    expect(linkifyBody('https://example.com')).toEqual([{ type: 'url', value: 'https://example.com' }]);
+  });
+});

--- a/src/renderer/components/kanban/link-utils.ts
+++ b/src/renderer/components/kanban/link-utils.ts
@@ -1,0 +1,119 @@
+/**
+ * Kanban card link parsing/rendering helpers (issue #198).
+ *
+ * Pure functions only -- no Electron/DOM access -- so they're unit
+ * testable directly and shared between CardDrawer's Links section, the
+ * `issue_ref` "open" affordance, and body linkify.
+ *
+ * These decide only whether/how something is RENDERED as clickable in the
+ * renderer. The main process (`src/main/handlers/link-handlers.ts`) is the
+ * authoritative gate that actually enforces http(s)-only before calling
+ * `shell.openExternal` -- nothing here is a security boundary by itself.
+ */
+
+const HTTP_URL_RE = /^https?:\/\//i;
+
+/** True when `value` parses as an http(s) URL. Never true for file://, javascript:, bare paths, etc. */
+export function isHttpUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!HTTP_URL_RE.test(trimmed)) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+// `owner/repo#123` -- GitHub-style shorthand for an issue or PR number.
+// GitHub itself resolves /issues/N to the PR page when N is actually a PR,
+// so constructing a single canonical /issues/ URL works for both.
+const SHORTHAND_RE = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)$/;
+
+// A full GitHub issue or PR URL, capturing owner/repo/number.
+const GITHUB_URL_RE = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)(?:[/?#].*)?$/i;
+
+/**
+ * Resolve a `github_issue`-type ref (or an `issue_ref` field value) to an
+ * openable https://github.com/... URL. Accepts either the `owner/repo#123`
+ * shorthand or a full GitHub issue/PR URL. Returns null when the value is
+ * neither -- callers should render plain text / hide the open affordance.
+ */
+export function parseGithubIssueRef(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const shorthand = trimmed.match(SHORTHAND_RE);
+  if (shorthand) {
+    const [, owner, repo, number] = shorthand;
+    return `https://github.com/${owner}/${repo}/issues/${number}`;
+  }
+
+  const fullUrl = trimmed.match(GITHUB_URL_RE);
+  if (fullUrl) {
+    const [, owner, repo, number] = fullUrl;
+    return `https://github.com/${owner}/${repo}/issues/${number}`;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a card-link ref to an openable http(s) URL given its `link_type`,
+ * or null when it isn't openable this way. `card` (navigates within the
+ * drawer) and `file` (reveal-in-folder) are handled separately by the
+ * caller -- they never go through this function.
+ */
+export function resolveLinkUrl(linkType: string, ref: string | null | undefined): string | null {
+  if (!ref) return null;
+  if (linkType === 'github_issue') return parseGithubIssueRef(ref);
+  if (linkType === 'url' || linkType === 'spec') {
+    return isHttpUrl(ref) ? ref.trim() : null;
+  }
+  return null;
+}
+
+// Bare http(s) URL, stopping at whitespace or characters that are almost
+// never part of a URL when it appears inline in prose (matching brackets,
+// quotes).
+const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
+
+export type BodySegment = { type: 'text'; value: string } | { type: 'url'; value: string };
+
+/**
+ * Split body text into alternating text/url segments so bare http(s) URLs
+ * can be rendered as clickable links at display time (never mutates the
+ * stored body -- issue #198 plan step 3).
+ */
+export function linkifyBody(text: string | null | undefined): BodySegment[] {
+  if (!text) return [];
+  const segments: BodySegment[] = [];
+  let lastIndex = 0;
+  BARE_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BARE_URL_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', value: text.slice(lastIndex, match.index) });
+    }
+    // Trim common trailing sentence punctuation that's (almost) never part
+    // of the URL itself, e.g. "see https://x.com/y." or "https://x.com/y,".
+    let url = match[0];
+    let trailing = '';
+    while (url.length > 1 && /[.,;:!?]/.test(url[url.length - 1])) {
+      trailing = url[url.length - 1] + trailing;
+      url = url.slice(0, -1);
+    }
+    segments.push({ type: 'url', value: url });
+    lastIndex = match.index + url.length;
+    if (trailing) {
+      segments.push({ type: 'text', value: trailing });
+      lastIndex = match.index + match[0].length;
+    }
+  }
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', value: text.slice(lastIndex) });
+  }
+  return segments;
+}

--- a/src/renderer/views/KanbanViewReact.tsx
+++ b/src/renderer/views/KanbanViewReact.tsx
@@ -338,6 +338,11 @@ const KanbanApp: React.FC = () => {
       .catch((e: any) => setError(e?.message || 'Failed to move card'));
   }, [refresh, currentUser]);
 
+  // Looked up only for the live workflow-phase tie-in below -- deliberately
+  // NOT used to gate whether the drawer renders (see selectedCardId usage
+  // further down): a `card`-type link (issue #198) can point at a card that
+  // the current assignee/due filter excludes from `cards`, and the drawer
+  // must still be able to open it by id via its own board:get-card fetch.
   const selectedCard = selectedCardId ? cards.find((c) => c.id === selectedCardId) || null : null;
 
   const agentOptions = Array.from(
@@ -482,14 +487,15 @@ const KanbanApp: React.FC = () => {
         )}
       </div>
 
-      {selectedCard && (
+      {selectedCardId && (
         <CardDrawer
-          cardId={selectedCard.id}
-          workflowPhase={selectedCard.workflow_registry_id ? workflowPhases.get(selectedCard.workflow_registry_id) || null : null}
+          cardId={selectedCardId}
+          workflowPhase={selectedCard?.workflow_registry_id ? workflowPhases.get(selectedCard.workflow_registry_id) || null : null}
           currentUser={currentUser}
           identities={identities}
           onClose={() => setSelectedCardId(null)}
           onMutated={refresh}
+          onNavigateToCard={(cardId) => setSelectedCardId(cardId)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- Kanban card drawer Links section, the `issue_ref` field, and bare URLs in the card body were all dead text -- nothing on a card was clickable, so there was no way to open a linked PR/GitHub issue from the board.
- Adds two narrow, host-owned IPC channels (`app:open-external`, `app:reveal-in-folder`) as the *only* path from the renderer into `shell.openExternal` / `shell.showItemInFolder` (renderer has no direct Node/Electron access). Only well-formed http/https URLs ever reach `openExternal`; `file`-type links only reveal in the system file manager, and only after confirming the path exists on disk.
- Links section now renders per `link_type`: `url` / `spec` (when the ref is itself a URL) / `github_issue` (accepts both `owner/repo#123` shorthand and full GitHub issue/PR URLs) open in the default browser; `card` swaps the drawer to the referenced card (falls back to plain text if that card no longer exists); `file` reveals in folder.
- `issue_ref` field gets an "Open" button when its value parses as a GitHub ref/URL.
- Bare `http(s)://` URLs inside the card body are linkified at display time only (never mutates the stored body).
- `KanbanViewReact.tsx`: the drawer's render no longer requires the target card to be present in the currently *filtered* `cards` list, so a `card`-type link still opens a card the active assignee/due filter would otherwise hide.

Fixes #198

## Acceptance criteria

- [x] `url` links in the drawer open in the default browser on click.
- [x] `github_issue` links work with both `owner/repo#123` shorthand and full URLs.
- [x] `card` links open the referenced card in the drawer.
- [x] `issue_ref` has an open affordance when parseable.
- [x] Bare URLs in card body text are clickable.
- [x] Non-http(s) refs never reach `openExternal`; `file` refs only reveal-in-folder.
- [x] Existing add-link form and link persistence unchanged.

## Test plan

- [x] `npm run build` -- clean (renderer + main tsc, asset copy)
- [x] New unit tests: `src/main/handlers/__tests__/link-handlers.test.ts` (IPC gate: allowed/rejected URL shapes, exists-before-reveal), `src/renderer/components/kanban/__tests__/link-utils.test.ts` (URL/shorthand parsing, body linkify), `src/renderer/components/kanban/__tests__/CardDrawer.links.test.tsx` (per-link-type rendering, issue_ref affordance, body linkify, add-link form unchanged) -- 66/66 passing
- [x] Full suite run for regressions: 25 pre-existing failures (openai-adapter/adapter-integration/provider-manager, ProviderSelector/VariableBrowser a11y, build-orchestrator, repository-manager -- issue #176 baseline, unaffected by this change), 471 passing, none in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)