### PR TITLE
Database Tab Foundation: close out #126 with IPC handler test coverage + checkConnection fix

### DIFF
--- a/src/main/__tests__/database-admin.test.ts
+++ b/src/main/__tests__/database-admin.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for src/main/database-admin.ts -- the module backing the
+ * `database-admin:*` IPC handlers registered in src/main/index.ts (issue #126,
+ * Database Tab Foundation and IPC Handlers).
+ *
+ * These handlers are the foundation that #128 (batch ops UI), #129 (schema
+ * explorer UI), and #130 (backup UI) build on top of, so this suite locks down
+ * the JSON-RPC response parsing (both response shapes MCP-Writing-Servers can
+ * return, plus plain-text and error responses), network-failure error
+ * messages, and that each exported wrapper calls the correct MCP tool name
+ * with the correct arguments.
+ *
+ * The database layer is fully mocked (axios + env-config) -- no real MCP
+ * server or database connection is required.
+ */
+
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('../logger', () => ({
+  LogCategory: { SYSTEM: 'SYSTEM' },
+  logWithCategory: jest.fn(),
+}));
+
+const mockLoadEnvConfig = jest.fn();
+jest.mock('../env-config', () => ({
+  loadEnvConfig: (...args: any[]) => mockLoadEnvConfig(...args),
+}));
+
+import * as databaseAdmin from '../database-admin';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+/** Build a JSON-RPC-format MCP tool response: { jsonrpc, result: { content: [...] }, id }. */
+function jsonRpcResponse(data: unknown, id: number = 1) {
+  return {
+    data: {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        content: [{ type: 'text', text: JSON.stringify(data) }],
+      },
+    },
+  };
+}
+
+/** Build a direct-format MCP tool response: { content: [...] } (no jsonrpc envelope). */
+function directResponse(data: unknown) {
+  return {
+    data: {
+      content: [{ type: 'text', text: JSON.stringify(data) }],
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLoadEnvConfig.mockResolvedValue({ DB_ADMIN_PORT: 3010 });
+});
+
+describe('database-admin response parsing (via queryRecords)', () => {
+  it('parses a JSON-RPC-format response', async () => {
+    mockedAxios.post.mockResolvedValue(jsonRpcResponse({ rows: [{ id: 1 }], totalCount: 1 }));
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: true, data: { rows: [{ id: 1 }], totalCount: 1 } });
+  });
+
+  it('parses a direct-format response (no jsonrpc envelope)', async () => {
+    mockedAxios.post.mockResolvedValue(directResponse({ ok: true }));
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: true, data: { ok: true } });
+  });
+
+  it('strips a text header before the JSON payload', async () => {
+    const payload = { count: 2 };
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        content: [
+          {
+            type: 'text',
+            text: `Query Results from 'characters':\n\nRecords returned: 2\n\n${JSON.stringify(payload)}`,
+          },
+        ],
+      },
+    });
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: true, data: payload });
+  });
+
+  it('returns plain text as data when the response body is not JSON', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { content: [{ type: 'text', text: 'OK, done.' }] },
+    });
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: true, data: 'OK, done.' });
+  });
+
+  it('surfaces a JSON-RPC error object as a failed result', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32000, message: 'Table does not exist', data: 'characters' },
+      },
+    });
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: false, error: 'Table does not exist', data: 'characters' });
+  });
+
+  it('returns a clear error when the MCP server is not running (ECONNREFUSED)', async () => {
+    mockedAxios.post.mockRejectedValue(Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Database administration server is not running. Please start the MCP system first.',
+    });
+  });
+
+  it('returns a timeout-specific error on ETIMEDOUT', async () => {
+    mockedAxios.post.mockRejectedValue(Object.assign(new Error('timeout of 30000ms exceeded'), { code: 'ETIMEDOUT' }));
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: false, error: 'Request timed out after 30 seconds' });
+  });
+
+  it('falls back to the raw error message for other failures', async () => {
+    mockedAxios.post.mockRejectedValue(new Error('socket hang up'));
+
+    const result = await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(result).toEqual({ success: false, error: 'socket hang up' });
+  });
+
+  it('calls the configured DB_ADMIN_PORT, falling back to 3010 if config load fails', async () => {
+    mockLoadEnvConfig.mockRejectedValue(new Error('no config file'));
+    mockedAxios.post.mockResolvedValue(directResponse([]));
+
+    await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://localhost:3010/api/tool-call',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('uses a custom DB_ADMIN_PORT from env config', async () => {
+    mockLoadEnvConfig.mockResolvedValue({ DB_ADMIN_PORT: 4242 });
+    mockedAxios.post.mockResolvedValue(directResponse([]));
+
+    await databaseAdmin.queryRecords({ table: 'characters' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://localhost:4242/api/tool-call',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+});
+
+describe('database-admin tool wrappers call the correct MCP tool + arguments', () => {
+  beforeEach(() => {
+    mockedAxios.post.mockResolvedValue(directResponse({}));
+  });
+
+  function toolCallBody() {
+    return mockedAxios.post.mock.calls[0][1] as any;
+  }
+
+  it('queryRecords -> db_query_records', async () => {
+    const params = { table: 'characters', limit: 10 };
+    await databaseAdmin.queryRecords(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_query_records', arguments: params });
+  });
+
+  it('insertRecord -> db_insert_record', async () => {
+    const params = { table: 'characters', data: { name: 'Mal' } };
+    await databaseAdmin.insertRecord(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_insert_record', arguments: params });
+  });
+
+  it('updateRecords -> db_update_records', async () => {
+    const params = { table: 'characters', data: { name: 'Mal' }, where: { id: 1 } };
+    await databaseAdmin.updateRecords(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_update_records', arguments: params });
+  });
+
+  it('deleteRecords -> db_delete_records', async () => {
+    const params = { table: 'characters', where: { id: 1 } };
+    await databaseAdmin.deleteRecords(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_delete_records', arguments: params });
+  });
+
+  it('batchInsert -> db_batch_insert', async () => {
+    const params = { table: 'characters', records: [{ name: 'Mal' }, { name: 'Jax' }] };
+    await databaseAdmin.batchInsert(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_batch_insert', arguments: params });
+  });
+
+  it('batchUpdate -> db_batch_update', async () => {
+    const params = { table: 'characters', updates: [{ where: { id: 1 }, data: { name: 'Mal' } }] };
+    await databaseAdmin.batchUpdate(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_batch_update', arguments: params });
+  });
+
+  it('batchDelete -> db_batch_delete', async () => {
+    const params = { table: 'characters', conditions: [{ id: 1 }] };
+    await databaseAdmin.batchDelete(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_batch_delete', arguments: params });
+  });
+
+  it('getSchema -> db_get_schema', async () => {
+    const params = { table: 'characters', includeConstraints: true };
+    await databaseAdmin.getSchema(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_get_schema', arguments: params });
+  });
+
+  it('listTables -> db_list_tables with no arguments', async () => {
+    await databaseAdmin.listTables();
+    expect(toolCallBody().params).toEqual({ name: 'db_list_tables', arguments: {} });
+  });
+
+  it('getRelationships -> db_get_relationships', async () => {
+    const params = { table: 'characters' };
+    await databaseAdmin.getRelationships(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_get_relationships', arguments: params });
+  });
+
+  it('listColumns -> db_list_columns', async () => {
+    const params = { table: 'characters' };
+    await databaseAdmin.listColumns(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_list_columns', arguments: params });
+  });
+
+  it('queryAuditLogs -> db_query_audit_logs', async () => {
+    const params = { table: 'characters', operation: 'UPDATE' as const };
+    await databaseAdmin.queryAuditLogs(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_query_audit_logs', arguments: params });
+  });
+
+  it('getAuditSummary -> db_get_audit_summary', async () => {
+    const params = { table: 'characters' };
+    await databaseAdmin.getAuditSummary(params);
+    expect(toolCallBody().params).toEqual({ name: 'db_get_audit_summary', arguments: params });
+  });
+
+  it('getServerInfo -> db_get_server_info with no arguments', async () => {
+    await databaseAdmin.getServerInfo();
+    expect(toolCallBody().params).toEqual({ name: 'db_get_server_info', arguments: {} });
+  });
+});
+
+describe('checkConnection', () => {
+  it('reports connected when /health responds 200', async () => {
+    mockedAxios.get.mockResolvedValue({ status: 200 });
+
+    const result = await databaseAdmin.checkConnection();
+
+    expect(result).toEqual({ success: true, message: 'Connected to database administration server' });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a real tool call when /health does not exist, and reports connected if it succeeds', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('404'));
+    mockedAxios.post.mockResolvedValue(directResponse([]));
+
+    const result = await databaseAdmin.checkConnection();
+
+    expect(result).toEqual({ success: true, message: 'Connected to database administration server' });
+    expect(mockedAxios.post).toHaveBeenCalled();
+  });
+
+  it('reports disconnected when both /health and the tool-call fallback fail', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('404'));
+    mockedAxios.post.mockRejectedValue(
+      Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })
+    );
+
+    const result = await databaseAdmin.checkConnection();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('reports disconnected when /health responds with a non-2xx status and the fallback also fails', async () => {
+    mockedAxios.get.mockResolvedValue({ status: 503 });
+    mockedAxios.post.mockRejectedValue(new Error('unreachable'));
+
+    const result = await databaseAdmin.checkConnection();
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/main/__tests__/database-backup.test.ts
+++ b/src/main/__tests__/database-backup.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for src/main/database-backup.ts -- the module backing the
+ * `database-backup:*` IPC handlers registered in src/main/index.ts (issue
+ * #126, Database Tab Foundation and IPC Handlers). #130 (Backup Management
+ * UI) builds its UI on top of these handlers.
+ *
+ * All I/O (child_process exec, fs-extra, Electron dialog/app) is mocked --
+ * no real Docker container, Postgres instance, or filesystem access is
+ * required. This also documents (via the exec command assertions) that
+ * backups operate against the `fictionlab-postgres` container and are
+ * written under Electron's userData directory, not the
+ * `C:\Backups\fictionlab` path used by the separate "FictionLab DB Daily
+ * Backup" Windows Task -- confirming the two don't collide.
+ */
+
+const mockExecAsync = jest.fn();
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+}));
+jest.mock('util', () => ({
+  ...jest.requireActual('util'),
+  promisify: () => mockExecAsync,
+}));
+
+jest.mock('../logger', () => ({
+  LogCategory: { SYSTEM: 'SYSTEM' },
+  logWithCategory: jest.fn(),
+}));
+
+jest.mock('../prerequisites', () => ({
+  getFixedEnv: jest.fn(() => ({ PATH: '/usr/bin' })),
+}));
+
+const mockLoadEnvConfig = jest.fn();
+jest.mock('../env-config', () => ({
+  loadEnvConfig: (...args: any[]) => mockLoadEnvConfig(...args),
+}));
+
+const mockShowSaveDialog = jest.fn();
+const mockShowOpenDialog = jest.fn();
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => 'C:/fake-userdata'),
+  },
+  dialog: {
+    showSaveDialog: (...args: any[]) => mockShowSaveDialog(...args),
+    showOpenDialog: (...args: any[]) => mockShowOpenDialog(...args),
+  },
+  shell: {
+    openPath: jest.fn(),
+  },
+}));
+
+import * as fs from 'fs-extra';
+jest.mock('fs-extra');
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+import * as databaseBackup from '../database-backup';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLoadEnvConfig.mockResolvedValue({
+    POSTGRES_DB: 'mcp_writing_db',
+    POSTGRES_USER: 'postgres',
+    POSTGRES_PASSWORD: 'secret',
+  });
+  mockedFs.ensureDir.mockResolvedValue(undefined as any);
+  mockedFs.pathExists.mockResolvedValue(true as any);
+});
+
+describe('createBackup', () => {
+  it('runs pg_dump inside the fictionlab-postgres container and writes the output to disk', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'BINARYDUMP', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 2048 } as any);
+
+    const result = await databaseBackup.createBackup();
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBeTruthy();
+    expect(result.size).toBe(2048);
+
+    const [command] = mockExecAsync.mock.calls[0];
+    expect(command).toContain('docker exec fictionlab-postgres pg_dump');
+    expect(command).toContain('-U postgres');
+    expect(command).toContain('-d mcp_writing_db');
+
+    expect(mockedFs.writeFile).toHaveBeenCalledWith(expect.any(String), 'BINARYDUMP');
+  });
+
+  it('writes backups under the Electron userData directory by default (not C:\\Backups\\fictionlab)', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'BINARYDUMP', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 1024 } as any);
+
+    const result = await databaseBackup.createBackup();
+
+    expect(result.path).toContain('fake-userdata');
+    expect(result.path).not.toContain('Backups');
+  });
+
+  it('honors a custom backup path when provided', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'BINARYDUMP', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 512 } as any);
+
+    const result = await databaseBackup.createBackup('D:/custom/my-backup.sql.gz');
+
+    expect(result.path).toBe('D:/custom/my-backup.sql.gz');
+    expect(mockedFs.writeFile).toHaveBeenCalledWith('D:/custom/my-backup.sql.gz', 'BINARYDUMP');
+  });
+
+  it('uses plain SQL pg_dump (no -Fc/-Z) when compressed=false', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'PLAINSQL', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+
+    await databaseBackup.createBackup(undefined, false);
+
+    const [command] = mockExecAsync.mock.calls[0];
+    expect(command).not.toContain('-Fc');
+  });
+
+  it('returns a failure result (not a throw) when pg_dump fails', async () => {
+    mockExecAsync.mockRejectedValue(new Error('docker: container not found'));
+
+    const result = await databaseBackup.createBackup();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('container not found');
+    expect(mockedFs.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('restoreBackup', () => {
+  it('rejects when the backup file does not exist', async () => {
+    mockedFs.pathExists.mockResolvedValue(false as any);
+
+    const result = await databaseBackup.restoreBackup('C:/missing.sql.gz');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+    expect(mockExecAsync).not.toHaveBeenCalled();
+  });
+
+  it('copies the backup into the container and runs pg_restore for a compressed backup', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const result = await databaseBackup.restoreBackup('C:/backups/mcp_writing_db_2026-01-01.sql.gz');
+
+    expect(result.success).toBe(true);
+    const commands = mockExecAsync.mock.calls.map((call) => call[0]);
+    expect(commands.some((c) => c.startsWith('docker cp'))).toBe(true);
+    expect(commands.some((c) => c.includes('pg_restore'))).toBe(true);
+  });
+
+  it('runs psql (not pg_restore) for an uncompressed .sql backup', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await databaseBackup.restoreBackup('C:/backups/mcp_writing_db_2026-01-01.sql');
+
+    const commands = mockExecAsync.mock.calls.map((call) => call[0]);
+    expect(commands.some((c) => c.includes('psql') && c.includes('-f'))).toBe(true);
+    expect(commands.some((c) => c.includes('pg_restore'))).toBe(false);
+  });
+
+  it('drops and recreates the database first when dropExisting is true', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await databaseBackup.restoreBackup('C:/backups/mcp_writing_db_2026-01-01.sql.gz', true);
+
+    const commands = mockExecAsync.mock.calls.map((call) => call[0]);
+    expect(commands.some((c) => c.includes('pg_terminate_backend'))).toBe(true);
+    expect(commands.some((c) => c.includes('dropdb'))).toBe(true);
+    expect(commands.some((c) => c.includes('createdb'))).toBe(true);
+  });
+
+  it('treats stderr containing ERROR as a failed restore', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: '', stderr: 'ERROR: relation does not exist' });
+
+    const result = await databaseBackup.restoreBackup('C:/backups/mcp_writing_db_2026-01-01.sql.gz');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('ERROR');
+  });
+
+  it('does not fail the restore if only the container cleanup step throws', async () => {
+    mockExecAsync
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // docker cp
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // pg_restore
+      .mockRejectedValueOnce(new Error('rm failed')); // cleanup
+
+    const result = await databaseBackup.restoreBackup('C:/backups/mcp_writing_db_2026-01-01.sql.gz');
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('listBackups', () => {
+  it('returns only .sql/.sql.gz files, sorted newest first', async () => {
+    mockedFs.readdir.mockResolvedValue(['ignore.txt', 'mcp_writing_db_2026-01-01.sql', 'mcp_writing_db_2026-02-01.sql.gz'] as any);
+    mockedFs.stat.mockImplementation(async (p: any) => {
+      const path = String(p);
+      if (path.includes('2026-01-01')) return { mtime: new Date('2026-01-01'), size: 100 } as any;
+      return { mtime: new Date('2026-02-01'), size: 200 } as any;
+    });
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result.success).toBe(true);
+    expect(result.backups).toHaveLength(2);
+    expect(result.backups[0].filename).toBe('mcp_writing_db_2026-02-01.sql.gz');
+    expect(result.backups[0].compressed).toBe(true);
+    expect(result.backups[1].compressed).toBe(false);
+  });
+
+  it('returns an empty, successful result when the directory has no backups', async () => {
+    mockedFs.readdir.mockResolvedValue([] as any);
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result).toEqual({ success: true, backups: [] });
+  });
+
+  it('returns a failure result if the directory cannot be read', async () => {
+    mockedFs.readdir.mockRejectedValue(new Error('EACCES'));
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result.success).toBe(false);
+    expect(result.backups).toEqual([]);
+    expect(result.error).toContain('EACCES');
+  });
+});
+
+describe('deleteBackup', () => {
+  it('deletes an existing backup file', async () => {
+    mockedFs.remove.mockResolvedValue(undefined as any);
+
+    const result = await databaseBackup.deleteBackup('C:/backups/old.sql');
+
+    expect(result.success).toBe(true);
+    expect(mockedFs.remove).toHaveBeenCalledWith('C:/backups/old.sql');
+  });
+
+  it('fails without touching the filesystem if the file is missing', async () => {
+    mockedFs.pathExists.mockResolvedValue(false as any);
+
+    const result = await databaseBackup.deleteBackup('C:/backups/missing.sql');
+
+    expect(result.success).toBe(false);
+    expect(mockedFs.remove).not.toHaveBeenCalled();
+  });
+});
+
+describe('save/open dialogs', () => {
+  it('returns null (not a throw) when the save dialog is canceled', async () => {
+    mockShowSaveDialog.mockResolvedValue({ canceled: true });
+
+    const result = await databaseBackup.selectBackupSaveLocation();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the chosen path from the save dialog', async () => {
+    mockShowSaveDialog.mockResolvedValue({ canceled: false, filePath: 'C:/chosen/backup.sql.gz' });
+
+    const result = await databaseBackup.selectBackupSaveLocation();
+
+    expect(result).toBe('C:/chosen/backup.sql.gz');
+  });
+
+  it('returns null when the restore-file open dialog is canceled', async () => {
+    mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+
+    const result = await databaseBackup.selectBackupFileForRestore();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the chosen path from the open dialog', async () => {
+    mockShowOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['C:/chosen/restore.sql'] });
+
+    const result = await databaseBackup.selectBackupFileForRestore();
+
+    expect(result).toBe('C:/chosen/restore.sql');
+  });
+});
+
+describe('getBackupDirectoryPath', () => {
+  it('resolves under the Electron userData directory', () => {
+    expect(databaseBackup.getBackupDirectoryPath()).toBe(require('path').join('C:/fake-userdata', 'backups'));
+  });
+});

--- a/src/main/database-admin.ts
+++ b/src/main/database-admin.ts
@@ -440,17 +440,36 @@ export async function checkConnection(): Promise<DatabaseOperationResult> {
   try {
     const baseUrl = await getMCPServerUrl();
 
-    // Try a simple health check or list tables
-    const response = await axios.get(`${baseUrl}/health`, {
-      timeout: 5000,
-    }).catch(() => {
-      // If /health doesn't exist, try calling a simple tool
-      return callMCPTool('db_list_tables', {});
-    });
+    // Try a simple health check first.
+    try {
+      const response = await axios.get(`${baseUrl}/health`, {
+        timeout: 5000,
+      });
+      if (response.status >= 200 && response.status < 300) {
+        return {
+          success: true,
+          message: 'Connected to database administration server',
+        };
+      }
+    } catch {
+      // /health may not exist on this server version -- fall through to the
+      // tool-call fallback below instead of failing outright.
+    }
+
+    // If /health doesn't exist (or didn't respond OK), fall back to calling a
+    // real, cheap tool so we actually confirm the server is reachable instead
+    // of assuming success just because a request was attempted.
+    const fallback = await callMCPTool('db_list_tables', {});
+    if (fallback.success) {
+      return {
+        success: true,
+        message: 'Connected to database administration server',
+      };
+    }
 
     return {
-      success: true,
-      message: 'Connected to database administration server',
+      success: false,
+      error: fallback.error || 'Cannot connect to database administration server',
     };
   } catch (error: any) {
     return {


### PR DESCRIPTION
## Summary

Issue #126 (Database Tab Foundation and IPC Handlers) asked for:
- `database-admin:*` / `database-backup:*` IPC handlers proxying to MCP-Writing-Servers' 25 database admin tools
- A renderer `databaseService` wrapper
- A `DatabaseTab` component
- Preload API exposure + `main/index.ts` registration

Auditing the current `develop` branch against those acceptance criteria found **all of it already implemented and merged**:
- `cf1d27e` "Implement Database Tab Foundation and IPC Handlers (Issue #126)" (Nov 2025) — `src/main/database-admin.ts`, `databaseService.ts`, `DatabaseTab.ts`, preload wiring, `main/index.ts` registration
- `3ec4248` "feat: Implement Database Admin UI Components (Issues #127-#130)" — the `DatabaseAdmin/{CRUD,Backup,Batch,Schema}` component families
- `ViewRouter.ts` already registers `settings-database` → `DatabaseView` → `DatabaseTab`; `Sidebar.ts` already has the nav item

The GitHub issue was simply never closed — those commits didn't say "Fixes #126". This PR closes that loop by fixing the one real gap found during the audit and adding the test coverage the foundation was missing, without touching #128/#129/#130's UI scope.

## What this PR actually changes

**1. Bug fix — `checkConnection()` always reported "connected" (`src/main/database-admin.ts`)**

The `/health` request result (and its `db_list_tables` fallback) was computed but never checked:

```ts
const response = await axios.get(`${baseUrl}/health`, { timeout: 5000 }).catch(() => {
  return callMCPTool('db_list_tables', {});
});
return { success: true, message: 'Connected to database administration server' }; // always!
```

Neither branch throws, so the function unconditionally returned `success: true` unless an exception literally propagated out of `getMCPServerUrl()`. This meant the "Connected/Disconnected" indicator in `LogsTab.ts` (which polls `checkConnection()` every 30s) could never actually show "Disconnected". Fixed to check the `/health` status and the fallback tool call's actual result before reporting connected.

**2. Unit test coverage for the IPC-backing modules (none existed before)**

- `src/main/__tests__/database-admin.test.ts` (28 tests) — JSON-RPC and direct MCP response formats, header-prefixed/plain-text response parsing, JSON-RPC error responses, `ECONNREFUSED`/`ETIMEDOUT` handling, per-tool argument passing for all 15 wrapper functions, and the `checkConnection()` fix above. Mocks `axios` + `env-config`.
- `src/main/__tests__/database-backup.test.ts` (21 tests) — `createBackup`/`restoreBackup`/`listBackups`/`deleteBackup`/save-and-open dialogs, including the `fictionlab-postgres` docker exec commands, compressed vs. plain SQL, `dropExisting` recreate flow, and stderr `ERROR` detection. Mocks `child_process`, `fs-extra`, and Electron dialogs.

## Verified for #128/#129/#130 (not implemented here — out of scope)

- `DatabaseAdmin/Batch/{BatchInsert,BatchUpdate,CSVUploader}.ts` and `DatabaseAdmin/Schema/{SchemaExplorer,TableDetails,RelationshipDiagram}.ts` already exist in the tree (from `3ec4248`) but aren't imported anywhere outside their own directories — unwired scaffolding for #128/#129 to plug into `DatabaseTab.ts`, the same way `BackupManager`/`CRUDPanel` are already wired in. Left untouched so those issues have a clean surface to build on.
- `database-backup.ts` writes backups under Electron's `userData` directory, not `C:\Backups\fictionlab` — confirmed no collision with the separate "FictionLab DB Daily Backup" Windows Task automation.
- `ViewRouter`/`Sidebar` registration for the database tab was already correct; no shared-shell changes were needed (kept my footprint there at zero, since other agents are concurrently working #132/#124/#123).

## Test plan
- [x] `npm run build` — clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] New tests: `npx jest src/main/__tests__/database-admin.test.ts src/main/__tests__/database-backup.test.ts` (49/49 passing)
- [x] Full `npx jest` — 520 passed / 25 failed / 3 skipped, vs. baseline (before this change) of 471 passed / 25 failed / 3 skipped — same pre-existing failures (issue #176), zero new failures, 49 new passing tests
- [ ] Visual/manual verification — this session has no GUI (`ELECTRON_RUN_AS_NODE=1`); Rebecca, please verify once built: open the Database tab, watch the Logs tab's DB connection indicator show "Disconnected" if the MCP admin server (port from `DB_ADMIN_PORT`, default 3010) isn't running, and "Connected" once it is

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)