### PR TITLE
fix(dashboard): wire up Dashboard tab cleanup and top-bar actions

### DIFF
--- a/src/renderer/components/__tests__/DashboardTab.test.ts
+++ b/src/renderer/components/__tests__/DashboardTab.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for DashboardTab (issue #132: Migrate Dashboard Card to Dashboard Tab).
+ *
+ * DashboardTab is the content component DashboardView.ts mounts inside the
+ * ViewRouter's `dashboard` view slot. These tests guard the four sections
+ * issue #132 specifies plus its acceptance criteria:
+ *  - Status Bar (top) with a system status indicator
+ *  - Quick Actions grid, with "Open Typing Mind" prominent
+ *  - Service Status Summary cards (PostgreSQL, MCP Servers, Typing Mind)
+ *  - Recent Activity (last 5 events)
+ *  - Auto-refresh runs on a timer
+ */
+
+import { DashboardTab } from '../DashboardTab';
+
+describe('DashboardTab', () => {
+  let dashboard: DashboardTab;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="dashboard-card"></div>';
+    dashboard = new DashboardTab();
+  });
+
+  afterEach(() => {
+    dashboard.destroy();
+    document.body.innerHTML = '';
+  });
+
+  describe('initial render', () => {
+    beforeEach(() => {
+      dashboard.initialize();
+    });
+
+    it('renders the status bar with a system status indicator', () => {
+      const indicator = document.getElementById('dashboard-status-indicator');
+      const text = document.getElementById('dashboard-status-text');
+      expect(indicator).not.toBeNull();
+      expect(indicator!.classList.contains('status-red')).toBe(true);
+      expect(text!.textContent).toBe('System Offline');
+    });
+
+    it('renders the quick actions grid with system controls', () => {
+      expect(document.getElementById('dashboard-start-system')).not.toBeNull();
+      expect(document.getElementById('dashboard-stop-system')).not.toBeNull();
+      expect(document.getElementById('dashboard-restart-system')).not.toBeNull();
+      expect(document.getElementById('dashboard-refresh-status')).not.toBeNull();
+    });
+
+    it('renders the "Open Typing Mind" button as prominent', () => {
+      const button = document.getElementById('dashboard-open-typing-mind');
+      expect(button).not.toBeNull();
+      expect(button!.classList.contains('prominent')).toBe(true);
+    });
+
+    it('renders service status summary cards for PostgreSQL and MCP servers', () => {
+      const postgresCard = document.getElementById('postgres-card');
+      const mcpCard = document.getElementById('mcp-servers-card');
+      expect(postgresCard).not.toBeNull();
+      expect(postgresCard!.querySelector('h4')!.textContent).toBe('PostgreSQL');
+      expect(mcpCard).not.toBeNull();
+    });
+
+    it('renders an "Open Browser" action on the Typing Mind card', () => {
+      const typingMindCard = document.getElementById('typing-mind-card');
+      expect(typingMindCard).not.toBeNull();
+      expect(typingMindCard!.querySelector('.open-browser-btn')).not.toBeNull();
+    });
+
+    it('renders an empty Recent Activity section with no events', () => {
+      const activityList = document.getElementById('activity-list');
+      expect(activityList).not.toBeNull();
+      expect(activityList!.querySelector('.activity-empty')).not.toBeNull();
+    });
+  });
+
+  describe('recent activity (last 5 events)', () => {
+    beforeEach(() => {
+      dashboard.initialize();
+    });
+
+    it('adds an event to the activity list', () => {
+      dashboard.addEvent('success', 'System started');
+
+      const activityList = document.getElementById('activity-list')!;
+      expect(activityList.querySelector('.activity-empty')).toBeNull();
+      expect(activityList.textContent).toContain('System started');
+      expect(dashboard.getRecentEvents()).toHaveLength(1);
+    });
+
+    it('keeps only the most recent 5 events, newest first', () => {
+      for (let i = 1; i <= 7; i++) {
+        dashboard.addEvent('info', `Event ${i}`);
+      }
+
+      const events = dashboard.getRecentEvents();
+      expect(events).toHaveLength(5);
+      expect(events[0].message).toBe('Event 7');
+      expect(events[4].message).toBe('Event 3');
+    });
+
+    it('escapes HTML in event messages', () => {
+      dashboard.addEvent('error', '<img src=x onerror=alert(1)>');
+
+      const activityList = document.getElementById('activity-list')!;
+      expect(activityList.querySelector('img')).toBeNull();
+      expect(activityList.innerHTML).toContain('&lt;img');
+    });
+
+    it('clearActivity() empties the list back to the empty state', () => {
+      dashboard.addEvent('info', 'Something happened');
+      dashboard.clearActivity();
+
+      expect(dashboard.getRecentEvents()).toHaveLength(0);
+      expect(document.getElementById('activity-list')!.querySelector('.activity-empty')).not.toBeNull();
+    });
+  });
+
+  describe('updateStatusIndicator', () => {
+    beforeEach(() => {
+      dashboard.initialize();
+    });
+
+    it.each([
+      ['online', 'status-green'],
+      ['degraded', 'status-yellow'],
+      ['starting', 'status-yellow'],
+      ['offline', 'status-red'],
+    ] as const)('sets %s status to the %s indicator class', (status, expectedClass) => {
+      dashboard.updateStatusIndicator(status, 'Some text');
+
+      const indicator = document.getElementById('dashboard-status-indicator')!;
+      expect(indicator.classList.contains(expectedClass)).toBe(true);
+      expect(document.getElementById('dashboard-status-text')!.textContent).toBe('Some text');
+    });
+  });
+
+  describe('auto-refresh', () => {
+    it('starts a 10-second refresh timer on initialize', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      dashboard.initialize();
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10000);
+      setIntervalSpy.mockRestore();
+    });
+
+    it('clears the refresh timer on destroy', () => {
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      dashboard.initialize();
+      dashboard.destroy();
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
+    });
+  });
+});

--- a/src/renderer/dashboard-handlers.ts
+++ b/src/renderer/dashboard-handlers.ts
@@ -1556,3 +1556,25 @@ export function cleanupDashboard(): void {
   stopStatusPolling();
   window.electronAPI.mcpSystem.removeProgressListener();
 }
+
+/**
+ * Export a diagnostic report for the Dashboard's top-bar "Export Report"
+ * action. Reuses the same `logger.exportDiagnosticReport` IPC call the
+ * Setup/Logs views use, but standalone (no dependence on a DOM button
+ * living outside the dashboard) so it can be invoked directly from
+ * DashboardView.handleAction('export').
+ */
+export async function exportDashboardDiagnosticReport(): Promise<void> {
+  try {
+    const result = await window.electronAPI.logger.exportDiagnosticReport();
+
+    if (result.success) {
+      showNotification(`Diagnostic report exported to: ${result.path}`, 'success');
+    } else {
+      showNotification(`Failed to export report: ${result.error}`, 'error');
+    }
+  } catch (error) {
+    console.error('Error exporting diagnostic report:', error);
+    showNotification('Failed to export diagnostic report', 'error');
+  }
+}

--- a/src/renderer/views/DashboardView.ts
+++ b/src/renderer/views/DashboardView.ts
@@ -7,6 +7,7 @@
 import type { View } from '../components/ViewRouter.js';
 import type { TopBarConfig } from '../components/TopBar.js';
 import { DashboardTab } from '../components/DashboardTab.js';
+import { cleanupDashboard, exportDashboardDiagnosticReport, updateSystemStatus } from '../dashboard-handlers.js';
 
 export class DashboardView implements View {
   private container: HTMLElement | null = null;
@@ -51,6 +52,17 @@ export class DashboardView implements View {
     }
     this.dashboardTab = null;
     this.container = null;
+
+    // Stop dashboard-handlers.ts's status polling / progress listener.
+    // Without this, navigating to another view left a 5-second interval
+    // (and its IPC progress listener) running forever in the background --
+    // cleanupDashboard() already existed for exactly this purpose but was
+    // never wired up to a view lifecycle hook.
+    try {
+      cleanupDashboard();
+    } catch (error) {
+      console.error('[DashboardView] Failed to clean up dashboard handlers:', error);
+    }
   }
 
   /**
@@ -61,12 +73,20 @@ export class DashboardView implements View {
 
     switch (actionId) {
       case 'refresh':
-        // Trigger dashboard refresh
+        // Trigger an immediate status refresh (same call the 5s polling
+        // loop makes) rather than only firing an event nobody listened for.
         window.dispatchEvent(new CustomEvent('dashboard-refresh'));
+        updateSystemStatus().catch((error) => {
+          console.error('[DashboardView] Refresh failed:', error);
+        });
         break;
       case 'export':
-        // Trigger export functionality
+        // Export a diagnostic report via the same IPC call the Setup/Logs
+        // views use, rather than only firing an event nobody listened for.
         window.dispatchEvent(new CustomEvent('dashboard-export'));
+        exportDashboardDiagnosticReport().catch((error) => {
+          console.error('[DashboardView] Export failed:', error);
+        });
         break;
       default:
         console.warn('[DashboardView] Unknown action:', actionId);

--- a/src/renderer/views/__tests__/DashboardView.test.ts
+++ b/src/renderer/views/__tests__/DashboardView.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for DashboardView's wiring to dashboard-handlers.ts
+ * (issue #132: Migrate Dashboard Card to Dashboard Tab).
+ *
+ * DashboardView is the thin View-interface wrapper ViewRouter mounts for the
+ * `dashboard` route; it delegates real content to DashboardTab, which in turn
+ * defers system-status polling and button handling to dashboard-handlers.ts.
+ * Two real gaps existed in that wrapper:
+ *
+ *  - dashboard-handlers.ts exports cleanupDashboard() specifically documented
+ *    as "called when navigating away" (it stops the 5s status-polling
+ *    setInterval and removes an IPC progress listener), but nothing ever
+ *    called it -- so leaving the Dashboard view left status polling running
+ *    forever in the background instead of stopping with the view.
+ *  - The top-bar "Refresh" and "Export Report" actions only dispatched
+ *    CustomEvents that nothing listened for -- clicking them did nothing.
+ *
+ * dashboard-handlers.ts is mocked wholesale so these tests can assert on the
+ * wiring itself without needing a full window.electronAPI IPC surface (that
+ * surface is exercised by dashboard-handlers' own callers, not here).
+ */
+
+jest.mock('../../dashboard-handlers.js', () => ({
+  cleanupDashboard: jest.fn(),
+  updateSystemStatus: jest.fn().mockResolvedValue(undefined),
+  exportDashboardDiagnosticReport: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { DashboardView } from '../DashboardView';
+import * as dashboardHandlers from '../../dashboard-handlers.js';
+
+describe('DashboardView', () => {
+  let container: HTMLElement;
+  let view: DashboardView;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<main id="content-area"></main>';
+    container = document.getElementById('content-area')!;
+    view = new DashboardView();
+  });
+
+  afterEach(async () => {
+    // Always tear down, even for tests that mount but don't explicitly
+    // unmount, so DashboardTab's real setInterval doesn't leak between tests.
+    await view.unmount();
+    document.body.innerHTML = '';
+  });
+
+  it('mounts a #dashboard-card container for DashboardTab to render into', async () => {
+    await view.mount(container);
+    expect(container.querySelector('#dashboard-card')).not.toBeNull();
+  });
+
+  it('stops dashboard-handlers status polling on unmount', async () => {
+    await view.mount(container);
+    await view.unmount();
+
+    expect(dashboardHandlers.cleanupDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw if cleanupDashboard itself throws', async () => {
+    (dashboardHandlers.cleanupDashboard as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    await view.mount(container);
+    await expect(view.unmount()).resolves.toBeUndefined();
+  });
+
+  it('triggers a real status refresh on the "refresh" top-bar action', async () => {
+    await view.mount(container);
+    view.handleAction('refresh');
+
+    expect(dashboardHandlers.updateSystemStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers a real diagnostic export on the "export" top-bar action', async () => {
+    await view.mount(container);
+    view.handleAction('export');
+
+    expect(dashboardHandlers.exportDashboardDiagnosticReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes the Dashboard title and Refresh/Export Report top-bar actions', () => {
+    const config = view.getTopBarConfig();
+
+    expect(config.title).toBe('Dashboard');
+    expect(config.actions?.map((a) => a.id)).toEqual(['refresh', 'export']);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #132 asked to migrate the old Dashboard Card content into a Dashboard Tab with a refined layout:
- [x] Status Bar (top) with a system status indicator
- [x] Quick Actions grid (Start/Stop/Restart, **Open Typing Mind** prominent, Refresh)
- [x] Service Status Summary cards (PostgreSQL, MCP Servers, Typing Mind with Open button)
- [x] Recent Activity (last 5 events)

That migration already happened (`DashboardTab.ts`, commit `a64e724`, back in November) and is already wired into the current **Sidebar + TopBar + ViewRouter** app shell via `DashboardView.ts` (the `View`-interface wrapper `ViewRouter.registerDefaultViews()` mounts for the `dashboard` route) — so the four sections, the prominent Typing Mind button, the service cards, and the 5-event activity log all already render correctly. The issue was just never closed.

Auditing the wrapper against the acceptance criteria line by line ("All existing dashboard functions work", "Auto-refresh works") surfaced two real gaps that predate this change:

**Status polling never stopped on navigation.** `dashboard-handlers.ts` already exported `cleanupDashboard()`, documented in its own comment as "called when navigating away" (it stops the 5-second `setInterval` status poll and removes an IPC progress listener) — but nothing in the codebase ever called it. Navigating from Dashboard to any other tab left that polling loop (and its IPC calls) running forever in the background for the lifetime of the app. `DashboardView.unmount()` now calls it.

**Top-bar "Refresh" and "Export Report" did nothing.** `DashboardView.getTopBarConfig()` exposes both as top-bar actions, but `handleAction()` only ever dispatched `CustomEvent`s (`dashboard-refresh`, `dashboard-export`) that nothing in the app listened for — clicking either button was a silent no-op. `handleAction('refresh')` now calls the dashboard's real `updateSystemStatus()` (the same call the 5s poll makes); `handleAction('export')` now calls a new `exportDashboardDiagnosticReport()` in `dashboard-handlers.ts`, which reuses the same `logger.exportDiagnosticReport` IPC call the Setup/Logs views already use for the same feature, just invokable without depending on a DOM button that lives outside the Dashboard.

## Changes
- `src/renderer/dashboard-handlers.ts` — new `exportDashboardDiagnosticReport()`
- `src/renderer/views/DashboardView.ts` — `unmount()` calls `cleanupDashboard()`; `handleAction()` calls the real refresh/export functions instead of only dispatching dead events
- `src/renderer/components/__tests__/DashboardTab.test.ts` — new: structure (status bar, quick actions, prominent Typing Mind button, service cards, recent activity), event cap/HTML-escaping, status indicator classes, 10s auto-refresh timer start/stop
- `src/renderer/views/__tests__/DashboardView.test.ts` — new: mount creates the `#dashboard-card` container, unmount stops polling, top-bar refresh/export actions call the real functions, top-bar config shape

## Test plan
- [x] `npm run build` — clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] New targeted tests pass: `npx jest src/renderer/components/__tests__/DashboardTab.test.ts src/renderer/views/__tests__/DashboardView.test.ts` (22/22 passing)
- [x] Full `npx jest` run: 25 failed / 493 passed — same 7 pre-existing failing suites as before this change (openai-adapter, adapter-integration, provider-manager, ProviderSelector.a11y, VariableBrowser.a11y, build-orchestrator, repository-manager — tracked in #176), none touching dashboard files
- [ ] Visual/manual verification — this session runs with `ELECTRON_RUN_AS_NODE=1`, so no real GUI window can open here. Rebecca, please verify once the Actions build artifact is available:
  - Dashboard tab renders all four sections with the "Open Typing Mind" button visually prominent
  - Clicking the top-bar **Refresh** button on the Dashboard visibly updates status/service cards
  - Clicking the top-bar **Export Report** button produces a success/failure notification and (on success) a report file
  - Navigate away from Dashboard and back a few times — confirm no console spam/growing memory from duplicate polling (should see one "Stopped status polling" log per leave, one "Started status polling" per return)

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)