### PR TITLE
feat(setup): surface disk space check, MCP version, and Claude Desktop config in Setup tab

### DIFF
--- a/src/renderer/components/SetupTab.ts
+++ b/src/renderer/components/SetupTab.ts
@@ -96,6 +96,25 @@ async function loadSetupTabData(): Promise<void> {
   } catch (error) {
     console.error('Error loading Setup Tab data:', error);
   }
+
+  await loadMCPServersVersion();
+}
+
+/**
+ * Load and display the current MCP-Writing-Servers version (non-mutating check,
+ * distinct from the "Update MCP-Writing-Servers" button which also pulls changes)
+ */
+async function loadMCPServersVersion(): Promise<void> {
+  const versionElement = document.getElementById('mcp-servers-current-version');
+  if (!versionElement) return;
+
+  try {
+    const updateCheck = await window.electronAPI.updater.checkMCPServers();
+    versionElement.textContent = `Current Version: ${updateCheck.currentVersion || 'unknown'}`;
+  } catch (error) {
+    console.error('Error loading MCP-Writing-Servers version:', error);
+    versionElement.textContent = 'Current Version: unavailable';
+  }
 }
 
 /**
@@ -111,7 +130,7 @@ export async function checkPrerequisites(): Promise<void> {
     button.textContent = 'Checking...';
 
     // Reset all icons to loading state
-    ['docker', 'git', 'wsl'].forEach(name => {
+    ['docker', 'git', 'wsl', 'disk-space'].forEach(name => {
       const iconElement = document.getElementById(`${name}-status-icon`);
       const detailElement = document.getElementById(`${name}-detail`);
       if (iconElement) {
@@ -130,8 +149,11 @@ export async function checkPrerequisites(): Promise<void> {
       wslItem.style.display = platformInfo.platform === 'windows' ? 'block' : 'none';
     }
 
-    // Check all prerequisites
-    const results = await window.electronAPI.prerequisites.checkAll();
+    // Check all prerequisites (disk space runs concurrently - it's a separate API)
+    const [results] = await Promise.all([
+      window.electronAPI.prerequisites.checkAll(),
+      checkDiskSpace(),
+    ]);
 
     console.log('Prerequisites check results:', results);
 
@@ -147,7 +169,7 @@ export async function checkPrerequisites(): Promise<void> {
     console.error('Error checking prerequisites:', error);
 
     // Show error state
-    ['docker', 'git', 'wsl'].forEach(name => {
+    ['docker', 'git', 'wsl', 'disk-space'].forEach(name => {
       const iconElement = document.getElementById(`${name}-status-icon`);
       const detailElement = document.getElementById(`${name}-detail`);
       if (iconElement) {
@@ -204,6 +226,45 @@ function updatePrereqUI(
     } else {
       errorElement.style.display = 'none';
     }
+  }
+}
+
+/**
+ * Check available disk space (bytes -> human-readable GB), reusing the same
+ * `docker-images:check-disk-space` sizing electron already uses to validate the
+ * bundled Docker images will fit before extraction.
+ */
+async function checkDiskSpace(): Promise<void> {
+  const iconElement = document.getElementById('disk-space-status-icon');
+  const detailElement = document.getElementById('disk-space-detail');
+  const errorElement = document.getElementById('disk-space-error');
+
+  if (!iconElement || !detailElement || !errorElement) return;
+
+  try {
+    const result = await window.electronAPI.dockerImages.checkDiskSpace();
+    iconElement.classList.remove('loading', 'success', 'error');
+
+    const freeGB = (result.freeSpace / 1024 ** 3).toFixed(1);
+    const requiredGB = (result.requiredSpace / 1024 ** 3).toFixed(1);
+
+    if (result.available) {
+      iconElement.classList.add('success');
+      detailElement.textContent = `${freeGB} GB free (${requiredGB} GB recommended)`;
+      errorElement.style.display = 'none';
+    } else {
+      iconElement.classList.add('error');
+      detailElement.textContent = `Low disk space: ${freeGB} GB free`;
+      errorElement.textContent = result.error || `At least ${requiredGB} GB is recommended for Docker images`;
+      errorElement.style.display = 'block';
+    }
+  } catch (error) {
+    console.error('Error checking disk space:', error);
+    iconElement.classList.remove('loading', 'success');
+    iconElement.classList.add('error');
+    detailElement.textContent = 'Check failed';
+    errorElement.textContent = error instanceof Error ? error.message : String(error);
+    errorElement.style.display = 'block';
   }
 }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -391,6 +391,14 @@ interface ElectronAPI {
     openConfigFolder: () => Promise<void>;
     getConfigInstructions: () => Promise<string>;
   };
+  dockerImages: {
+    checkDiskSpace: () => Promise<{
+      available: boolean;
+      freeSpace: number;
+      requiredSpace: number;
+      error?: string;
+    }>;
+  };
   updater: {
     checkAll: () => Promise<any>;
     checkMCPServers: () => Promise<any>;

--- a/src/renderer/views/SetupView.ts
+++ b/src/renderer/views/SetupView.ts
@@ -8,7 +8,7 @@ import type { View } from '../components/ViewRouter.js';
 import type { TopBarConfig } from '../components/TopBar.js';
 import { initializeSetupTab } from '../components/SetupTab.js';
 import { loadEnvConfig, setupEnvConfigListeners } from '../env-config-handlers.js';
-import { loadClientOptions, setupClientSelectionListeners } from '../client-selection-handlers.js';
+import { loadClientOptions, setupClientSelectionListeners, setupClaudeDesktopListeners } from '../client-selection-handlers.js';
 
 export class SetupView implements View {
   private container: HTMLElement | null = null;
@@ -37,6 +37,8 @@ export class SetupView implements View {
       setupClientSelectionListeners();
       loadClientOptions();
 
+      setupClaudeDesktopListeners();
+
       console.log('[SetupView] Form event listeners attached');
     } catch (error) {
       console.error('[SetupView] Failed to initialize setup:', error);
@@ -59,6 +61,7 @@ export class SetupView implements View {
         ${this.renderUpdateTools()}
         ${this.renderPrerequisites()}
         ${this.renderClientSelection()}
+        ${this.renderClaudeDesktopConfig()}
         ${this.renderEnvConfig()}
       </div>
     `;
@@ -113,6 +116,7 @@ export class SetupView implements View {
               MCP-Writing-Servers
               <span class="tooltip" title="Update the MCP Writing Servers repository via git pull">ⓘ</span>
             </label>
+            <div id="mcp-servers-current-version" style="margin-bottom: 8px; font-size: 0.9rem; opacity: 0.9;">Current Version: Loading...</div>
             <button type="button" class="test-button" id="update-mcp-servers" title="Pull latest changes from MCP-Writing-Servers repository">Update MCP-Writing-Servers</button>
             <div id="mcp-update-status" style="margin-top: 8px; font-size: 0.9rem; display: none;"></div>
           </div>
@@ -166,6 +170,15 @@ export class SetupView implements View {
             <div class="prereq-detail" id="wsl-detail">Checking...</div>
             <div class="prereq-error" id="wsl-error" style="display: none;"></div>
           </div>
+
+          <div class="prereq-item" id="disk-space-item">
+            <h3>
+              <span class="status-icon loading" id="disk-space-status-icon"></span>
+              Disk Space
+            </h3>
+            <div class="prereq-detail" id="disk-space-detail">Checking...</div>
+            <div class="prereq-error" id="disk-space-error" style="display: none;"></div>
+          </div>
         </div>
 
         <button class="test-button" id="check-prerequisites" title="Verify that Docker Desktop and Git are properly installed and running on your system">Check Prerequisites</button>
@@ -200,6 +213,40 @@ export class SetupView implements View {
         </div>
 
         <div class="client-selection-status" id="client-selection-status"></div>
+      </div>
+    `;
+  }
+
+  private renderClaudeDesktopConfig(): string {
+    return `
+      <div class="env-config-card" id="claude-desktop-card">
+        <h2>Claude Desktop</h2>
+        <p style="margin-bottom: 20px; opacity: 0.9;">
+          Automatically configure Claude Desktop with your MCP server settings, or manage the configuration manually.
+        </p>
+
+        <div class="form-group">
+          <label>
+            Status
+            <span class="tooltip" title="Whether Claude Desktop's MCP configuration file has been set up">ⓘ</span>
+          </label>
+          <div id="claude-desktop-status-text" style="font-size: 0.95rem; font-weight: 500;">Checking...</div>
+        </div>
+
+        <div class="client-selection-actions" style="justify-content: flex-start; margin-top: 15px;">
+          <button type="button" class="test-button" id="claude-desktop-auto-config-btn" title="Automatically write MCP server settings into Claude Desktop's config file">Auto-Configure Claude Desktop</button>
+          <button type="button" class="test-button" id="claude-desktop-open-folder-btn" title="Open the folder containing Claude Desktop's config file">Open Config Folder</button>
+          <button type="button" class="test-button" id="claude-desktop-reset-btn" style="display: none;" title="Remove all MCP server settings from Claude Desktop's config">Reset Configuration</button>
+        </div>
+
+        <div id="claude-desktop-config-preview" style="display: none; margin-top: 15px;">
+          <label>Current Configuration</label>
+          <pre id="claude-desktop-config-content" class="error-stack"></pre>
+        </div>
+
+        <p style="margin-top: 15px; font-size: 0.85rem; opacity: 0.85;">
+          Don't have Claude Desktop yet? <a href="#" id="claude-desktop-download-link">Download it here</a>.
+        </p>
       </div>
     `;
   }

--- a/src/renderer/views/__tests__/SetupView.test.ts
+++ b/src/renderer/views/__tests__/SetupView.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression tests for the Setup tab content rewrite (issue #123).
+ *
+ * SetupView already wrapped an existing legacy SetupTab component (client
+ * selection, prerequisites, environment configuration, update tools), but it
+ * was missing three things the issue's spec and acceptance criteria called
+ * for:
+ *
+ *  - "Disk space check" under Prerequisites -- the backend already exposed
+ *    `dockerImages.checkDiskSpace()` (used to validate bundled Docker images
+ *    will fit), but nothing in the Setup tab surfaced it.
+ *  - "Show current versions" under Update Tools -- FictionLab's version was
+ *    shown on load, but MCP-Writing-Servers' current version was only ever
+ *    displayed after clicking "Update", not proactively.
+ *  - "Configure Claude Desktop" under Client Setup -- client-selection-handlers.ts
+ *    already had fully-working Claude Desktop status/auto-configure/reset
+ *    handlers (`setupClaudeDesktopListeners`), but nothing rendered the
+ *    corresponding DOM or ever called that function, so the functionality
+ *    was completely unreachable.
+ *
+ * These tests guard all three additions without re-testing the pre-existing
+ * (already covered by manual QA) client selection / env config behavior.
+ */
+
+import { SetupView } from '../SetupView';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeElectronAPIMock(overrides: Record<string, any> = {}) {
+  return {
+    getAppVersion: jest.fn().mockResolvedValue('1.2.3'),
+    getPlatformInfo: jest.fn().mockResolvedValue({ platform: 'win32', arch: 'x64', version: 'v20.0.0' }),
+    prerequisites: {
+      getPlatformInfo: jest.fn().mockResolvedValue({ platform: 'windows' }),
+      checkAll: jest.fn().mockResolvedValue({
+        docker: { installed: true, running: true, version: '24.0' },
+        git: { installed: true, version: '2.40' },
+        wsl: { installed: true, version: 'WSL2' },
+        platform: 'windows',
+      }),
+    },
+    dockerImages: {
+      checkDiskSpace: jest.fn().mockResolvedValue({
+        available: true,
+        freeSpace: 100 * 1024 ** 3,
+        requiredSpace: 20 * 1024 ** 3,
+      }),
+    },
+    updater: {
+      checkMCPServers: jest.fn().mockResolvedValue({ available: false, currentVersion: 'abc1234' }),
+    },
+    envConfig: {
+      getConfig: jest.fn().mockResolvedValue({
+        POSTGRES_DB: 'db',
+        POSTGRES_USER: 'user',
+        POSTGRES_PASSWORD: 'pass',
+        POSTGRES_PORT: 5432,
+        MCP_CONNECTOR_PORT: 3100,
+        HTTP_SSE_PORT: 3200,
+        DB_ADMIN_PORT: 3300,
+        MCP_AUTH_TOKEN: 'tok',
+      }),
+      getEnvFilePath: jest.fn().mockResolvedValue('/fake/.env'),
+      calculatePasswordStrength: jest.fn().mockResolvedValue('strong'),
+      checkPort: jest.fn().mockResolvedValue(true),
+    },
+    clientSelection: {
+      getOptions: jest.fn().mockResolvedValue([]),
+      getSelection: jest.fn().mockResolvedValue({ clients: [] }),
+    },
+    claudeDesktop: {
+      isConfigured: jest.fn().mockResolvedValue(false),
+      getConfig: jest.fn().mockResolvedValue(null),
+      autoConfigure: jest.fn().mockResolvedValue({ success: true }),
+      openConfigFolder: jest.fn().mockResolvedValue(undefined),
+      resetConfig: jest.fn().mockResolvedValue({ success: true }),
+    },
+    ...overrides,
+  };
+}
+
+describe('SetupView content', () => {
+  let container: HTMLElement;
+  let view: SetupView;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<main id="content-area"></main>';
+    container = document.getElementById('content-area')!;
+  });
+
+  afterEach(async () => {
+    await view?.unmount();
+    document.body.innerHTML = '';
+  });
+
+  describe('disk space prerequisite check', () => {
+    it('shows free/required space and a success icon when space is available', async () => {
+      (window as any).electronAPI = makeElectronAPIMock();
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      const icon = document.getElementById('disk-space-status-icon')!;
+      const detail = document.getElementById('disk-space-detail')!;
+
+      expect(icon.classList.contains('success')).toBe(true);
+      expect(icon.classList.contains('loading')).toBe(false);
+      expect(detail.textContent).toBe('100.0 GB free (20.0 GB recommended)');
+    });
+
+    it('shows an error state with the low-space message when unavailable', async () => {
+      (window as any).electronAPI = makeElectronAPIMock({
+        dockerImages: {
+          checkDiskSpace: jest.fn().mockResolvedValue({
+            available: false,
+            freeSpace: 5 * 1024 ** 3,
+            requiredSpace: 20 * 1024 ** 3,
+          }),
+        },
+      });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      const icon = document.getElementById('disk-space-status-icon')!;
+      const detail = document.getElementById('disk-space-detail')!;
+      const error = document.getElementById('disk-space-error')!;
+
+      expect(icon.classList.contains('error')).toBe(true);
+      expect(detail.textContent).toBe('Low disk space: 5.0 GB free');
+      expect(error.style.display).toBe('block');
+      expect(error.textContent).toContain('20.0 GB is recommended');
+    });
+
+    it('is re-checked alongside Docker/Git/WSL when "Check Prerequisites" is clicked', async () => {
+      const checkDiskSpace = jest.fn().mockResolvedValue({
+        available: true,
+        freeSpace: 50 * 1024 ** 3,
+        requiredSpace: 20 * 1024 ** 3,
+      });
+      (window as any).electronAPI = makeElectronAPIMock({ dockerImages: { checkDiskSpace } });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      expect(checkDiskSpace).toHaveBeenCalledTimes(1);
+
+      document.getElementById('check-prerequisites')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushPromises();
+
+      expect(checkDiskSpace).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Update Tools current versions', () => {
+    it('shows the MCP-Writing-Servers current version on load without clicking Update', async () => {
+      const checkMCPServers = jest.fn().mockResolvedValue({ available: true, currentVersion: 'deadbee', latestVersion: '1234567' });
+      (window as any).electronAPI = makeElectronAPIMock({ updater: { checkMCPServers } });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      expect(checkMCPServers).toHaveBeenCalled();
+      expect(document.getElementById('mcp-servers-current-version')!.textContent).toBe('Current Version: deadbee');
+    });
+
+    it('falls back gracefully when the version check fails', async () => {
+      (window as any).electronAPI = makeElectronAPIMock({
+        updater: { checkMCPServers: jest.fn().mockRejectedValue(new Error('git not found')) },
+      });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      expect(document.getElementById('mcp-servers-current-version')!.textContent).toBe('Current Version: unavailable');
+    });
+  });
+
+  describe('Claude Desktop configuration', () => {
+    it('renders the Claude Desktop card and reflects "Not Configured" status', async () => {
+      (window as any).electronAPI = makeElectronAPIMock({
+        claudeDesktop: {
+          isConfigured: jest.fn().mockResolvedValue(false),
+          getConfig: jest.fn().mockResolvedValue(null),
+          autoConfigure: jest.fn().mockResolvedValue({ success: true }),
+          openConfigFolder: jest.fn().mockResolvedValue(undefined),
+          resetConfig: jest.fn().mockResolvedValue({ success: true }),
+        },
+      });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      expect(document.getElementById('claude-desktop-card')).not.toBeNull();
+      const statusText = document.getElementById('claude-desktop-status-text')!;
+      expect(statusText.textContent).toBe('Not Configured');
+    });
+
+    it('reflects "Configured" status and shows the config preview', async () => {
+      (window as any).electronAPI = makeElectronAPIMock({
+        claudeDesktop: {
+          isConfigured: jest.fn().mockResolvedValue(true),
+          getConfig: jest.fn().mockResolvedValue({ mcpServers: { foo: {} } }),
+          autoConfigure: jest.fn().mockResolvedValue({ success: true }),
+          openConfigFolder: jest.fn().mockResolvedValue(undefined),
+          resetConfig: jest.fn().mockResolvedValue({ success: true }),
+        },
+      });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      expect(document.getElementById('claude-desktop-status-text')!.textContent).toBe('✓ Configured');
+      const preview = document.getElementById('claude-desktop-config-preview')!;
+      expect(preview.style.display).toBe('block');
+      expect(document.getElementById('claude-desktop-config-content')!.textContent).toContain('mcpServers');
+    });
+
+    it('calls claudeDesktop.autoConfigure() when the auto-configure button is clicked', async () => {
+      const autoConfigure = jest.fn().mockResolvedValue({ success: true });
+      (window as any).electronAPI = makeElectronAPIMock({
+        claudeDesktop: {
+          isConfigured: jest.fn().mockResolvedValue(false),
+          getConfig: jest.fn().mockResolvedValue(null),
+          autoConfigure,
+          openConfigFolder: jest.fn().mockResolvedValue(undefined),
+          resetConfig: jest.fn().mockResolvedValue({ success: true }),
+        },
+      });
+      view = new SetupView();
+      await view.mount(container);
+      await flushPromises();
+
+      document.getElementById('claude-desktop-auto-config-btn')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushPromises();
+
+      expect(autoConfigure).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #123 asked for a Setup tab covering client setup/config, update tools,
and prerequisites checking. Auditing the live `SetupView` (wrapper) /
`SetupTab` (legacy component) against the issue's spec line by line, most of
it already shipped in earlier PRs - but three pieces of already-written
backend/handler code were never actually wired into the rendered UI:

- **"Disk space check" (Prerequisites Check Section) - missing entirely.**
  `dockerImages.checkDiskSpace()` already existed in the main process (used
  to validate the bundled Docker images will fit before extraction), but
  nothing in the Setup tab surfaced it. It's now a fourth `prereq-item`
  alongside Docker/Git/WSL, re-checked every time "Check Prerequisites" is
  clicked.
- **"Show current versions" (Update Tools Section) - half-done.**
  FictionLab's version was already shown on load, but MCP-Writing-Servers'
  version was only ever shown after clicking "Update" (and only in the
  "already up to date" branch - clicking through an actual update never
  showed it). It's now shown proactively via a non-mutating
  `updater.checkMCPServers()` call, mirroring the FictionLab line.
- **"Configure Claude Desktop" (Client Setup Section) - fully unreachable.**
  `client-selection-handlers.ts` already contained a complete,
  working `setupClaudeDesktopListeners()` / `updateClaudeDesktopStatus()`
  implementation (status text, auto-configure, open-config-folder, reset,
  config JSON preview, download link) - but nothing ever rendered the
  corresponding DOM or called that function from `SetupView`. Added the
  missing card and wired the call into `SetupView.mount()`.

Note: the issue's original spec also mentions "Install/Configure Typing
Mind," but TypingMind's local-install machinery was intentionally removed in
#163/#172 as dead code - not reintroduced here. The generic client-selection
checkboxes already cover client setup/config more generally.

## Changes
- `src/renderer/views/SetupView.ts` - new Claude Desktop card, disk-space
  prereq-item, MCP-Writing-Servers current-version line; wires
  `setupClaudeDesktopListeners()` into `mount()`
- `src/renderer/components/SetupTab.ts` - `checkDiskSpace()` (parallel with
  the existing Docker/Git/WSL `checkAll()`), `loadMCPServersVersion()`
- `src/renderer/renderer.ts` - added `dockerImages.checkDiskSpace` to the
  `ElectronAPI` interface (existing preload method was untyped)
- `src/renderer/views/__tests__/SetupView.test.ts` - new, 8 tests covering
  all three additions

No stylesheet changes - reused existing `prereq-item`, `env-config-card`,
`client-selection-actions`, and `error-stack` classes throughout.

## Test plan
- [x] `npm run build` - clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] New targeted tests: `npx jest src/renderer/views/__tests__/SetupView.test.ts` (8/8 passing)
- [x] Full `npx jest` run: 25 failures, all pre-existing (openai-adapter,
      adapter-integration, provider-manager, ProviderSelector/VariableBrowser
      a11y, build-orchestrator, repository-manager - the known issue #176
      baseline), none touching the files this PR changes
- [ ] Visual/manual verification - this session has no GUI (Electron can't
      open a real window here). Rebecca, please verify once a build is
      available:
  - Settings > Setup tab renders a "Disk Space" prerequisite item and
    "Check Prerequisites" populates it (green if enough free space, red
    with a message if low)
  - Update Tools shows an MCP-Writing-Servers "Current Version: <sha>" line
    on tab load, without clicking anything
  - A new "Claude Desktop" card appears between Client Selection and
    Environment Configuration, showing Configured/Not Configured status,
    and Auto-Configure / Open Config Folder / Reset buttons work end-to-end

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)