### PR TITLE
feat(services): detailed per-service management for the Services tab

### DIFF
--- a/src/main/__tests__/mcp-system-service-control.test.ts
+++ b/src/main/__tests__/mcp-system-service-control.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the per-service control guard in mcp-system.ts (issue #124).
+ *
+ * controlService / getContainerResourceUsage receive their arguments over
+ * IPC, where TypeScript's compile-time types are erased -- and both values
+ * end up interpolated into a shell command line. These tests pin the
+ * runtime whitelist that keeps a compromised renderer from injecting
+ * arbitrary shell commands or targeting non-FictionLab containers.
+ */
+
+// mcp-system.ts pulls in Electron and a wide slice of the main process at
+// import time; none of that is under test here.
+jest.mock('electron', () => ({
+  app: {
+    getVersion: jest.fn(() => '0.0.0-test'),
+    getPath: jest.fn(() => require('os').tmpdir()),
+    getAppPath: jest.fn(() => process.cwd()),
+    isPackaged: false,
+  },
+}));
+jest.mock('child_process', () => ({ exec: jest.fn() }));
+jest.mock('../logger', () => ({
+  logWithCategory: jest.fn(),
+  LogCategory: { DOCKER: 'DOCKER', SYSTEM: 'SYSTEM' },
+}));
+jest.mock('../env-config', () => ({ loadEnvConfig: jest.fn() }));
+jest.mock('../client-selection', () => ({ loadClientSelection: jest.fn() }));
+jest.mock('../typingmind-auto-config', () => ({}));
+jest.mock('../mcp-config-generator', () => ({ getMCPConfigPath: jest.fn(() => '/tmp/mcp-config.json') }));
+jest.mock('../pgbouncer-config', () => ({}));
+jest.mock('../prerequisites', () => ({
+  checkDockerRunning: jest.fn(),
+  getFixedEnv: jest.fn(() => process.env),
+  getPlatform: jest.fn(() => 'windows'),
+}));
+jest.mock('../docker', () => ({ startAndWaitForDocker: jest.fn() }));
+
+import { exec } from 'child_process';
+import {
+  validateServiceControlRequest,
+  controlService,
+  getContainerResourceUsage,
+} from '../mcp-system';
+
+describe('validateServiceControlRequest (issue #124 runtime whitelist)', () => {
+  it.each([
+    ['postgres', 'start'],
+    ['postgres', 'stop'],
+    ['postgres', 'restart'],
+    ['mcp-writing-servers', 'start'],
+    ['mcp-connector', 'restart'],
+  ])('accepts %s / %s', (service, action) => {
+    expect(validateServiceControlRequest(service, action)).toBeNull();
+  });
+
+  it('rejects unknown service names', () => {
+    expect(validateServiceControlRequest('pgadmin', 'start')).toMatch(/Unknown service/);
+  });
+
+  it('rejects shell metacharacters smuggled into the service name', () => {
+    expect(validateServiceControlRequest('postgres; rm -rf /', 'start')).toMatch(/Unknown service/);
+    expect(validateServiceControlRequest('postgres && curl evil', 'restart')).toMatch(/Unknown service/);
+  });
+
+  it('rejects prototype-chain property names', () => {
+    expect(validateServiceControlRequest('__proto__', 'start')).toMatch(/Unknown service/);
+    expect(validateServiceControlRequest('constructor', 'stop')).toMatch(/Unknown service/);
+  });
+
+  it('rejects unknown actions', () => {
+    expect(validateServiceControlRequest('postgres', 'up')).toMatch(/Invalid service action/);
+    expect(validateServiceControlRequest('postgres', 'start; whoami')).toMatch(/Invalid service action/);
+  });
+});
+
+describe('controlService rejection path', () => {
+  beforeEach(() => {
+    (exec as unknown as jest.Mock).mockClear();
+  });
+
+  it('fails without shelling out when the service name is not whitelisted', async () => {
+    const result = await controlService('evil; whoami' as any, 'start');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Unknown service/);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('fails without shelling out when the action is not whitelisted', async () => {
+    const result = await controlService('postgres', 'up --build' as any);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid service action/);
+    expect(exec).not.toHaveBeenCalled();
+  });
+});
+
+describe('getContainerResourceUsage rejection path', () => {
+  beforeEach(() => {
+    (exec as unknown as jest.Mock).mockClear();
+  });
+
+  it('returns null without shelling out for unknown service names', async () => {
+    const result = await getContainerResourceUsage('evil; whoami' as any);
+
+    expect(result).toBeNull();
+    expect(exec).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1141,6 +1141,24 @@ function setupIPC(): void {
     return await mcpSystem.checkPortConflicts();
   });
 
+  // issue #124: per-service start/stop/restart for the Services tab
+  registerHandler('mcp-system:control-service', "", async (
+    _event,
+    serviceName: mcpSystem.ManagedServiceName,
+    action: 'start' | 'stop' | 'restart'
+  ) => {
+    logWithCategory('info', LogCategory.DOCKER, `IPC: ${action} service ${serviceName}...`);
+    return await mcpSystem.controlService(serviceName, action);
+  });
+
+  // issue #124: per-service live resource usage (CPU/memory) for the Services tab
+  registerHandler('mcp-system:resource-usage', "", async (
+    _event,
+    serviceName: mcpSystem.ManagedServiceName
+  ) => {
+    return await mcpSystem.getContainerResourceUsage(serviceName);
+  });
+
   registerHandler('mcp-system:working-directory', "", async () => {
     return mcpSystem.getMCPWorkingDirectoryPath();
   });

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -1903,6 +1903,134 @@ export async function viewServiceLogs(
 }
 
 /**
+ * Individually-controllable services within the docker-compose stack
+ * (issue #124 -- Services tab per-service controls).
+ */
+export type ManagedServiceName = 'postgres' | 'mcp-writing-servers' | 'mcp-connector';
+
+const MANAGED_SERVICE_CONTAINER_MAP: Record<ManagedServiceName, string> = {
+  'postgres': 'fictionlab-postgres',
+  'mcp-writing-servers': 'fictionlab-mcp-servers',
+  'mcp-connector': 'fictionlab-mcp-connector',
+};
+
+const MANAGED_SERVICE_ACTIONS = ['start', 'stop', 'restart'] as const;
+
+/**
+ * Runtime guard for IPC-supplied service-control arguments. TypeScript
+ * types are erased at runtime, and both values are interpolated into a
+ * shell command by execDockerCompose, so they MUST be validated against
+ * explicit whitelists here. Returns an error message, or null when safe.
+ * Exported for tests.
+ */
+export function validateServiceControlRequest(
+  serviceName: string,
+  action: string
+): string | null {
+  if (!(MANAGED_SERVICE_ACTIONS as readonly string[]).includes(action)) {
+    return `Invalid service action "${action}". Allowed: ${MANAGED_SERVICE_ACTIONS.join(', ')}`;
+  }
+  if (!Object.prototype.hasOwnProperty.call(MANAGED_SERVICE_CONTAINER_MAP, serviceName)) {
+    return `Unknown service "${serviceName}". Allowed: ${Object.keys(MANAGED_SERVICE_CONTAINER_MAP).join(', ')}`;
+  }
+  return null;
+}
+
+/**
+ * Start, stop, or restart a single named service within the docker-compose
+ * stack, rather than the whole system (issue #124). Uses
+ * `docker compose <action> <service>` scoped to just that service.
+ */
+export async function controlService(
+  serviceName: ManagedServiceName,
+  action: 'start' | 'stop' | 'restart'
+): Promise<SystemOperationResult> {
+  logWithCategory('info', LogCategory.DOCKER, `Service control: ${action} ${serviceName}`);
+
+  const validationError = validateServiceControlRequest(serviceName, action);
+  if (validationError) {
+    logWithCategory('warn', LogCategory.DOCKER, `Rejected service control request: ${validationError}`);
+    return {
+      success: false,
+      message: validationError,
+      error: validationError,
+    };
+  }
+
+  try {
+    const composeFile = getDockerComposeFilePath('core');
+
+    if (!await fs.pathExists(composeFile)) {
+      throw new Error(`docker-compose.yml not found at ${composeFile}`);
+    }
+
+    await execDockerCompose(composeFile, action, [serviceName]);
+
+    const verbPast = action === 'stop' ? 'stopped' : `${action}ed`;
+    return {
+      success: true,
+      message: `${serviceName} ${verbPast} successfully`,
+    };
+  } catch (error: any) {
+    logWithCategory('error', LogCategory.DOCKER, `Failed to ${action} ${serviceName}`, error);
+    return {
+      success: false,
+      message: `Failed to ${action} ${serviceName}`,
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * Live CPU/memory usage for a single container, read via `docker stats`
+ * (issue #124 -- resource usage monitoring).
+ */
+export interface ContainerResourceUsage {
+  cpuPercent: string;
+  memoryUsage: string;
+  memoryPercent: string;
+}
+
+/**
+ * Get live resource usage for a managed service's container.
+ * Returns null if the container isn't running or stats can't be read
+ * (e.g. Docker unavailable) -- callers should treat null as "not available".
+ */
+export async function getContainerResourceUsage(
+  serviceName: ManagedServiceName
+): Promise<ContainerResourceUsage | null> {
+  // Same runtime guard as controlService: the name reaches a shell command.
+  if (validateServiceControlRequest(serviceName, 'start') !== null) {
+    logWithCategory('warn', LogCategory.DOCKER, `Rejected resource-usage request for unknown service "${serviceName}"`);
+    return null;
+  }
+
+  const containerName = MANAGED_SERVICE_CONTAINER_MAP[serviceName];
+
+  try {
+    const { stdout } = await execAsync(
+      `docker stats --no-stream --format "{{json .}}" ${containerName}`
+    );
+
+    if (!stdout.trim()) {
+      return null;
+    }
+
+    // docker stats prints one JSON object per line; we only asked for one container
+    const stats = JSON.parse(stdout.trim().split('\n')[0]);
+
+    return {
+      cpuPercent: stats.CPUPerc,
+      memoryUsage: stats.MemUsage,
+      memoryPercent: stats.MemPerc,
+    };
+  } catch (error) {
+    logWithCategory('warn', LogCategory.DOCKER, `Failed to get resource usage for ${containerName}`, error);
+    return null;
+  }
+}
+
+/**
  * Save startup metadata
  */
 async function saveStartupMetadata(): Promise<void> {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1414,6 +1414,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     /**
+     * Start, stop, or restart a single named service within the stack
+     * (issue #124 -- per-service controls on the Services tab), rather than
+     * the whole system.
+     */
+    controlService: (
+      serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector',
+      action: 'start' | 'stop' | 'restart'
+    ): Promise<MCPSystemOperationResult> => {
+      return ipcRenderer.invoke('mcp-system:control-service', serviceName, action);
+    },
+
+    /**
+     * Get live CPU/memory usage for a single service's container
+     * (issue #124 -- resource usage monitoring). Resolves to null if the
+     * container isn't running or stats aren't available.
+     */
+    getResourceUsage: (
+      serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector'
+    ): Promise<{ cpuPercent: string; memoryUsage: string; memoryPercent: string } | null> => {
+      return ipcRenderer.invoke('mcp-system:resource-usage', serviceName);
+    },
+
+    /**
      * Get MCP working directory path
      */
     getWorkingDirectory: (): Promise<string> => {

--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -1,36 +1,25 @@
 /**
- * ServicesTab Component
+ * ServicesTab Component (issue #124)
  * Comprehensive service management interface for all FictionLab services
  *
  * Features:
- * - PostgreSQL database management with connection details and controls
- * - MCP Servers monitoring and management
- * - Typing Mind service control with browser launcher
- * - Docker Desktop lifecycle management
- * - Per-service log viewing
- * - Resource usage monitoring
- * - Health status indicators
+ * - PostgreSQL database management with connection details and real controls
+ * - Individual MCP server management (Connector + Writing Servers): status,
+ *   port, start/stop/restart, and per-server logs
+ * - Typing Mind card: cloud app status via its local MCP Connector dependency
+ * - Docker Desktop lifecycle management with real version info
+ * - Per-service log viewing (with credential redaction)
+ * - Real resource usage monitoring via `docker stats`
+ * - Start All / Stop All / Restart All top-bar actions (window events
+ *   dispatched by ServicesView)
+ * - Ports settings section with conflict checking
  */
-
-interface ServiceStatus {
-  running: boolean;
-  healthy: boolean;
-  status: string;
-  health: 'healthy' | 'unhealthy' | 'starting' | 'none' | 'unknown';
-}
 
 interface ContainerHealth {
   name: string;
   status: string;
   health: 'healthy' | 'unhealthy' | 'starting' | 'none' | 'unknown';
   running: boolean;
-}
-
-interface MCPSystemStatus {
-  running: boolean;
-  healthy: boolean;
-  containers: ContainerHealth[];
-  message: string;
 }
 
 interface ServiceUrls {
@@ -54,6 +43,69 @@ interface EnvConfig {
 }
 
 /**
+ * Shape of one entry from mcpSystem.getDetailedStatus().services
+ */
+interface DetailedServiceStatusEntry {
+  serviceName: string;
+  containerName: string;
+  status: 'starting' | 'running' | 'healthy' | 'unhealthy' | 'stopped' | 'missing';
+  health: 'healthy' | 'unhealthy' | 'starting' | 'none' | 'unknown';
+  url?: string;
+  port?: number;
+  message: string;
+}
+
+/**
+ * Live per-container resource usage from mcpSystem.getResourceUsage()
+ */
+interface ResourceUsage {
+  cpuPercent: string;
+  memoryUsage: string;
+  memoryPercent: string;
+}
+
+/**
+ * Services that can be individually controlled via mcpSystem.controlService
+ */
+type ControlledService = 'postgres' | 'mcp-writing-servers' | 'mcp-connector';
+
+type ServiceAction = 'start' | 'stop' | 'restart';
+
+const ACTION_PROGRESS_LABEL: Record<ServiceAction, string> = {
+  start: 'Starting',
+  stop: 'Stopping',
+  restart: 'Restarting',
+};
+
+function pastTense(action: ServiceAction): string {
+  return action === 'stop' ? 'stopped' : `${action}ed`;
+}
+
+/**
+ * Container names as reported by getDetailedStatus, keyed by service id.
+ */
+const SERVICE_CONTAINERS: Record<ControlledService, string> = {
+  'postgres': 'fictionlab-postgres',
+  'mcp-connector': 'fictionlab-mcp-connector',
+  'mcp-writing-servers': 'fictionlab-mcp-servers',
+};
+
+/**
+ * The two individually-managed MCP servers shown in the MCP Servers card.
+ * elementPrefix matches the ids in ServicesView markup
+ * (`<prefix>-status-badge`, `<prefix>-port-info`, `<prefix>-resource-usage`,
+ * `<prefix>-start|stop|restart|view-logs`).
+ */
+const MCP_SERVERS: Array<{
+  service: 'mcp-connector' | 'mcp-writing-servers';
+  elementPrefix: string;
+  displayName: string;
+}> = [
+  { service: 'mcp-connector', elementPrefix: 'mcp-connector', displayName: 'MCP Connector' },
+  { service: 'mcp-writing-servers', elementPrefix: 'mcp-writing-servers', displayName: 'MCP Writing Servers' },
+];
+
+/**
  * A single row in the Ports settings table
  */
 interface PortRowDefinition {
@@ -74,17 +126,24 @@ const PORT_ROWS: PortRowDefinition[] = [
   { key: 'WORKFLOW_MANAGER_PORT', name: 'Workflow Manager' },
 ];
 
-interface DockerStatus {
-  running: boolean;
-  healthy: boolean;
-  message: string;
-  error?: string;
-}
-
 export class ServicesTab {
   private updateInterval: NodeJS.Timeout | null = null;
   private readonly REFRESH_INTERVAL = 5000; // 5 seconds
   private lastSuggestedPortsConfig: EnvConfig | null = null;
+  private dockerVersion: string | null = null;
+
+  // Bound top-bar action handlers (ServicesView dispatches these window
+  // events from its TopBar actions). Kept as fields so cleanup() can
+  // remove exactly the listeners initialize() added.
+  private readonly onStartAllEvent = (): void => {
+    void this.handleSystemAction('start');
+  };
+  private readonly onStopAllEvent = (): void => {
+    void this.handleSystemAction('stop');
+  };
+  private readonly onRestartAllEvent = (): void => {
+    void this.handleSystemAction('restart');
+  };
 
   constructor() {
     console.log('ServicesTab component initialized');
@@ -99,6 +158,9 @@ export class ServicesTab {
     try {
       // Setup event listeners
       this.setupEventListeners();
+
+      // Docker version rarely changes; fetch once and cache
+      await this.loadDockerVersion();
 
       // Load initial service status
       await this.refreshAllServices();
@@ -123,7 +185,7 @@ export class ServicesTab {
     // PostgreSQL controls
     this.setupPostgresListeners();
 
-    // MCP Servers controls
+    // Individual MCP server controls (Connector + Writing Servers)
     this.setupMCPServersListeners();
 
     // Typing Mind controls
@@ -137,6 +199,11 @@ export class ServicesTab {
     if (refreshBtn) {
       refreshBtn.addEventListener('click', () => this.refreshAllServices());
     }
+
+    // Top-bar Start All / Stop All / Restart All actions (issue #124)
+    window.addEventListener('services-start-all', this.onStartAllEvent);
+    window.addEventListener('services-stop-all', this.onStopAllEvent);
+    window.addEventListener('services-restart-all', this.onRestartAllEvent);
 
     // Ports section controls
     this.setupPortsListeners();
@@ -404,37 +471,51 @@ export class ServicesTab {
     const viewLogsBtn = document.getElementById('postgres-view-logs');
     const viewConnectionBtn = document.getElementById('postgres-view-connection');
 
-    if (startBtn) startBtn.addEventListener('click', () => this.handlePostgresStart());
-    if (stopBtn) stopBtn.addEventListener('click', () => this.handlePostgresStop());
-    if (restartBtn) restartBtn.addEventListener('click', () => this.handlePostgresRestart());
+    if (startBtn) startBtn.addEventListener('click', () => this.handleServiceControl('postgres', 'PostgreSQL', 'start'));
+    if (stopBtn) stopBtn.addEventListener('click', () => this.handleServiceControl('postgres', 'PostgreSQL', 'stop'));
+    if (restartBtn) restartBtn.addEventListener('click', () => this.handleServiceControl('postgres', 'PostgreSQL', 'restart'));
     if (viewLogsBtn) viewLogsBtn.addEventListener('click', () => this.handleViewLogs('postgres', 'PostgreSQL'));
     if (viewConnectionBtn) viewConnectionBtn.addEventListener('click', () => this.handleShowConnectionDetails());
   }
 
   /**
-   * Setup MCP Servers service listeners
+   * Setup per-server listeners for the MCP Servers card (issue #124):
+   * each of the two servers gets its own start/stop/restart/logs controls,
+   * plus the card-level aggregate health check.
    */
   private setupMCPServersListeners(): void {
-    const startBtn = document.getElementById('mcp-servers-start');
-    const stopBtn = document.getElementById('mcp-servers-stop');
-    const restartBtn = document.getElementById('mcp-servers-restart');
-    const viewLogsBtn = document.getElementById('mcp-servers-view-logs');
-    const healthCheckBtn = document.getElementById('mcp-servers-health-check');
+    for (const server of MCP_SERVERS) {
+      const startBtn = document.getElementById(`${server.elementPrefix}-start`);
+      const stopBtn = document.getElementById(`${server.elementPrefix}-stop`);
+      const restartBtn = document.getElementById(`${server.elementPrefix}-restart`);
+      const viewLogsBtn = document.getElementById(`${server.elementPrefix}-view-logs`);
 
-    if (startBtn) startBtn.addEventListener('click', () => this.handleMCPServersStart());
-    if (stopBtn) stopBtn.addEventListener('click', () => this.handleMCPServersStop());
-    if (restartBtn) restartBtn.addEventListener('click', () => this.handleMCPServersRestart());
-    if (viewLogsBtn) viewLogsBtn.addEventListener('click', () => this.handleViewLogs('mcp-writing-servers', 'MCP Servers'));
+      if (startBtn) startBtn.addEventListener('click', () => this.handleServiceControl(server.service, server.displayName, 'start'));
+      if (stopBtn) stopBtn.addEventListener('click', () => this.handleServiceControl(server.service, server.displayName, 'stop'));
+      if (restartBtn) restartBtn.addEventListener('click', () => this.handleServiceControl(server.service, server.displayName, 'restart'));
+      if (viewLogsBtn) viewLogsBtn.addEventListener('click', () => this.handleViewLogs(server.service, server.displayName));
+    }
+
+    const healthCheckBtn = document.getElementById('mcp-servers-health-check');
     if (healthCheckBtn) healthCheckBtn.addEventListener('click', () => this.handleMCPServersHealthCheck());
   }
 
   /**
-   * Setup Typing Mind service listeners
+   * Setup Typing Mind service listeners. Typing Mind itself is a cloud web
+   * app; its lifecycle controls act on the local MCP Connector it depends on.
    */
   private setupTypingMindListeners(): void {
+    const startBtn = document.getElementById('typing-mind-start');
+    const stopBtn = document.getElementById('typing-mind-stop');
+    const restartBtn = document.getElementById('typing-mind-restart');
+    const viewLogsBtn = document.getElementById('typing-mind-view-logs');
     const openBrowserBtn = document.getElementById('typing-mind-open-browser');
     const configureBtn = document.getElementById('typing-mind-configure');
 
+    if (startBtn) startBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'start'));
+    if (stopBtn) stopBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'stop'));
+    if (restartBtn) restartBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'restart'));
+    if (viewLogsBtn) viewLogsBtn.addEventListener('click', () => this.handleViewLogs('mcp-connector', 'MCP Connector (Typing Mind)'));
     if (openBrowserBtn) openBrowserBtn.addEventListener('click', () => this.handleOpenTypingMind());
     if (configureBtn) configureBtn.addEventListener('click', () => this.handleConfigureTypingMind());
   }
@@ -455,15 +536,79 @@ export class ServicesTab {
   }
 
   /**
+   * Start / stop / restart a single service via the per-service control IPC
+   * (issue #124 -- replaces the old "use the Dashboard" placeholder handlers).
+   */
+  private async handleServiceControl(
+    service: ControlledService,
+    displayName: string,
+    action: ServiceAction
+  ): Promise<void> {
+    try {
+      this.showNotification(`${ACTION_PROGRESS_LABEL[action]} ${displayName}...`, 'info');
+
+      const result = await window.electronAPI.mcpSystem.controlService(service, action);
+
+      if (result.success) {
+        this.showNotification(`${displayName} ${pastTense(action)} successfully`, 'success');
+      } else {
+        this.showNotification(`Failed to ${action} ${displayName}: ${result.error || result.message}`, 'error');
+      }
+
+      await this.refreshAllServices();
+    } catch (error) {
+      console.error(`Error during ${action} of ${displayName}:`, error);
+      this.showNotification(`Failed to ${action} ${displayName}`, 'error');
+    }
+  }
+
+  /**
+   * Start / stop / restart the whole MCP system. Wired to the top bar's
+   * Start All / Stop All / Restart All actions via window events.
+   */
+  private async handleSystemAction(action: ServiceAction): Promise<void> {
+    try {
+      this.showNotification(`${ACTION_PROGRESS_LABEL[action]} all services...`, 'info');
+
+      const api = window.electronAPI.mcpSystem;
+      const result = action === 'start'
+        ? await api.start()
+        : action === 'stop'
+          ? await api.stop()
+          : await api.restart();
+
+      if (result.success) {
+        this.showNotification(`All services ${pastTense(action)} successfully`, 'success');
+      } else {
+        this.showNotification(`Failed to ${action} services: ${result.message}`, 'error');
+      }
+
+      await this.refreshAllServices();
+    } catch (error) {
+      console.error(`Error during system ${action}:`, error);
+      this.showNotification(`Failed to ${action} services`, 'error');
+    }
+  }
+
+  /**
    * Refresh all services status
    */
   private async refreshAllServices(): Promise<void> {
     try {
-      // Update all service cards
-      await this.updatePostgreSQLCard();
-      await this.updateMCPServersCard();
-      await this.updateTypingMindCard();
-      await this.updateDockerCard();
+      // One status + one config fetch shared by all cards
+      const [detailed, config] = await Promise.all([
+        window.electronAPI.mcpSystem.getDetailedStatus(),
+        window.electronAPI.envConfig.getConfig() as Promise<EnvConfig>,
+      ]);
+
+      const services: DetailedServiceStatusEntry[] = detailed?.services ?? [];
+
+      await Promise.all([
+        this.updatePostgreSQLCard(services, config),
+        this.updateMCPServersCard(services),
+        this.updateTypingMindCard(services),
+        this.updateDockerCard(),
+      ]);
 
       // Update last refresh timestamp
       this.updateLastRefreshTime();
@@ -473,137 +618,210 @@ export class ServicesTab {
   }
 
   /**
-   * Update PostgreSQL service card
+   * Find a service's detailed status entry by its container name
    */
-  private async updatePostgreSQLCard(): Promise<void> {
+  private findService(
+    services: DetailedServiceStatusEntry[],
+    service: ControlledService
+  ): DetailedServiceStatusEntry | undefined {
+    return services.find(s => s.containerName === SERVICE_CONTAINERS[service]);
+  }
+
+  /**
+   * Whether a detailed status entry represents a container that is up
+   * (running in any state, including still starting or unhealthy)
+   */
+  private isServiceUp(entry: DetailedServiceStatusEntry | undefined): boolean {
+    if (!entry) return false;
+    return entry.status === 'healthy'
+      || entry.status === 'running'
+      || entry.status === 'starting'
+      || entry.status === 'unhealthy';
+  }
+
+  /**
+   * Apply a status badge (text + class) for a detailed status entry
+   */
+  private applyStatusBadge(elementId: string, entry: DetailedServiceStatusEntry | undefined): void {
+    const badge = document.getElementById(elementId);
+    if (!badge) return;
+
+    if (!entry || entry.status === 'missing' || entry.status === 'stopped') {
+      badge.className = 'service-status-badge status-offline';
+      badge.textContent = 'Offline';
+    } else if (entry.status === 'healthy') {
+      badge.className = 'service-status-badge status-healthy';
+      badge.textContent = 'Healthy';
+    } else if (entry.status === 'running') {
+      badge.className = 'service-status-badge status-healthy';
+      badge.textContent = 'Running';
+    } else if (entry.status === 'starting') {
+      badge.className = 'service-status-badge status-starting';
+      badge.textContent = 'Starting';
+    } else {
+      badge.className = 'service-status-badge status-offline';
+      badge.textContent = 'Unhealthy';
+    }
+  }
+
+  /**
+   * Render real resource usage into an element. Fetches live CPU/memory via
+   * `docker stats` when the service is up (issue #124 -- replaces the old
+   * hardcoded placeholder numbers).
+   */
+  private async updateResourceUsage(
+    elementId: string,
+    service: ControlledService,
+    isUp: boolean
+  ): Promise<void> {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+
+    if (!isUp) {
+      el.innerHTML = '<div class="resource-item">Not running</div>';
+      return;
+    }
+
     try {
-      const status = await window.electronAPI.mcpSystem.getStatus();
-      const config = await window.electronAPI.envConfig.getConfig();
+      const usage: ResourceUsage | null = await window.electronAPI.mcpSystem.getResourceUsage(service);
 
-      const container = status.containers.find(c => c.name.includes('postgres'));
-
-      const statusBadge = document.getElementById('postgres-status-badge');
-      const portDisplay = document.getElementById('postgres-port-info');
-      const versionDisplay = document.getElementById('postgres-version-info');
-      const resourceDisplay = document.getElementById('postgres-resource-usage');
-
-      if (statusBadge) {
-        if (container?.running && container.health === 'healthy') {
-          statusBadge.className = 'service-status-badge status-healthy';
-          statusBadge.textContent = 'Healthy';
-        } else if (container?.running) {
-          statusBadge.className = 'service-status-badge status-starting';
-          statusBadge.textContent = 'Starting';
-        } else {
-          statusBadge.className = 'service-status-badge status-offline';
-          statusBadge.textContent = 'Offline';
-        }
-      }
-
-      if (portDisplay) {
-        portDisplay.textContent = `Port: ${config.POSTGRES_PORT}`;
-      }
-
-      if (versionDisplay) {
-        versionDisplay.textContent = 'Version: PostgreSQL 17';
-      }
-
-      // Update resource usage (simulated for now)
-      if (resourceDisplay && container?.running) {
-        resourceDisplay.innerHTML = `
+      if (usage) {
+        el.innerHTML = `
           <div class="resource-item">
             <span>CPU:</span>
-            <span class="resource-value">~2%</span>
+            <span class="resource-value">${this.escapeHtml(usage.cpuPercent)}</span>
           </div>
           <div class="resource-item">
             <span>Memory:</span>
-            <span class="resource-value">~128MB</span>
+            <span class="resource-value">${this.escapeHtml(usage.memoryUsage)} (${this.escapeHtml(usage.memoryPercent)})</span>
           </div>
         `;
-      } else if (resourceDisplay) {
-        resourceDisplay.innerHTML = '<div class="resource-item">Not running</div>';
+      } else {
+        el.innerHTML = '<div class="resource-item">Usage unavailable</div>';
       }
+    } catch (error) {
+      console.error(`Error fetching resource usage for ${service}:`, error);
+      el.innerHTML = '<div class="resource-item">Usage unavailable</div>';
+    }
+  }
+
+  /**
+   * Update PostgreSQL service card: status badge, connection info
+   * (host / port / database), live resource usage, and control states.
+   */
+  private async updatePostgreSQLCard(
+    services: DetailedServiceStatusEntry[],
+    config: EnvConfig
+  ): Promise<void> {
+    try {
+      const entry = this.findService(services, 'postgres');
+      const isUp = this.isServiceUp(entry);
+
+      this.applyStatusBadge('postgres-status-badge', entry);
+
+      const hostDisplay = document.getElementById('postgres-host-info');
+      const portDisplay = document.getElementById('postgres-port-info');
+      const databaseDisplay = document.getElementById('postgres-database-info');
+
+      if (hostDisplay) hostDisplay.textContent = 'Host: localhost';
+      if (portDisplay) portDisplay.textContent = `Port: ${config.POSTGRES_PORT}`;
+      if (databaseDisplay) databaseDisplay.textContent = `Database: ${config.POSTGRES_DB}`;
+
+      await this.updateResourceUsage('postgres-resource-usage', 'postgres', isUp);
 
       // Enable/disable controls based on status
-      this.updateServiceControls('postgres', container?.running || false);
+      this.updateServiceControls('postgres', isUp);
     } catch (error) {
       console.error('Error updating PostgreSQL card:', error);
     }
   }
 
   /**
-   * Update MCP Servers service card
+   * Update the MCP Servers card: per-server rows (status badge, port, live
+   * resource usage, control states) plus the aggregate card badge.
    */
-  private async updateMCPServersCard(): Promise<void> {
+  private async updateMCPServersCard(services: DetailedServiceStatusEntry[]): Promise<void> {
     try {
-      const status = await window.electronAPI.mcpSystem.getStatus();
-      const config = await window.electronAPI.envConfig.getConfig();
+      const entries = MCP_SERVERS.map(server => ({
+        server,
+        entry: this.findService(services, server.service),
+      }));
 
-      const container = status.containers.find(c =>
-        c.name.includes('mcp-writing-servers') || c.name.includes('mcp-connector')
-      );
+      // Aggregate badge: healthy only when every server is healthy
+      const aggregateBadge = document.getElementById('mcp-servers-status-badge');
+      if (aggregateBadge) {
+        const upCount = entries.filter(({ entry }) => this.isServiceUp(entry)).length;
+        const healthyCount = entries.filter(({ entry }) => entry?.status === 'healthy' || entry?.status === 'running').length;
 
-      const statusBadge = document.getElementById('mcp-servers-status-badge');
-      const portDisplay = document.getElementById('mcp-servers-port-info');
-      const versionDisplay = document.getElementById('mcp-servers-version-info');
-      const resourceDisplay = document.getElementById('mcp-servers-resource-usage');
-
-      if (statusBadge) {
-        if (container?.running && container.health === 'healthy') {
-          statusBadge.className = 'service-status-badge status-healthy';
-          statusBadge.textContent = 'Healthy';
-        } else if (container?.running) {
-          statusBadge.className = 'service-status-badge status-starting';
-          statusBadge.textContent = 'Starting';
+        if (healthyCount === entries.length) {
+          aggregateBadge.className = 'service-status-badge status-healthy';
+          aggregateBadge.textContent = 'Healthy';
+        } else if (upCount > 0) {
+          aggregateBadge.className = 'service-status-badge status-starting';
+          aggregateBadge.textContent = 'Degraded';
         } else {
-          statusBadge.className = 'service-status-badge status-offline';
-          statusBadge.textContent = 'Offline';
+          aggregateBadge.className = 'service-status-badge status-offline';
+          aggregateBadge.textContent = 'Offline';
         }
       }
 
-      if (portDisplay) {
-        portDisplay.textContent = `Connector Port: ${config.MCP_CONNECTOR_PORT} | HTTP/SSE Port: ${config.HTTP_SSE_PORT}`;
-      }
+      // Per-server rows
+      await Promise.all(entries.map(async ({ server, entry }) => {
+        const isUp = this.isServiceUp(entry);
 
-      if (versionDisplay) {
-        versionDisplay.textContent = 'Version: Latest';
-      }
+        this.applyStatusBadge(`${server.elementPrefix}-status-badge`, entry);
 
-      // Update resource usage
-      if (resourceDisplay && container?.running) {
-        resourceDisplay.innerHTML = `
-          <div class="resource-item">
-            <span>CPU:</span>
-            <span class="resource-value">~1%</span>
-          </div>
-          <div class="resource-item">
-            <span>Memory:</span>
-            <span class="resource-value">~64MB</span>
-          </div>
-        `;
-      } else if (resourceDisplay) {
-        resourceDisplay.innerHTML = '<div class="resource-item">Not running</div>';
-      }
+        const portDisplay = document.getElementById(`${server.elementPrefix}-port-info`);
+        if (portDisplay) {
+          portDisplay.textContent = entry?.port !== undefined ? `Port: ${entry.port}` : 'Port: --';
+        }
 
-      // Enable/disable controls based on status
-      this.updateServiceControls('mcp-servers', container?.running || false);
+        await this.updateResourceUsage(`${server.elementPrefix}-resource-usage`, server.service, isUp);
+
+        this.updateServiceControls(server.elementPrefix, isUp);
+      }));
     } catch (error) {
       console.error('Error updating MCP Servers card:', error);
     }
   }
 
   /**
-   * Update Typing Mind service card (cloud link only — no local container)
+   * Update Typing Mind card. Typing Mind is a cloud web app -- its status
+   * reflects the local MCP Connector it depends on.
    */
-  private async updateTypingMindCard(): Promise<void> {
+  private async updateTypingMindCard(services: DetailedServiceStatusEntry[]): Promise<void> {
     try {
-      const urls = await window.electronAPI.mcpSystem.getUrls();
+      const connector = this.findService(services, 'mcp-connector');
+      const isUp = this.isServiceUp(connector);
 
+      const badge = document.getElementById('typing-mind-status-badge');
+      if (badge) {
+        if (connector?.status === 'healthy' || connector?.status === 'running') {
+          badge.className = 'service-status-badge status-healthy';
+          badge.textContent = 'Ready';
+        } else if (connector?.status === 'starting') {
+          badge.className = 'service-status-badge status-starting';
+          badge.textContent = 'Starting';
+        } else {
+          badge.className = 'service-status-badge status-offline';
+          badge.textContent = 'Offline';
+        }
+      }
+
+      const urls: ServiceUrls = await window.electronAPI.mcpSystem.getUrls();
       const urlDisplay = document.getElementById('typing-mind-url-info');
-
       if (urlDisplay) {
         urlDisplay.textContent = urls.typingMind || 'https://www.typingmind.com';
       }
+
+      const portDisplay = document.getElementById('typing-mind-port-info');
+      if (portDisplay) {
+        portDisplay.textContent = connector?.port !== undefined
+          ? `Connector Port: ${connector.port}`
+          : 'Connector Port: --';
+      }
+
+      this.updateServiceControls('typing-mind', isUp);
     } catch (error) {
       console.error('Error updating Typing Mind card:', error);
     }
@@ -617,7 +835,6 @@ export class ServicesTab {
       const status = await window.electronAPI.docker.healthCheck();
 
       const statusBadge = document.getElementById('docker-status-badge');
-      const versionDisplay = document.getElementById('docker-version-info');
       const healthDisplay = document.getElementById('docker-health-info');
 
       if (statusBadge) {
@@ -633,9 +850,7 @@ export class ServicesTab {
         }
       }
 
-      if (versionDisplay) {
-        versionDisplay.textContent = 'Docker Desktop';
-      }
+      this.renderDockerVersion();
 
       if (healthDisplay) {
         healthDisplay.textContent = status.message;
@@ -645,6 +860,33 @@ export class ServicesTab {
       this.updateServiceControls('docker-service', status.running);
     } catch (error) {
       console.error('Error updating Docker card:', error);
+    }
+  }
+
+  /**
+   * Fetch and cache the real Docker version (issue #124 -- replaces the
+   * hardcoded "Docker Desktop" placeholder).
+   */
+  private async loadDockerVersion(): Promise<void> {
+    try {
+      const status = await window.electronAPI.prerequisites.getDockerVersion();
+      this.dockerVersion = status?.version || null;
+    } catch (error) {
+      console.error('Error fetching Docker version:', error);
+      this.dockerVersion = null;
+    }
+    this.renderDockerVersion();
+  }
+
+  /**
+   * Render the cached Docker version into the Docker card
+   */
+  private renderDockerVersion(): void {
+    const versionDisplay = document.getElementById('docker-version-info');
+    if (versionDisplay) {
+      versionDisplay.textContent = this.dockerVersion
+        ? `Version: Docker ${this.dockerVersion}`
+        : 'Version: unknown';
     }
   }
 
@@ -662,63 +904,31 @@ export class ServicesTab {
   }
 
   /**
-   * Handle PostgreSQL start
-   */
-  private async handlePostgresStart(): Promise<void> {
-    this.showNotification('PostgreSQL is managed as part of the full system. Use Dashboard to start all services.', 'info');
-  }
-
-  /**
-   * Handle PostgreSQL stop
-   */
-  private async handlePostgresStop(): Promise<void> {
-    this.showNotification('PostgreSQL is managed as part of the full system. Use Dashboard to stop all services.', 'info');
-  }
-
-  /**
-   * Handle PostgreSQL restart
-   */
-  private async handlePostgresRestart(): Promise<void> {
-    this.showNotification('PostgreSQL is managed as part of the full system. Use Dashboard to restart all services.', 'info');
-  }
-
-  /**
-   * Handle MCP Servers start
-   */
-  private async handleMCPServersStart(): Promise<void> {
-    this.showNotification('MCP Servers are managed as part of the full system. Use Dashboard to start all services.', 'info');
-  }
-
-  /**
-   * Handle MCP Servers stop
-   */
-  private async handleMCPServersStop(): Promise<void> {
-    this.showNotification('MCP Servers are managed as part of the full system. Use Dashboard to stop all services.', 'info');
-  }
-
-  /**
-   * Handle MCP Servers restart
-   */
-  private async handleMCPServersRestart(): Promise<void> {
-    this.showNotification('MCP Servers are managed as part of the full system. Use Dashboard to restart all services.', 'info');
-  }
-
-  /**
-   * Handle MCP Servers health check
+   * Handle MCP Servers health check: per-server status summary in a dialog
    */
   private async handleMCPServersHealthCheck(): Promise<void> {
     try {
-      const status = await window.electronAPI.mcpSystem.getStatus();
-      const container = status.containers.find(c =>
-        c.name.includes('mcp-writing-servers') || c.name.includes('mcp-connector')
-      );
+      const detailed = await window.electronAPI.mcpSystem.getDetailedStatus();
+      const services: DetailedServiceStatusEntry[] = detailed?.services ?? [];
 
-      if (container) {
-        const healthMsg = `Status: ${container.status}\nHealth: ${container.health}\nRunning: ${container.running}`;
-        this.showNotification(healthMsg, container.health === 'healthy' ? 'success' : 'info');
-      } else {
-        this.showNotification('MCP Servers container not found', 'error');
-      }
+      const lines = MCP_SERVERS.map(server => {
+        const entry = this.findService(services, server.service);
+        if (!entry) {
+          return `${server.displayName}: container not found`;
+        }
+        return `${server.displayName}\n  Status: ${entry.status}\n  Health: ${entry.health}\n  ${entry.message}`;
+      });
+
+      const allHealthy = MCP_SERVERS.every(server => {
+        const entry = this.findService(services, server.service);
+        return entry?.status === 'healthy' || entry?.status === 'running';
+      });
+
+      this.showLogsDialog('MCP Servers Health Check', lines.join('\n\n'));
+      this.showNotification(
+        allHealthy ? 'All MCP servers are healthy' : 'Some MCP servers are not healthy',
+        allHealthy ? 'success' : 'info'
+      );
     } catch (error) {
       console.error('Error checking MCP Servers health:', error);
       this.showNotification('Failed to check health status', 'error');
@@ -731,18 +941,15 @@ export class ServicesTab {
   private async handleOpenTypingMind(): Promise<void> {
     try {
       const urls = await window.electronAPI.mcpSystem.getUrls();
+      const url = urls.typingMind || 'https://www.typingmind.com';
 
-      if (urls.typingMind) {
-        // Use the Typing Mind window opener from the API
-        const result = await (window.electronAPI as any).typingMind.openWindow(urls.typingMind);
+      // Use the Typing Mind window opener from the API
+      const result = await window.electronAPI.typingMind.openWindow(url);
 
-        if (result.success) {
-          this.showNotification('Opening Typing Mind...', 'info');
-        } else {
-          this.showNotification(`Failed to open Typing Mind: ${result.error}`, 'error');
-        }
+      if (result.success) {
+        this.showNotification('Opening Typing Mind...', 'info');
       } else {
-        this.showNotification('Typing Mind is not running', 'error');
+        this.showNotification(`Failed to open Typing Mind: ${result.error}`, 'error');
       }
     } catch (error) {
       console.error('Error opening Typing Mind:', error);
@@ -780,6 +987,7 @@ export class ServicesTab {
 
       if (result.success) {
         this.showNotification('Docker Desktop started successfully!', 'success');
+        await this.loadDockerVersion();
         await this.refreshAllServices();
       } else {
         this.showNotification(`Failed to start Docker: ${result.error || result.message}`, 'error');
@@ -820,6 +1028,7 @@ export class ServicesTab {
 
       if (result.success) {
         this.showNotification('Docker Desktop restarted successfully!', 'success');
+        await this.loadDockerVersion();
         await this.refreshAllServices();
       } else {
         this.showNotification(`Failed to restart Docker: ${result.error || result.message}`, 'error');
@@ -892,7 +1101,7 @@ export class ServicesTab {
 
       if (result.success) {
         const redactedLogs = this.redactSensitiveInfo(result.logs);
-        this.showLogsDialog(displayName, redactedLogs);
+        this.showLogsDialog(`${displayName} Logs`, redactedLogs);
       } else {
         this.showNotification(`Failed to get logs: ${result.error}`, 'error');
       }
@@ -1029,10 +1238,17 @@ postgresql://${config.POSTGRES_USER}:********@localhost:${config.POSTGRES_PORT}/
   }
 
   /**
-   * Cleanup when navigating away from tab
+   * Cleanup when navigating away from tab: stops the auto-refresh interval
+   * and removes the window-level top-bar action listeners (issue #124 --
+   * previously the interval and listeners leaked across navigations).
    */
   public cleanup(): void {
     this.stopAutoRefresh();
+
+    window.removeEventListener('services-start-all', this.onStartAllEvent);
+    window.removeEventListener('services-stop-all', this.onStopAllEvent);
+    window.removeEventListener('services-restart-all', this.onRestartAllEvent);
+
     console.log('ServicesTab cleanup complete');
   }
 }

--- a/src/renderer/components/__tests__/ServicesTab.test.ts
+++ b/src/renderer/components/__tests__/ServicesTab.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for the Services tab (issue #124): ServicesView markup + ServicesTab
+ * behavior, exercised together the way ViewRouter mounts them.
+ *
+ * Covers the issue's acceptance criteria at the unit level:
+ * - All services manageable from the tab (real per-service controls via
+ *   mcpSystem.controlService, whole-system actions via the top-bar's
+ *   services-start-all/-stop-all/-restart-all window events)
+ * - Logs viewable per service (per-server View Logs buttons open the logs
+ *   dialog, with credentials redacted)
+ * - Resource monitoring works (real values from mcpSystem.getResourceUsage
+ *   rendered into the cards, "Not running" when a container is down)
+ * - Service actions functional (buttons call the IPC surface with the right
+ *   service ids; control states follow each service's running state)
+ *
+ * Also guards the unmount contract: ServicesView.unmount() must call
+ * ServicesTab.cleanup(), stopping the 5s auto-refresh interval and removing
+ * the window-level top-bar action listeners (previously these leaked).
+ */
+
+import { ServicesView } from '../../views/ServicesView';
+
+interface MockAPI {
+  mcpSystem: {
+    start: jest.Mock;
+    stop: jest.Mock;
+    restart: jest.Mock;
+    getDetailedStatus: jest.Mock;
+    getUrls: jest.Mock;
+    getLogs: jest.Mock;
+    controlService: jest.Mock;
+    getResourceUsage: jest.Mock;
+  };
+  envConfig: {
+    getConfig: jest.Mock;
+    checkPort: jest.Mock;
+  };
+  docker: {
+    healthCheck: jest.Mock;
+    startAndWait: jest.Mock;
+    stop: jest.Mock;
+    restart: jest.Mock;
+  };
+  prerequisites: {
+    getDockerVersion: jest.Mock;
+  };
+  typingMind: {
+    openWindow: jest.Mock;
+    autoConfigure: jest.Mock;
+  };
+}
+
+const CONFIG_FIXTURE = {
+  POSTGRES_DB: 'fictionlab',
+  POSTGRES_USER: 'fictionlab_user',
+  POSTGRES_PASSWORD: 'secretpw',
+  POSTGRES_PORT: 5432,
+  MCP_CONNECTOR_PORT: 50880,
+  HTTP_SSE_PORT: 50881,
+  DB_ADMIN_PORT: 8081,
+  MCP_AUTH_TOKEN: 'token',
+  PGBOUNCER_PORT: 6432,
+  NPE_PORT: 8765,
+  WORKFLOW_MANAGER_PORT: 8766,
+};
+
+/**
+ * Default status: postgres + connector healthy, writing servers stopped.
+ * Exercises both branches of every per-service state render.
+ */
+function makeDetailedStatusFixture() {
+  return {
+    overall: { running: true, healthy: false, ready: false, message: '2/3 services ready' },
+    services: [
+      {
+        serviceName: 'PostgreSQL Database',
+        containerName: 'fictionlab-postgres',
+        status: 'healthy',
+        health: 'healthy',
+        port: 5432,
+        url: 'postgres://fictionlab_user:****@localhost:5432/fictionlab',
+        message: 'Service is healthy and ready',
+      },
+      {
+        serviceName: 'MCP Connector',
+        containerName: 'fictionlab-mcp-connector',
+        status: 'healthy',
+        health: 'healthy',
+        port: 50880,
+        url: 'http://localhost:50880',
+        message: 'Service is healthy and ready',
+      },
+      {
+        serviceName: 'MCP Writing Servers',
+        containerName: 'fictionlab-mcp-servers',
+        status: 'stopped',
+        health: 'none',
+        port: 3001,
+        message: 'Service is stopped',
+      },
+    ],
+    timestamp: new Date(),
+  };
+}
+
+function makeMockAPI(): MockAPI {
+  return {
+    mcpSystem: {
+      start: jest.fn().mockResolvedValue({ success: true, message: 'started' }),
+      stop: jest.fn().mockResolvedValue({ success: true, message: 'stopped' }),
+      restart: jest.fn().mockResolvedValue({ success: true, message: 'restarted' }),
+      getDetailedStatus: jest.fn().mockResolvedValue(makeDetailedStatusFixture()),
+      getUrls: jest.fn().mockResolvedValue({
+        typingMind: 'https://www.typingmind.com',
+        mcpConnector: 'http://localhost:50880',
+        postgres: 'postgres://fictionlab_user:****@localhost:5432/fictionlab',
+      }),
+      getLogs: jest.fn().mockResolvedValue({
+        success: true,
+        logs: 'connecting to postgresql://admin:supersecret@localhost:5432/fictionlab',
+      }),
+      controlService: jest.fn().mockResolvedValue({ success: true, message: 'ok' }),
+      getResourceUsage: jest.fn().mockResolvedValue({
+        cpuPercent: '3.14%',
+        memoryUsage: '150MiB / 8GiB',
+        memoryPercent: '1.83%',
+      }),
+    },
+    envConfig: {
+      getConfig: jest.fn().mockResolvedValue(CONFIG_FIXTURE),
+      checkPort: jest.fn().mockResolvedValue(true),
+    },
+    docker: {
+      healthCheck: jest.fn().mockResolvedValue({ running: true, healthy: true, message: 'Docker is healthy' }),
+      startAndWait: jest.fn().mockResolvedValue({ success: true, message: 'ok' }),
+      stop: jest.fn().mockResolvedValue({ success: true, message: 'ok' }),
+      restart: jest.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    },
+    prerequisites: {
+      getDockerVersion: jest.fn().mockResolvedValue({ installed: true, running: true, version: '27.4.0' }),
+    },
+    typingMind: {
+      openWindow: jest.fn().mockResolvedValue({ success: true }),
+      autoConfigure: jest.fn().mockResolvedValue({ success: true }),
+    },
+  };
+}
+
+// jsdom has no setImmediate; a zero-delay macrotask lets all pending
+// microtask chains (async click handlers) settle first.
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('Services tab (issue #124)', () => {
+  let container: HTMLElement;
+  let view: ServicesView;
+  let api: MockAPI;
+  let mounted: boolean;
+
+  beforeEach(() => {
+    api = makeMockAPI();
+    (window as any).electronAPI = api;
+
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    view = new ServicesView();
+    mounted = false;
+  });
+
+  afterEach(async () => {
+    if (mounted) {
+      await view.unmount();
+    }
+    document.body.innerHTML = '';
+  });
+
+  async function mountView(): Promise<void> {
+    await view.mount(container);
+    mounted = true;
+    await flushPromises();
+  }
+
+  function text(id: string): string {
+    const el = document.getElementById(id);
+    return el ? (el.textContent || '') : '';
+  }
+
+  function button(id: string): HTMLButtonElement {
+    const el = document.getElementById(id) as HTMLButtonElement | null;
+    if (!el) throw new Error(`Button #${id} not found`);
+    return el;
+  }
+
+  it('renders all four service cards, both MCP server rows, and the ports table', async () => {
+    await mountView();
+
+    expect(container.textContent).toContain('PostgreSQL Database');
+    expect(container.textContent).toContain('MCP Servers');
+    expect(container.textContent).toContain('MCP Connector');
+    expect(container.textContent).toContain('MCP Writing Servers');
+    expect(container.textContent).toContain('Typing Mind');
+    expect(container.textContent).toContain('Docker Desktop');
+
+    const portRows = document.querySelectorAll('#ports-table-body tr');
+    expect(portRows.length).toBe(7);
+  });
+
+  it('shows PostgreSQL connection info (host, port, database) from the env config', async () => {
+    await mountView();
+
+    expect(text('postgres-host-info')).toBe('Host: localhost');
+    expect(text('postgres-port-info')).toBe('Port: 5432');
+    expect(text('postgres-database-info')).toBe('Database: fictionlab');
+  });
+
+  it('renders real resource usage for running services and "Not running" for stopped ones', async () => {
+    await mountView();
+
+    // Running services show live docker stats values
+    expect(text('postgres-resource-usage')).toContain('3.14%');
+    expect(text('postgres-resource-usage')).toContain('150MiB / 8GiB');
+    expect(text('mcp-connector-resource-usage')).toContain('3.14%');
+
+    // Stopped service shows no fabricated numbers
+    expect(text('mcp-writing-servers-resource-usage')).toContain('Not running');
+
+    // Stats were only fetched for the running services
+    const requested = api.mcpSystem.getResourceUsage.mock.calls.map(c => c[0]);
+    expect(requested).toContain('postgres');
+    expect(requested).toContain('mcp-connector');
+    expect(requested).not.toContain('mcp-writing-servers');
+  });
+
+  it('shows individual status and port per MCP server, with a Degraded aggregate badge', async () => {
+    await mountView();
+
+    expect(text('mcp-connector-status-badge')).toBe('Healthy');
+    expect(text('mcp-connector-port-info')).toBe('Port: 50880');
+
+    expect(text('mcp-writing-servers-status-badge')).toBe('Offline');
+    expect(text('mcp-writing-servers-port-info')).toBe('Port: 3001');
+
+    expect(text('mcp-servers-status-badge')).toBe('Degraded');
+  });
+
+  it('enables/disables each service\'s controls according to its own running state', async () => {
+    await mountView();
+
+    // Connector is up: cannot start again, can stop/restart
+    expect(button('mcp-connector-start').disabled).toBe(true);
+    expect(button('mcp-connector-stop').disabled).toBe(false);
+    expect(button('mcp-connector-restart').disabled).toBe(false);
+
+    // Writing servers are stopped: can start, cannot stop/restart
+    expect(button('mcp-writing-servers-start').disabled).toBe(false);
+    expect(button('mcp-writing-servers-stop').disabled).toBe(true);
+    expect(button('mcp-writing-servers-restart').disabled).toBe(true);
+
+    // Postgres is up
+    expect(button('postgres-start').disabled).toBe(true);
+    expect(button('postgres-stop').disabled).toBe(false);
+  });
+
+  it('wires per-service buttons to mcpSystem.controlService with the right service id', async () => {
+    await mountView();
+
+    button('postgres-restart').click();
+    await flushPromises();
+    expect(api.mcpSystem.controlService).toHaveBeenCalledWith('postgres', 'restart');
+
+    button('mcp-writing-servers-start').click();
+    await flushPromises();
+    expect(api.mcpSystem.controlService).toHaveBeenCalledWith('mcp-writing-servers', 'start');
+
+    button('mcp-connector-stop').click();
+    await flushPromises();
+    expect(api.mcpSystem.controlService).toHaveBeenCalledWith('mcp-connector', 'stop');
+
+    // Typing Mind's lifecycle buttons act on its local MCP Connector dependency
+    button('typing-mind-restart').click();
+    await flushPromises();
+    expect(api.mcpSystem.controlService).toHaveBeenCalledWith('mcp-connector', 'restart');
+  });
+
+  it('opens a per-server logs dialog with credentials redacted', async () => {
+    await mountView();
+
+    button('mcp-connector-view-logs').click();
+    await flushPromises();
+
+    expect(api.mcpSystem.getLogs).toHaveBeenCalledWith('mcp-connector', 100);
+
+    const dialog = document.querySelector('.logs-dialog');
+    expect(dialog).not.toBeNull();
+
+    const body = dialog!.querySelector('.logs-dialog-body pre');
+    expect(body!.textContent).toContain('postgresql://admin:********@');
+    expect(body!.textContent).not.toContain('supersecret');
+
+    (dialog!.querySelector('.logs-dialog-close-btn') as HTMLButtonElement).click();
+    expect(document.querySelector('.logs-dialog')).toBeNull();
+  });
+
+  it('shows the real Docker version instead of a hardcoded label', async () => {
+    await mountView();
+
+    expect(api.prerequisites.getDockerVersion).toHaveBeenCalled();
+    expect(text('docker-version-info')).toBe('Version: Docker 27.4.0');
+  });
+
+  it('reflects the MCP Connector state on the Typing Mind card and opens the browser', async () => {
+    await mountView();
+
+    expect(text('typing-mind-status-badge')).toBe('Ready');
+    expect(text('typing-mind-port-info')).toBe('Connector Port: 50880');
+
+    button('typing-mind-open-browser').click();
+    await flushPromises();
+    expect(api.typingMind.openWindow).toHaveBeenCalledWith('https://www.typingmind.com');
+  });
+
+  it('handles the top bar Start All / Stop All / Restart All window events', async () => {
+    await mountView();
+
+    window.dispatchEvent(new CustomEvent('services-start-all'));
+    await flushPromises();
+    expect(api.mcpSystem.start).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new CustomEvent('services-stop-all'));
+    await flushPromises();
+    expect(api.mcpSystem.stop).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new CustomEvent('services-restart-all'));
+    await flushPromises();
+    expect(api.mcpSystem.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-refreshes every 5s and stops refreshing + listening after unmount', async () => {
+    jest.useFakeTimers();
+    try {
+      await view.mount(container);
+      mounted = true;
+
+      const callsAfterMount = api.mcpSystem.getDetailedStatus.mock.calls.length;
+
+      // Interval fires -> another refresh
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(api.mcpSystem.getDetailedStatus.mock.calls.length).toBeGreaterThan(callsAfterMount);
+
+      await view.unmount();
+      mounted = false;
+
+      const callsAfterUnmount = api.mcpSystem.getDetailedStatus.mock.calls.length;
+
+      // No further refreshes after cleanup
+      await jest.advanceTimersByTimeAsync(15000);
+      expect(api.mcpSystem.getDetailedStatus.mock.calls.length).toBe(callsAfterUnmount);
+
+      // Window listeners removed: top-bar events no longer reach the tab
+      window.dispatchEvent(new CustomEvent('services-start-all'));
+      await jest.advanceTimersByTimeAsync(0);
+      expect(api.mcpSystem.start).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -216,6 +216,28 @@ interface MCPSystemStatus {
   message: string;
 }
 
+// issue #124: per-service detail used by the Services tab's individual server rows
+interface DetailedServiceStatus {
+  serviceName: string;
+  containerName: string;
+  status: 'starting' | 'running' | 'healthy' | 'unhealthy' | 'stopped' | 'missing';
+  health: 'healthy' | 'unhealthy' | 'starting' | 'none' | 'unknown';
+  url?: string;
+  port?: number;
+  message: string;
+}
+
+interface DetailedSystemStatus {
+  overall: {
+    running: boolean;
+    healthy: boolean;
+    ready: boolean;
+    message: string;
+  };
+  services: DetailedServiceStatus[];
+  timestamp: Date;
+}
+
 interface ServiceLogsResult {
   success: boolean;
   logs: string;
@@ -338,9 +360,13 @@ interface ElectronAPI {
     stop: () => Promise<MCPSystemOperationResult>;
     restart: () => Promise<MCPSystemOperationResult>;
     getStatus: () => Promise<MCPSystemStatus>;
+    getDetailedStatus: () => Promise<DetailedSystemStatus>;
     getUrls: () => Promise<ServiceUrls>;
     getLogs: (serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector', tail?: number) => Promise<ServiceLogsResult>;
     checkPorts: () => Promise<PortConflictResult>;
+    // issue #124: per-service controls + resource usage on the Services tab
+    controlService: (serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector', action: 'start' | 'stop' | 'restart') => Promise<MCPSystemOperationResult>;
+    getResourceUsage: (serviceName: 'postgres' | 'mcp-writing-servers' | 'mcp-connector') => Promise<{ cpuPercent: string; memoryUsage: string; memoryPercent: string } | null>;
     getWorkingDirectory: () => Promise<string>;
     onProgress: (callback: (progress: MCPSystemProgress) => void) => void;
     removeProgressListener: () => void;

--- a/src/renderer/views/ServicesView.ts
+++ b/src/renderer/views/ServicesView.ts
@@ -1,15 +1,20 @@
 /**
  * ServicesView
- * Wrapper for existing ServicesTab component
+ * Wrapper for the ServicesTab component
  * Implements View interface for ViewRouter compatibility
+ *
+ * Content rewrite for issue #124 -- detailed per-service controls for
+ * PostgreSQL, the two MCP servers (Connector + Writing Servers), Typing
+ * Mind, and Docker Desktop, plus the pre-existing Ports settings section.
  */
 
 import type { View } from '../components/ViewRouter.js';
 import type { TopBarConfig } from '../components/TopBar.js';
-import { initializeServicesTab } from '../components/ServicesTab.js';
+import { ServicesTab, initializeServicesTab } from '../components/ServicesTab.js';
 
 export class ServicesView implements View {
   private container: HTMLElement | null = null;
+  private servicesTab: ServicesTab | null = null;
 
   /**
    * Mount the services view
@@ -20,9 +25,9 @@ export class ServicesView implements View {
     // Render the full services HTML content
     container.innerHTML = this.renderServicesHTML();
 
-    // Initialize the existing services functionality
+    // Initialize the services functionality
     try {
-      await initializeServicesTab();
+      this.servicesTab = await initializeServicesTab();
       console.log('[ServicesView] Services tab initialized');
     } catch (error) {
       console.error('[ServicesView] Failed to initialize services:', error);
@@ -107,6 +112,10 @@ export class ServicesView implements View {
     `;
   }
 
+  /**
+   * PostgreSQL Card: status, connection info (host/port/database), lifecycle
+   * controls, logs, connection details, and live resource usage.
+   */
   private renderPostgreSQLCard(): string {
     return `
       <div class="service-card" style="border: 2px solid rgba(255, 255, 255, 0.2);">
@@ -118,8 +127,9 @@ export class ServicesView implements View {
         </div>
         <div class="service-card-body">
           <div class="service-info" style="margin-bottom: 15px;">
+            <div class="service-detail" id="postgres-host-info">Host: localhost</div>
             <div class="service-detail" id="postgres-port-info">Port: 5432</div>
-            <div class="service-detail" id="postgres-version-info">Version: PostgreSQL 17</div>
+            <div class="service-detail" id="postgres-database-info">Database: --</div>
           </div>
           <div class="service-info" style="margin-bottom: 15px;">
             <h5 style="margin-bottom: 5px; font-size: 0.9rem; opacity: 0.9;">Resource Usage</h5>
@@ -139,6 +149,11 @@ export class ServicesView implements View {
     `;
   }
 
+  /**
+   * MCP Servers Card: aggregate status plus individual rows for the MCP
+   * Connector and MCP Writing Servers -- each with its own status, port,
+   * start/stop/restart controls, view-logs button, and resource usage.
+   */
   private renderMCPServersCard(): string {
     return `
       <div class="service-card" style="border: 2px solid rgba(255, 255, 255, 0.2);">
@@ -150,27 +165,56 @@ export class ServicesView implements View {
         </div>
         <div class="service-card-body">
           <div class="service-info" style="margin-bottom: 15px;">
-            <div class="service-detail" id="mcp-servers-port-info">Connector Port: 50880</div>
-            <div class="service-detail" id="mcp-servers-version-info">Version: Latest</div>
-          </div>
-          <div class="service-info" style="margin-bottom: 15px;">
-            <h5 style="margin-bottom: 5px; font-size: 0.9rem; opacity: 0.9;">Resource Usage</h5>
-            <div id="mcp-servers-resource-usage" style="font-size: 0.85rem; opacity: 0.9;">
-              <div class="resource-item">Not running</div>
+            <h5 style="margin-bottom: 8px; font-size: 0.9rem; opacity: 0.9;">Individual Servers</h5>
+
+            <div id="mcp-connector-row" style="border: 1px solid rgba(255,255,255,0.15); border-radius: 6px; padding: 10px; margin-bottom: 10px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
+                <strong style="font-size: 0.9rem;">MCP Connector</strong>
+                <span id="mcp-connector-status-badge" class="service-status-badge status-offline">Offline</span>
+              </div>
+              <div class="service-detail" id="mcp-connector-port-info">Port: --</div>
+              <div id="mcp-connector-resource-usage" style="font-size: 0.8rem; opacity: 0.9; margin-top: 4px;">
+                <div class="resource-item">Not running</div>
+              </div>
+              <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px;">
+                <button id="mcp-connector-start" class="service-action-btn" title="Start MCP Connector">Start</button>
+                <button id="mcp-connector-stop" class="service-action-btn" title="Stop MCP Connector">Stop</button>
+                <button id="mcp-connector-restart" class="service-action-btn" title="Restart MCP Connector">Restart</button>
+                <button id="mcp-connector-view-logs" class="service-action-btn" title="View MCP Connector logs">View Logs</button>
+              </div>
+            </div>
+
+            <div id="mcp-writing-servers-row" style="border: 1px solid rgba(255,255,255,0.15); border-radius: 6px; padding: 10px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
+                <strong style="font-size: 0.9rem;">MCP Writing Servers</strong>
+                <span id="mcp-writing-servers-status-badge" class="service-status-badge status-offline">Offline</span>
+              </div>
+              <div class="service-detail" id="mcp-writing-servers-port-info">Port: --</div>
+              <div id="mcp-writing-servers-resource-usage" style="font-size: 0.8rem; opacity: 0.9; margin-top: 4px;">
+                <div class="resource-item">Not running</div>
+              </div>
+              <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px;">
+                <button id="mcp-writing-servers-start" class="service-action-btn" title="Start MCP Writing Servers">Start</button>
+                <button id="mcp-writing-servers-stop" class="service-action-btn" title="Stop MCP Writing Servers">Stop</button>
+                <button id="mcp-writing-servers-restart" class="service-action-btn" title="Restart MCP Writing Servers">Restart</button>
+                <button id="mcp-writing-servers-view-logs" class="service-action-btn" title="View MCP Writing Servers logs">View Logs</button>
+              </div>
             </div>
           </div>
+
           <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 8px;">
-            <button id="mcp-servers-start" class="service-action-btn" title="Start MCP Servers">Start</button>
-            <button id="mcp-servers-stop" class="service-action-btn" title="Stop MCP Servers">Stop</button>
-            <button id="mcp-servers-restart" class="service-action-btn" title="Restart MCP Servers">Restart</button>
-            <button id="mcp-servers-view-logs" class="service-action-btn" title="View MCP Servers logs">View Logs</button>
-            <button id="mcp-servers-health-check" class="service-action-btn" title="Check health status">Health Check</button>
+            <button id="mcp-servers-health-check" class="service-action-btn" title="Check health status of all MCP servers">Health Check</button>
           </div>
         </div>
       </div>
     `;
   }
 
+  /**
+   * Typing Mind Card: Typing Mind itself is a cloud web app with nothing
+   * local to run, so its status/start/stop/restart/logs reflect the local
+   * MCP Connector it depends on to reach FictionLab's MCP servers.
+   */
   private renderTypingMindCard(): string {
     return `
       <div class="service-card" style="border: 2px solid rgba(255, 255, 255, 0.2);">
@@ -178,12 +222,22 @@ export class ServicesView implements View {
           <div class="service-name">
             <h4>Typing Mind</h4>
           </div>
+          <span id="typing-mind-status-badge" class="service-status-badge status-offline">Not Configured</span>
         </div>
         <div class="service-card-body">
           <div class="service-info" style="margin-bottom: 15px;">
             <div class="service-detail" id="typing-mind-url-info">https://www.typingmind.com</div>
+            <div class="service-detail" id="typing-mind-port-info">Connector Port: --</div>
           </div>
+          <p style="font-size: 0.8rem; opacity: 0.8; margin-bottom: 10px;">
+            Typing Mind runs in the cloud. Start/Stop/Restart and Logs below control the local
+            MCP Connector that Typing Mind talks to.
+          </p>
           <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 8px;">
+            <button id="typing-mind-start" class="service-action-btn" title="Start the MCP Connector">Start</button>
+            <button id="typing-mind-stop" class="service-action-btn" title="Stop the MCP Connector">Stop</button>
+            <button id="typing-mind-restart" class="service-action-btn" title="Restart the MCP Connector">Restart</button>
+            <button id="typing-mind-view-logs" class="service-action-btn" title="View MCP Connector logs">View Logs</button>
             <button id="typing-mind-open-browser" class="service-action-btn" title="Open in browser">Open Browser</button>
             <button id="typing-mind-configure" class="service-action-btn" title="Configure Typing Mind">Configure</button>
           </div>
@@ -203,7 +257,7 @@ export class ServicesView implements View {
         </div>
         <div class="service-card-body">
           <div class="service-info" style="margin-bottom: 15px;">
-            <div class="service-detail" id="docker-version-info">Docker Desktop</div>
+            <div class="service-detail" id="docker-version-info">Version: Checking...</div>
             <div class="service-detail" id="docker-health-info">Status: Checking...</div>
           </div>
           <div class="service-info" style="margin-bottom: 15px;">
@@ -226,6 +280,10 @@ export class ServicesView implements View {
    * Unmount the services view
    */
   async unmount(): Promise<void> {
+    if (this.servicesTab) {
+      this.servicesTab.cleanup();
+    }
+    this.servicesTab = null;
     this.container = null;
   }
 


### PR DESCRIPTION
## Summary

Implements issue #124's Services tab spec as a content rewrite inside the existing `ServicesView` slot on the Sidebar + TopBar + ViewRouter shell (route `settings-services`), per PR #196's audit. Navigation, ViewRouter, and Sidebar are untouched; shared-file edits (`index.ts`, `preload.ts`, `renderer.ts`) are minimal and strictly additive.

### What the tab now does

**PostgreSQL card** — status badge, connection info on the card (host / port / database from env config), working Start/Stop/Restart, View Logs, Connection Info dialog, and **real** resource usage.

**MCP Servers card** — the two servers (MCP Connector, MCP Writing Servers) are now managed **individually**: each has its own status badge, port, live resource usage, Start/Stop/Restart, and View Logs; the card keeps an aggregate badge (Healthy / Degraded / Offline) and a health-check summary dialog.

**Typing Mind card** — status badge, connector port, Start/Stop/Restart, View Logs, Open Browser, Configure. Typing Mind itself is a cloud web app with nothing local to run, so its status and lifecycle controls are mapped to the local MCP Connector it depends on (the card says so explicitly).

**Docker Desktop card** — real installed Docker version (was a hardcoded label), health status, Start/Stop/Restart, Health Check.

**Top bar** — Start All / Stop All / Restart All actions are now actually wired: `ServicesView` dispatched `services-start-all/-stop-all/-restart-all` window events that nothing listened to.

### Backend (additive only)

- `mcp-system:control-service` — per-service start/stop/restart via `docker compose <action> <service>` scoped to one service (previous buttons were placeholders telling the user to use the Dashboard)
- `mcp-system:resource-usage` — live CPU/memory via `docker stats --no-stream` (cards previously rendered hardcoded fake numbers)
- **Runtime whitelist guard** on both handlers' arguments: they arrive over IPC where TypeScript types are erased, and they are interpolated into a shell command line, so service name and action are validated against explicit whitelists before any exec

### Fixed along the way

- `ServicesView.unmount()` never called `ServicesTab.cleanup()`, so the 5s auto-refresh interval (and now the window listeners) leaked across every navigation away from the tab

## Acceptance criteria

- [x] All services manageable from tab — per-service + whole-system controls, all wired to real IPC
- [x] Logs viewable per service — PostgreSQL, MCP Connector, MCP Writing Servers, Typing Mind (connector), with credential redaction
- [x] Resource monitoring works — real `docker stats` values; "Not running" when a container is down
- [x] Service actions functional — no placeholder handlers remain; button enable/disable follows each service's own state

## Test plan

- [x] `npm run build` clean (`tsc` renderer + main)
- [x] New unit tests: `src/renderer/components/__tests__/ServicesTab.test.ts` (11 tests — mounts the real ServicesView+ServicesTab together, covers every acceptance criterion plus the unmount/cleanup contract) and `src/main/__tests__/mcp-system-service-control.test.ts` (13 tests — pins the runtime whitelist / shell-injection rejection paths)
- [x] Full `npx jest`: 494 passed / 25 failed — the 25 failures are exactly the pre-existing #176 baseline (repository-manager, build-orchestrator, VariableBrowser + ProviderSelector a11y, openai-adapter, adapter-integration, provider-manager); no new failures
- [ ] Visual/manual verification — this session runs headless (`ELECTRON_RUN_AS_NODE=1`), so no GUI could be opened. Rebecca, please verify in the running app: card layout/styling of the two MCP server sub-rows, badge colors per state, the logs dialog rendering, real resource numbers appearing within ~5s of opening the tab, per-service Start/Stop/Restart actually cycling containers, Start All/Stop All/Restart All from the top bar, and that Typing Mind's Open Browser opens the window

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)