### PR TITLE
Database Batch Operations UI (#128): wire up Bulk Insert/Update/Delete

### DIFF
--- a/src/renderer/components/DatabaseAdmin/Batch/BatchDelete.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/BatchDelete.ts
@@ -1,0 +1,544 @@
+/**
+ * Batch Delete Component
+ * Handles bulk delete operations: filter-based record selection, a preview
+ * of affected records before anything is removed, and a confirmation step
+ * that states the exact record count. Mirrors BatchUpdate's where-condition
+ * builder so the three batch operations (Insert/Update/Delete) share the
+ * same interaction model.
+ *
+ * Transaction support: db_batch_delete (src/main/database-admin.ts ->
+ * MCP-Writing-Servers) executes each condition set as a single statement on
+ * the server. If the call fails, none of the matched records are removed --
+ * this component treats the whole preview set as "failed" (no partial
+ * credit) so the UI never implies a partial delete happened.
+ */
+
+import { databaseService, BatchDeleteParams, QueryParams } from '../../../services/databaseService.js';
+
+export interface BatchDeleteResult {
+  success: boolean;
+  deleted: number;
+  failed: number;
+  errors: Array<{ condition: any; error: string }>;
+  totalProcessed: number;
+}
+
+export interface BatchDeleteOptions {
+  onComplete?: (result: BatchDeleteResult) => void;
+  onError?: (error: string) => void;
+}
+
+export class BatchDelete {
+  private container: HTMLElement | null = null;
+  private options: BatchDeleteOptions;
+  private currentTable: string = '';
+  private tableColumns: string[] = [];
+  private selectedRecords: any[] = [];
+  private selectedTotalCount: number = 0;
+  private hasPreviewed: boolean = false;
+
+  constructor(containerId: string, options: BatchDeleteOptions = {}) {
+    this.options = { ...options };
+    this.container = document.getElementById(containerId);
+  }
+
+  /**
+   * Render the batch delete interface
+   */
+  public render(): void {
+    if (!this.container) return;
+
+    this.container.innerHTML = `
+      <div class="batch-delete">
+        <div class="batch-delete-header">
+          <h3>Bulk Delete</h3>
+          <div class="delete-warning-banner">
+            Deletions are permanent. Always preview the affected records before executing.
+          </div>
+        </div>
+
+        <div class="batch-delete-table-selector">
+          <label for="batch-delete-table">Target Table:</label>
+          <select id="batch-delete-table" class="form-select">
+            <option value="">Select a table...</option>
+          </select>
+          <button id="batch-delete-refresh-tables" class="action-button secondary small">Refresh</button>
+        </div>
+
+        <div class="batch-delete-content">
+          <div class="batch-delete-section">
+            <h4>Step 1: Filter Records to Delete</h4>
+            <div class="where-conditions">
+              <div id="delete-where-conditions-list"></div>
+              <button id="add-delete-where-condition" class="action-button secondary small">Add Condition</button>
+              <button id="preview-delete-selection" class="action-button secondary">Preview Affected Records</button>
+            </div>
+            <div id="delete-selection-preview" class="selection-preview"></div>
+          </div>
+        </div>
+
+        <div class="batch-delete-actions">
+          <button id="batch-delete-execute" class="action-button danger" disabled>
+            Delete Records
+          </button>
+          <button id="batch-delete-cancel" class="action-button secondary">
+            Cancel
+          </button>
+        </div>
+
+        <div id="batch-delete-progress" class="batch-progress" style="display: none;">
+          <div class="progress-header">
+            <span id="delete-progress-status">Processing...</span>
+          </div>
+          <div class="progress-bar">
+            <div id="delete-progress-fill" class="progress-fill"></div>
+          </div>
+        </div>
+
+        <div id="batch-delete-results" class="batch-results" style="display: none;"></div>
+      </div>
+    `;
+
+    this.attachEventListeners();
+    this.loadTables();
+  }
+
+  /**
+   * Attach event listeners
+   */
+  private attachEventListeners(): void {
+    const tableSelect = document.getElementById('batch-delete-table') as HTMLSelectElement;
+    tableSelect?.addEventListener('change', (e) => {
+      const target = e.target as HTMLSelectElement;
+      this.handleTableChange(target.value);
+    });
+
+    const refreshButton = document.getElementById('batch-delete-refresh-tables');
+    refreshButton?.addEventListener('click', () => this.loadTables());
+
+    const addWhereButton = document.getElementById('add-delete-where-condition');
+    addWhereButton?.addEventListener('click', () => this.addWhereCondition());
+
+    const previewButton = document.getElementById('preview-delete-selection');
+    previewButton?.addEventListener('click', () => this.previewSelection());
+
+    const executeButton = document.getElementById('batch-delete-execute');
+    executeButton?.addEventListener('click', () => this.executeDelete());
+
+    const cancelButton = document.getElementById('batch-delete-cancel');
+    cancelButton?.addEventListener('click', () => this.cancel());
+  }
+
+  /**
+   * Load available tables
+   */
+  private async loadTables(): Promise<void> {
+    try {
+      const result = await databaseService.listTables();
+
+      if (result.success && result.data) {
+        const tables = result.data.tables || result.data;
+        this.updateTableSelector(Array.isArray(tables) ? tables : []);
+      } else {
+        this.options.onError?.('Failed to load tables');
+      }
+    } catch (error: any) {
+      this.options.onError?.(`Error loading tables: ${error.message}`);
+    }
+  }
+
+  /**
+   * Update table selector dropdown
+   */
+  private updateTableSelector(tables: string[]): void {
+    const tableSelect = document.getElementById('batch-delete-table') as HTMLSelectElement;
+    if (!tableSelect) return;
+
+    tableSelect.innerHTML = '<option value="">Select a table...</option>' +
+      tables.map(table => `<option value="${table}">${table}</option>`).join('');
+  }
+
+  /**
+   * Handle table selection change
+   */
+  private async handleTableChange(tableName: string): Promise<void> {
+    this.currentTable = tableName;
+    this.selectedRecords = [];
+    this.selectedTotalCount = 0;
+    this.hasPreviewed = false;
+    this.disableExecuteButton();
+
+    const previewDiv = document.getElementById('delete-selection-preview');
+    if (previewDiv) previewDiv.innerHTML = '';
+
+    if (!tableName) {
+      this.tableColumns = [];
+      this.renderWhereConditions();
+      return;
+    }
+
+    try {
+      const result = await databaseService.listColumns(tableName);
+
+      if (result.success && result.data) {
+        const columns = result.data.columns || result.data;
+        this.tableColumns = Array.isArray(columns)
+          ? columns.map((col: any) => typeof col === 'string' ? col : col.name)
+          : [];
+
+        this.renderWhereConditions();
+      }
+    } catch (error: any) {
+      this.options.onError?.(`Error loading columns: ${error.message}`);
+    }
+  }
+
+  /**
+   * Add a filter (where) condition row
+   */
+  private addWhereCondition(): void {
+    if (this.tableColumns.length === 0) return;
+
+    const conditionsList = document.getElementById('delete-where-conditions-list');
+    if (!conditionsList) return;
+
+    const conditionId = `delete-where-${Date.now()}-${Math.round(Math.random() * 1e6)}`;
+
+    const conditionHtml = `
+      <div class="condition-row" id="${conditionId}">
+        <select class="condition-column">
+          <option value="">Select column...</option>
+          ${this.tableColumns.map(col => `<option value="${col}">${col}</option>`).join('')}
+        </select>
+        <select class="condition-operator">
+          <option value="=">=</option>
+          <option value="!=">!=</option>
+          <option value=">">></option>
+          <option value="<"><</option>
+          <option value=">=">>=</option>
+          <option value="<="><=</option>
+          <option value="LIKE">LIKE</option>
+        </select>
+        <input type="text" class="condition-value" placeholder="Value">
+        <button class="delete-condition-button" data-id="${conditionId}">×</button>
+      </div>
+    `;
+
+    conditionsList.insertAdjacentHTML('beforeend', conditionHtml);
+
+    const deleteButton = conditionsList.querySelector(`[data-id="${conditionId}"]`);
+    deleteButton?.addEventListener('click', () => {
+      document.getElementById(conditionId)?.remove();
+      this.invalidatePreview();
+    });
+
+    conditionsList.querySelectorAll('.condition-column, .condition-operator, .condition-value').forEach(input => {
+      input.addEventListener('input', () => this.invalidatePreview());
+      input.addEventListener('change', () => this.invalidatePreview());
+    });
+  }
+
+  /**
+   * Render the (empty-state) hint for the conditions list
+   */
+  private renderWhereConditions(): void {
+    const conditionsList = document.getElementById('delete-where-conditions-list');
+    if (!conditionsList) return;
+
+    conditionsList.innerHTML = '<div class="where-hint">Add conditions to filter which records will be deleted (leave empty to target every row in the table).</div>';
+  }
+
+  /**
+   * Collect filter conditions from the UI
+   */
+  private collectWhereConditions(): Record<string, any> {
+    const conditions: Record<string, any> = {};
+    const rows = document.querySelectorAll('#delete-where-conditions-list .condition-row');
+
+    rows.forEach(row => {
+      const column = (row.querySelector('.condition-column') as HTMLSelectElement)?.value;
+      const value = (row.querySelector('.condition-value') as HTMLInputElement)?.value;
+
+      if (column && value) {
+        conditions[column] = value;
+      }
+    });
+
+    return conditions;
+  }
+
+  /**
+   * A change to the filter conditions invalidates any prior preview, so the
+   * user can't execute a delete against a selection that no longer matches
+   * what's on screen.
+   */
+  private invalidatePreview(): void {
+    this.hasPreviewed = false;
+    this.disableExecuteButton();
+  }
+
+  /**
+   * Preview affected records (and total count) before deleting
+   */
+  private async previewSelection(): Promise<void> {
+    const previewDiv = document.getElementById('delete-selection-preview');
+    if (!previewDiv || !this.currentTable) return;
+
+    const conditions = this.collectWhereConditions();
+
+    try {
+      const params: QueryParams = {
+        table: this.currentTable,
+        where: Object.keys(conditions).length > 0 ? conditions : undefined,
+        limit: 100,
+      };
+
+      const result = await databaseService.queryRecords(params);
+
+      if (result.success && result.data) {
+        const records = result.data.data || [];
+        const totalCount = result.data.totalCount ?? records.length;
+
+        this.selectedRecords = records;
+        this.selectedTotalCount = totalCount;
+        this.hasPreviewed = true;
+
+        previewDiv.innerHTML = `
+          <div class="preview-info">
+            <strong>${totalCount} record(s) will be deleted</strong>
+            ${totalCount > records.length ? ` (showing first ${records.length})` : ''}
+          </div>
+          ${this.renderRecordsTable(records.slice(0, 10))}
+          ${records.length > 10 ? `<div class="preview-more">... and ${records.length - 10} more records in preview</div>` : ''}
+        `;
+
+        this.updateExecuteButtonState();
+      } else {
+        this.hasPreviewed = false;
+        previewDiv.innerHTML = `<div class="preview-error">Error: ${result.error || 'Failed to query records'}</div>`;
+        this.disableExecuteButton();
+      }
+    } catch (error: any) {
+      this.hasPreviewed = false;
+      previewDiv.innerHTML = `<div class="preview-error">Error: ${this.escapeHtml(error.message)}</div>`;
+      this.disableExecuteButton();
+    }
+  }
+
+  /**
+   * Render a read-only preview table of matched records
+   */
+  private renderRecordsTable(records: any[]): string {
+    if (records.length === 0) {
+      return '<div class="empty-preview">No records match this filter</div>';
+    }
+
+    const columns = Object.keys(records[0]);
+
+    return `
+      <div class="preview-table-wrapper">
+        <table class="preview-table">
+          <thead>
+            <tr>${columns.map(col => `<th>${this.escapeHtml(col)}</th>`).join('')}</tr>
+          </thead>
+          <tbody>
+            ${records.map(record => `
+              <tr>
+                ${columns.map(col => `<td>${this.escapeHtml(String(record[col] ?? ''))}</td>`).join('')}
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  /**
+   * Enable the execute button once a preview has run and matched at least
+   * one record.
+   */
+  private updateExecuteButtonState(): void {
+    const executeButton = document.getElementById('batch-delete-execute') as HTMLButtonElement;
+    if (!executeButton) return;
+    executeButton.disabled = !this.hasPreviewed || this.selectedTotalCount === 0;
+  }
+
+  private disableExecuteButton(): void {
+    const executeButton = document.getElementById('batch-delete-execute') as HTMLButtonElement;
+    if (executeButton) executeButton.disabled = true;
+  }
+
+  /**
+   * Confirm (stating the exact record count) and execute the delete
+   */
+  private async executeDelete(): Promise<void> {
+    if (!this.hasPreviewed) {
+      alert('Please preview the affected records first.');
+      return;
+    }
+
+    const conditions = this.collectWhereConditions();
+
+    if (!confirm(
+      `Are you sure you want to delete ${this.selectedTotalCount} record(s) from "${this.currentTable}"? This cannot be undone.`
+    )) {
+      return;
+    }
+
+    await this.performBatchDelete(conditions);
+  }
+
+  /**
+   * Perform batch delete with progress tracking
+   */
+  private async performBatchDelete(conditions: Record<string, any>): Promise<void> {
+    const progressDiv = document.getElementById('batch-delete-progress');
+    const resultsDiv = document.getElementById('batch-delete-results');
+    const statusSpan = document.getElementById('delete-progress-status');
+    const progressFill = document.getElementById('delete-progress-fill');
+
+    if (progressDiv) progressDiv.style.display = 'block';
+    if (resultsDiv) resultsDiv.style.display = 'none';
+    if (statusSpan) statusSpan.textContent = `Deleting ${this.selectedTotalCount} record(s)...`;
+    if (progressFill) progressFill.style.width = '20%';
+
+    const totalProcessed = this.selectedTotalCount;
+
+    try {
+      const params: BatchDeleteParams = {
+        table: this.currentTable,
+        conditions: [conditions],
+      };
+
+      const result = await databaseService.batchDelete(params);
+
+      if (progressFill) progressFill.style.width = '100%';
+
+      if (result.success) {
+        if (statusSpan) statusSpan.textContent = 'Complete!';
+
+        const finalResult: BatchDeleteResult = {
+          success: true,
+          deleted: totalProcessed,
+          failed: 0,
+          errors: [],
+          totalProcessed,
+        };
+
+        this.showResults(finalResult);
+        this.options.onComplete?.(finalResult);
+        this.hasPreviewed = false;
+        this.disableExecuteButton();
+      } else {
+        if (statusSpan) statusSpan.textContent = 'Failed';
+
+        // The delete either never started or was rolled back server-side --
+        // no partial credit is given.
+        const finalResult: BatchDeleteResult = {
+          success: false,
+          deleted: 0,
+          failed: totalProcessed,
+          errors: [{
+            condition: conditions,
+            error: `${result.error || 'Delete failed'} -- transaction rolled back, no records were deleted.`,
+          }],
+          totalProcessed,
+        };
+
+        this.showResults(finalResult);
+        this.options.onComplete?.(finalResult);
+      }
+    } catch (error: any) {
+      if (statusSpan) statusSpan.textContent = 'Failed';
+
+      const finalResult: BatchDeleteResult = {
+        success: false,
+        deleted: 0,
+        failed: totalProcessed,
+        errors: [{
+          condition: conditions,
+          error: `${error.message} -- transaction rolled back, no records were deleted.`,
+        }],
+        totalProcessed,
+      };
+
+      this.showResults(finalResult);
+      this.options.onError?.(`Batch delete failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Show delete results
+   */
+  private showResults(result: BatchDeleteResult): void {
+    const resultsDiv = document.getElementById('batch-delete-results');
+    if (!resultsDiv) return;
+
+    resultsDiv.style.display = 'block';
+
+    resultsDiv.innerHTML = `
+      <div class="batch-results-summary ${result.success ? 'success' : 'partial'}">
+        <h4>${result.success ? 'Deleted successfully' : 'Delete failed'}</h4>
+        <div class="results-stats">
+          <div class="stat">
+            <span class="stat-label">Total Processed:</span>
+            <span class="stat-value">${result.totalProcessed}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">Successfully Deleted:</span>
+            <span class="stat-value success">${result.deleted}</span>
+          </div>
+          ${result.failed > 0 ? `
+          <div class="stat">
+            <span class="stat-label">Failed:</span>
+            <span class="stat-value error">${result.failed}</span>
+          </div>
+          ` : ''}
+        </div>
+        ${result.errors.length > 0 ? `
+        <div class="results-errors">
+          <h5>Errors:</h5>
+          <ul>
+            ${result.errors.map(err => `<li>${this.escapeHtml(err.error)}</li>`).join('')}
+          </ul>
+        </div>
+        ` : ''}
+      </div>
+    `;
+  }
+
+  /**
+   * Cancel and reset
+   */
+  private cancel(): void {
+    this.selectedRecords = [];
+    this.selectedTotalCount = 0;
+    this.hasPreviewed = false;
+
+    const conditionsList = document.getElementById('delete-where-conditions-list');
+    if (conditionsList) this.renderWhereConditions();
+
+    const previewDiv = document.getElementById('delete-selection-preview');
+    if (previewDiv) previewDiv.innerHTML = '';
+
+    const resultsDiv = document.getElementById('batch-delete-results');
+    if (resultsDiv) resultsDiv.style.display = 'none';
+
+    const progressDiv = document.getElementById('batch-delete-progress');
+    if (progressDiv) progressDiv.style.display = 'none';
+
+    this.disableExecuteButton();
+  }
+
+  /**
+   * Escape HTML for safe display
+   */
+  private escapeHtml(unsafe: string): string {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+}

--- a/src/renderer/components/DatabaseAdmin/Batch/BatchInsert.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/BatchInsert.ts
@@ -3,8 +3,8 @@
  * Handles bulk insert operations with CSV, manual entry, and JSON input
  */
 
-import { CSVUploader, CSVParseResult } from './CSVUploader';
-import { databaseService, BatchInsertParams } from '../../../services/databaseService';
+import { CSVUploader, CSVParseResult } from './CSVUploader.js';
+import { databaseService, BatchInsertParams } from '../../../services/databaseService.js';
 
 export interface BatchInsertResult {
   success: boolean;
@@ -95,6 +95,13 @@ export class BatchInsert {
           <h4>Column Mapping</h4>
           <div class="column-mapping-hint">Map source columns to table columns:</div>
           <div id="column-mapping-grid"></div>
+        </div>
+
+        <div class="batch-size-config">
+          <label for="batch-insert-batch-size">Batch size:</label>
+          <input type="number" id="batch-insert-batch-size" class="batch-size-input"
+            min="1" max="1000" value="${this.options.batchSize ?? this.DEFAULT_BATCH_SIZE}">
+          <span class="batch-size-hint">Records sent per transaction</span>
         </div>
 
         <div class="batch-insert-actions">
@@ -577,6 +584,19 @@ export class BatchInsert {
   }
 
   /**
+   * Read the user-configured batch size (falls back to the default if the
+   * input is missing, empty, or out of range).
+   */
+  private getConfiguredBatchSize(): number {
+    const input = document.getElementById('batch-insert-batch-size') as HTMLInputElement | null;
+    const parsed = input ? parseInt(input.value, 10) : NaN;
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return this.options.batchSize || this.DEFAULT_BATCH_SIZE;
+    }
+    return Math.min(parsed, 1000);
+  }
+
+  /**
    * Perform batch insert with progress tracking
    */
   private async performBatchInsert(records: Array<Record<string, any>>): Promise<void> {
@@ -589,7 +609,7 @@ export class BatchInsert {
     if (progressDiv) progressDiv.style.display = 'block';
     if (resultsDiv) resultsDiv.style.display = 'none';
 
-    const batchSize = this.options.batchSize || this.DEFAULT_BATCH_SIZE;
+    const batchSize = this.getConfiguredBatchSize();
     const totalRecords = records.length;
     let processedCount = 0;
     let successCount = 0;

--- a/src/renderer/components/DatabaseAdmin/Batch/BatchPanel.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/BatchPanel.ts
@@ -1,0 +1,191 @@
+/**
+ * BatchPanel Component
+ *
+ * Container that wires the Batch Operations scaffolding (BatchInsert,
+ * BatchUpdate, BatchDelete -- from commit 3ec4248 / issues #127-#130) into a
+ * single tabbed panel for issue #128 ("Database Batch Operations UI").
+ *
+ * Each sub-component is lazily constructed the first time its tab is
+ * activated (they hit the DB via databaseService on render), then reused
+ * for the lifetime of the panel so table selections / staged data aren't
+ * lost when the user flips between tabs.
+ */
+
+import { BatchInsert, BatchInsertResult } from './BatchInsert.js';
+import { BatchUpdate, BatchUpdateResult } from './BatchUpdate.js';
+import { BatchDelete, BatchDeleteResult } from './BatchDelete.js';
+
+export type BatchOperationTab = 'insert' | 'update' | 'delete';
+
+export interface BatchPanelOptions {
+  onStatusChange?: (message: string, type: 'success' | 'error' | 'info') => void;
+}
+
+const TABS: Array<{ id: BatchOperationTab; label: string }> = [
+  { id: 'insert', label: 'Bulk Insert' },
+  { id: 'update', label: 'Bulk Update' },
+  { id: 'delete', label: 'Bulk Delete' },
+];
+
+export class BatchPanel {
+  private container: HTMLElement | null = null;
+  private options: BatchPanelOptions;
+  private currentTab: BatchOperationTab = 'insert';
+  private batchInsert: BatchInsert | null = null;
+  private batchUpdate: BatchUpdate | null = null;
+  private batchDelete: BatchDelete | null = null;
+
+  constructor(options: BatchPanelOptions = {}) {
+    this.options = options;
+  }
+
+  /**
+   * Render the panel into the given container and mount the default tab.
+   */
+  public initialize(container: HTMLElement): void {
+    this.container = container;
+    this.render();
+  }
+
+  /**
+   * Render the tab shell
+   */
+  private render(): void {
+    if (!this.container) return;
+
+    this.container.innerHTML = `
+      <div class="batch-panel">
+        <div class="batch-panel-header">
+          <h3>Batch Operations</h3>
+          <p class="batch-panel-subtitle">Bulk insert, update, or delete records for a single table</p>
+        </div>
+        <div class="batch-panel-tabs" role="tablist">
+          ${TABS.map(tab => `
+            <button class="batch-tab-button${tab.id === this.currentTab ? ' active' : ''}"
+              data-tab="${tab.id}" role="tab" aria-selected="${tab.id === this.currentTab}">
+              ${tab.label}
+            </button>
+          `).join('')}
+        </div>
+        <div class="batch-panel-content">
+          <div id="batch-panel-insert" class="batch-panel-tab-content${this.currentTab === 'insert' ? ' active' : ''}"></div>
+          <div id="batch-panel-update" class="batch-panel-tab-content${this.currentTab === 'update' ? ' active' : ''}"></div>
+          <div id="batch-panel-delete" class="batch-panel-tab-content${this.currentTab === 'delete' ? ' active' : ''}"></div>
+        </div>
+        <div id="batch-panel-status" class="batch-panel-status" role="status" aria-live="polite"></div>
+      </div>
+    `;
+
+    this.attachEventListeners();
+    this.mountActiveTab();
+  }
+
+  /**
+   * Attach tab-switch listeners
+   */
+  private attachEventListeners(): void {
+    const tabButtons = this.container?.querySelectorAll('.batch-tab-button');
+    tabButtons?.forEach(button => {
+      button.addEventListener('click', () => {
+        const tab = button.getAttribute('data-tab') as BatchOperationTab | null;
+        if (tab) this.switchTab(tab);
+      });
+    });
+  }
+
+  /**
+   * Switch the active tab (mounting the target sub-component on first visit)
+   */
+  private switchTab(tab: BatchOperationTab): void {
+    if (this.currentTab === tab) return;
+    this.currentTab = tab;
+
+    const tabButtons = this.container?.querySelectorAll('.batch-tab-button');
+    tabButtons?.forEach(button => {
+      const isActive = button.getAttribute('data-tab') === tab;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-selected', String(isActive));
+    });
+
+    const tabPanels = this.container?.querySelectorAll('.batch-panel-tab-content');
+    tabPanels?.forEach(panel => {
+      panel.classList.toggle('active', panel.id === `batch-panel-${tab}`);
+    });
+
+    this.mountActiveTab();
+  }
+
+  /**
+   * Lazily construct + render the sub-component backing the current tab
+   */
+  private mountActiveTab(): void {
+    switch (this.currentTab) {
+      case 'insert':
+        if (!this.batchInsert) {
+          this.batchInsert = new BatchInsert('batch-panel-insert', {
+            onProgress: (progress, total) => this.setStatus(`Inserting ${progress} / ${total}...`, 'info'),
+            onComplete: (result: BatchInsertResult) => this.setStatus(
+              result.success
+                ? `Inserted ${result.inserted} record(s) successfully.`
+                : `Insert completed with ${result.failed} error(s) (${result.inserted} succeeded).`,
+              result.success ? 'success' : 'error'
+            ),
+            onError: (error) => this.setStatus(error, 'error'),
+          });
+          this.batchInsert.render();
+        }
+        break;
+      case 'update':
+        if (!this.batchUpdate) {
+          this.batchUpdate = new BatchUpdate('batch-panel-update', {
+            onComplete: (result: BatchUpdateResult) => this.setStatus(
+              result.success
+                ? `Updated ${result.updated} record(s) successfully.`
+                : `Update failed (${result.errors[0]?.error || 'unknown error'}).`,
+              result.success ? 'success' : 'error'
+            ),
+            onError: (error) => this.setStatus(error, 'error'),
+          });
+          this.batchUpdate.render();
+        }
+        break;
+      case 'delete':
+        if (!this.batchDelete) {
+          this.batchDelete = new BatchDelete('batch-panel-delete', {
+            onComplete: (result: BatchDeleteResult) => this.setStatus(
+              result.success
+                ? `Deleted ${result.deleted} record(s) successfully.`
+                : `Delete failed (${result.errors[0]?.error || 'unknown error'}).`,
+              result.success ? 'success' : 'error'
+            ),
+            onError: (error) => this.setStatus(error, 'error'),
+          });
+          this.batchDelete.render();
+        }
+        break;
+    }
+  }
+
+  /**
+   * Update the shared status line beneath the tab content
+   */
+  private setStatus(message: string, type: 'success' | 'error' | 'info'): void {
+    const statusEl = document.getElementById('batch-panel-status');
+    if (statusEl) {
+      statusEl.textContent = message;
+      statusEl.className = `batch-panel-status ${type}`;
+    }
+    this.options.onStatusChange?.(message, type);
+  }
+
+  /**
+   * Release references to sub-components (called when the Database tab
+   * navigates away from the batch view).
+   */
+  public destroy(): void {
+    this.batchInsert = null;
+    this.batchUpdate = null;
+    this.batchDelete = null;
+    this.container = null;
+  }
+}

--- a/src/renderer/components/DatabaseAdmin/Batch/BatchUpdate.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/BatchUpdate.ts
@@ -3,7 +3,7 @@
  * Handles bulk update operations with record selection and preview
  */
 
-import { databaseService, BatchUpdateParams, QueryParams } from '../../../services/databaseService';
+import { databaseService, BatchUpdateParams, QueryParams } from '../../../services/databaseService.js';
 
 export interface BatchUpdateResult {
   success: boolean;

--- a/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchDelete.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchDelete.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for BatchDelete (issue #128): filter-based selection, preview of
+ * affected records before deleting, confirmation naming the exact record
+ * count, and transaction-rollback semantics on failure (no partial delete
+ * is ever reported).
+ */
+
+import { BatchDelete } from '../BatchDelete';
+
+interface MockDatabaseAdmin {
+  listTables: jest.Mock;
+  listColumns: jest.Mock;
+  queryRecords: jest.Mock;
+  batchDelete: jest.Mock;
+}
+
+function makeMockAPI(): MockDatabaseAdmin {
+  return {
+    listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: ['characters'] } }),
+    listColumns: jest.fn().mockResolvedValue({ success: true, data: { columns: ['id', 'name', 'status'] } }),
+    queryRecords: jest.fn().mockResolvedValue({
+      success: true,
+      data: { data: [{ id: 1, name: 'Ada', status: 'archived' }], totalCount: 12 },
+    }),
+    batchDelete: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('BatchDelete', () => {
+  let container: HTMLElement;
+  let api: MockDatabaseAdmin;
+
+  beforeEach(() => {
+    api = makeMockAPI();
+    (window as any).electronAPI = { databaseAdmin: api };
+
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.id = 'batch-delete-test-container';
+    document.body.appendChild(container);
+  });
+
+  function makeDelete(options: ConstructorParameters<typeof BatchDelete>[1] = {}) {
+    const del = new BatchDelete('batch-delete-test-container', options);
+    del.render();
+    return del;
+  }
+
+  async function selectTable(tableName = 'characters'): Promise<void> {
+    await flushPromises();
+    const select = document.getElementById('batch-delete-table') as HTMLSelectElement;
+    select.value = tableName;
+    select.dispatchEvent(new Event('change'));
+    await flushPromises();
+  }
+
+  function addWhereRow(column: string, value: string): void {
+    (document.getElementById('add-delete-where-condition') as HTMLButtonElement).click();
+    const row = document.querySelector('#delete-where-conditions-list .condition-row') as HTMLElement;
+    (row.querySelector('.condition-column') as HTMLSelectElement).value = column;
+    (row.querySelector('.condition-value') as HTMLInputElement).value = value;
+  }
+
+  it('keeps the delete button disabled until the affected records have been previewed', async () => {
+    makeDelete();
+    await selectTable();
+
+    const executeBtn = document.getElementById('batch-delete-execute') as HTMLButtonElement;
+    expect(executeBtn.disabled).toBe(true);
+
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(executeBtn.disabled).toBe(false);
+  });
+
+  it('previews affected records showing the exact total count', async () => {
+    makeDelete();
+    await selectTable();
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(api.queryRecords).toHaveBeenCalledWith(expect.objectContaining({
+      table: 'characters',
+      where: { status: 'archived' },
+    }));
+
+    const previewDiv = document.getElementById('delete-selection-preview')!;
+    expect(previewDiv.innerHTML).toMatch(/12 record\(s\) will be deleted/i);
+  });
+
+  it('invalidates the preview (and re-disables execute) when a condition changes after previewing', async () => {
+    makeDelete();
+    await selectTable();
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    const executeBtn = document.getElementById('batch-delete-execute') as HTMLButtonElement;
+    expect(executeBtn.disabled).toBe(false);
+
+    const valueInput = document.querySelector('#delete-where-conditions-list .condition-value') as HTMLInputElement;
+    valueInput.value = 'different';
+    valueInput.dispatchEvent(new Event('input'));
+
+    expect(executeBtn.disabled).toBe(true);
+  });
+
+  it('confirms naming the exact record count, then calls batchDelete on confirm', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const onComplete = jest.fn();
+    makeDelete({ onComplete });
+    await selectTable();
+
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    (document.getElementById('batch-delete-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('12 record(s)'));
+    expect(api.batchDelete).toHaveBeenCalledWith({
+      table: 'characters',
+      conditions: [{ status: 'archived' }],
+    });
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      deleted: 12,
+      failed: 0,
+      totalProcessed: 12,
+    }));
+
+    confirmSpy.mockRestore();
+  });
+
+  it('does not call batchDelete if the user cancels the confirmation', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    makeDelete();
+    await selectTable();
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    (document.getElementById('batch-delete-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(api.batchDelete).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('reports zero partial deletes and a rollback message when the server call fails (transaction rollback)', async () => {
+    api.batchDelete.mockResolvedValueOnce({ success: false, error: 'foreign key violation' });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const onComplete = jest.fn();
+    makeDelete({ onComplete });
+    await selectTable();
+
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    (document.getElementById('batch-delete-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    const result = onComplete.mock.calls[0][0];
+    expect(result.success).toBe(false);
+    expect(result.deleted).toBe(0); // no partial credit
+    expect(result.failed).toBe(12);
+    expect(result.errors[0].error).toMatch(/foreign key violation.*rolled back/i);
+
+    const resultsDiv = document.getElementById('batch-delete-results')!;
+    expect(resultsDiv.innerHTML).toMatch(/delete failed/i);
+  });
+
+  it('surfaces a rejected promise (network error) with the same rollback semantics', async () => {
+    api.batchDelete.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const onError = jest.fn();
+    const onComplete = jest.fn();
+    makeDelete({ onComplete, onError });
+    await selectTable();
+
+    addWhereRow('status', 'archived');
+    (document.getElementById('preview-delete-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    (document.getElementById('batch-delete-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('ECONNREFUSED'));
+    // onComplete is not called on the thrown-exception path -- only onError.
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('requires a preview before allowing execute even if clicked directly', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    makeDelete();
+    await selectTable();
+    addWhereRow('status', 'archived');
+
+    // Never click preview -- execute button stays disabled, but exercise the
+    // guard directly in case a caller enables it programmatically.
+    const executeBtn = document.getElementById('batch-delete-execute') as HTMLButtonElement;
+    executeBtn.disabled = false;
+    executeBtn.click();
+    await flushPromises();
+
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringMatching(/preview the affected records/i));
+    expect(api.batchDelete).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchInsert.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchInsert.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for BatchInsert (issue #128): table/column loading, JSON-paste mode,
+ * the configurable batch-size input, chunked execution against
+ * databaseService.batchInsert, and the acceptance criteria from the issue:
+ *   - Can insert 100+ records successfully
+ *   - Progress indicator shows status
+ *   - Error handling per row
+ *   - Transaction rollback on error (a failed batch call fails ALL rows in
+ *     that batch -- no partial credit, since the server-side call is
+ *     transactional).
+ */
+
+import { BatchInsert } from '../BatchInsert';
+
+interface MockDatabaseAdmin {
+  listTables: jest.Mock;
+  listColumns: jest.Mock;
+  batchInsert: jest.Mock;
+}
+
+function makeMockAPI(): MockDatabaseAdmin {
+  return {
+    listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: ['characters', 'scenes'] } }),
+    listColumns: jest.fn().mockResolvedValue({ success: true, data: { columns: ['id', 'name', 'age'] } }),
+    batchInsert: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('BatchInsert', () => {
+  let container: HTMLElement;
+  let api: MockDatabaseAdmin;
+
+  beforeEach(() => {
+    api = makeMockAPI();
+    (window as any).electronAPI = { databaseAdmin: api };
+
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.id = 'batch-insert-test-container';
+    document.body.appendChild(container);
+  });
+
+  function makeInsert(options: ConstructorParameters<typeof BatchInsert>[1] = {}) {
+    const insert = new BatchInsert('batch-insert-test-container', options);
+    insert.render();
+    return insert;
+  }
+
+  async function selectTable(tableName = 'characters'): Promise<void> {
+    await flushPromises(); // let loadTables() resolve
+    const select = document.getElementById('batch-insert-table') as HTMLSelectElement;
+    select.value = tableName;
+    select.dispatchEvent(new Event('change'));
+    await flushPromises(); // let listColumns() resolve
+  }
+
+  it('loads tables into the selector on render', async () => {
+    makeInsert();
+    await flushPromises();
+
+    expect(api.listTables).toHaveBeenCalledTimes(1);
+    const select = document.getElementById('batch-insert-table') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map(o => o.value);
+    expect(optionValues).toEqual(['', 'characters', 'scenes']);
+  });
+
+  it('loads columns for the selected table', async () => {
+    makeInsert();
+    await selectTable('characters');
+
+    expect(api.listColumns).toHaveBeenCalledWith({ table: 'characters' });
+  });
+
+  it('parses a JSON array pasted into the JSON mode textarea', async () => {
+    makeInsert();
+    await selectTable();
+
+    // Switch to JSON mode
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify([{ name: 'Ada' }, { name: 'Grace' }]);
+
+    const parseBtn = document.getElementById('json-parse-button') as HTMLButtonElement;
+    parseBtn.click();
+
+    const resultDiv = document.getElementById('json-parse-result')!;
+    expect(resultDiv.innerHTML).toMatch(/successfully parsed 2 records/i);
+
+    const executeBtn = document.getElementById('batch-insert-execute') as HTMLButtonElement;
+    expect(executeBtn.disabled).toBe(false);
+  });
+
+  it('respects the batch-size input, chunking 250 records into 100/100/50', async () => {
+    makeInsert({ batchSize: 100 });
+    await selectTable();
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+
+    const records = Array.from({ length: 250 }, (_, i) => ({ name: `Row ${i}` }));
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify(records);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+    await flushPromises();
+    await flushPromises();
+
+    expect(api.batchInsert).toHaveBeenCalledTimes(3);
+    expect(api.batchInsert.mock.calls[0][0].records).toHaveLength(100);
+    expect(api.batchInsert.mock.calls[1][0].records).toHaveLength(100);
+    expect(api.batchInsert.mock.calls[2][0].records).toHaveLength(50);
+  });
+
+  it('can insert 100+ records successfully and reports the final count via onComplete', async () => {
+    const onComplete = jest.fn();
+    makeInsert({ onComplete });
+    await selectTable();
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+
+    const records = Array.from({ length: 150 }, (_, i) => ({ name: `Row ${i}` }));
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify(records);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      inserted: 150,
+      failed: 0,
+      totalProcessed: 150,
+    }));
+  });
+
+  it('reports progress via onProgress as batches are processed', async () => {
+    const onProgress = jest.fn();
+    makeInsert({ onProgress, batchSize: 50 });
+    await selectTable();
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+    const records = Array.from({ length: 100 }, (_, i) => ({ name: `Row ${i}` }));
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify(records);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(onProgress).toHaveBeenCalledWith(0, 100);
+    expect(onProgress).toHaveBeenCalledWith(50, 100);
+
+    const progressText = document.getElementById('progress-text')!;
+    expect(progressText.textContent).toBe('100 / 100');
+  });
+
+  it('handles per-row errors without partial credit when a batch call fails (transaction rollback)', async () => {
+    api.batchInsert
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, error: 'constraint violation' });
+
+    const onComplete = jest.fn();
+    makeInsert({ onComplete, batchSize: 50 });
+    await selectTable();
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+    const records = Array.from({ length: 100 }, (_, i) => ({ name: `Row ${i}` }));
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify(records);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+
+    await flushPromises();
+    await flushPromises();
+
+    const result = onComplete.mock.calls[0][0];
+    expect(result.success).toBe(false);
+    expect(result.inserted).toBe(50); // first batch succeeded
+    expect(result.failed).toBe(50); // second batch failed entirely -- no partial rows
+    expect(result.errors).toHaveLength(50);
+    expect(result.errors[0].error).toBe('constraint violation');
+  });
+
+  it('applies column mapping before inserting', async () => {
+    makeInsert();
+    await selectTable(); // columns: id, name, age
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify([{ full_name: 'Ada', years: 30 }]);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+
+    // Map full_name -> name, years -> age
+    const nameMapSelect = document.querySelector('[data-source="full_name"]') as HTMLSelectElement;
+    nameMapSelect.value = 'name';
+    nameMapSelect.dispatchEvent(new Event('change'));
+
+    const yearsMapSelect = document.querySelector('[data-source="years"]') as HTMLSelectElement;
+    yearsMapSelect.value = 'age';
+    yearsMapSelect.dispatchEvent(new Event('change'));
+
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(api.batchInsert).toHaveBeenCalledWith(expect.objectContaining({
+      table: 'characters',
+      records: [{ name: 'Ada', age: 30 }],
+    }));
+  });
+
+  it('the batch-size input overrides the constructor default', async () => {
+    makeInsert({ batchSize: 100 });
+    await selectTable();
+
+    const batchSizeInput = document.getElementById('batch-insert-batch-size') as HTMLInputElement;
+    batchSizeInput.value = '10';
+
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+    const records = Array.from({ length: 25 }, (_, i) => ({ name: `Row ${i}` }));
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify(records);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+
+    await flushPromises();
+    await flushPromises();
+
+    // 25 records / batch size 10 = 3 calls (10, 10, 5)
+    expect(api.batchInsert).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchPanel.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchPanel.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for BatchPanel (issue #128): the tabbed container wiring
+ * BatchInsert / BatchUpdate / BatchDelete together, as mounted by
+ * DatabaseTab's "Batch Ops" quick action.
+ */
+
+import { BatchPanel } from '../BatchPanel';
+
+function makeMockAPI() {
+  return {
+    listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: ['characters'] } }),
+    listColumns: jest.fn().mockResolvedValue({ success: true, data: { columns: ['id', 'name'] } }),
+    queryRecords: jest.fn().mockResolvedValue({ success: true, data: { data: [], totalCount: 0 } }),
+    batchInsert: jest.fn().mockResolvedValue({ success: true }),
+    batchUpdate: jest.fn().mockResolvedValue({ success: true }),
+    batchDelete: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('BatchPanel', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    (window as any).electronAPI = { databaseAdmin: makeMockAPI() };
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('renders three tabs with Bulk Insert active by default', () => {
+    const panel = new BatchPanel();
+    panel.initialize(container);
+
+    const buttons = Array.from(container.querySelectorAll('.batch-tab-button')) as HTMLButtonElement[];
+    expect(buttons.map(b => b.getAttribute('data-tab'))).toEqual(['insert', 'update', 'delete']);
+    expect(buttons[0].classList.contains('active')).toBe(true);
+
+    // The insert sub-component should have mounted its own DOM into the
+    // insert tab's container (proves BatchInsert.render() actually ran).
+    expect(document.getElementById('batch-insert-table')).not.toBeNull();
+  });
+
+  it('lazily mounts BatchUpdate only when its tab is first activated', async () => {
+    const panel = new BatchPanel();
+    panel.initialize(container);
+
+    expect(document.getElementById('batch-update-table')).toBeNull();
+
+    const updateTab = container.querySelector('[data-tab="update"]') as HTMLButtonElement;
+    updateTab.click();
+    await flushPromises();
+
+    expect(document.getElementById('batch-update-table')).not.toBeNull();
+    expect(updateTab.classList.contains('active')).toBe(true);
+    expect(container.querySelector('[data-tab="insert"]')!.classList.contains('active')).toBe(false);
+  });
+
+  it('lazily mounts BatchDelete only when its tab is first activated', async () => {
+    const panel = new BatchPanel();
+    panel.initialize(container);
+
+    const deleteTab = container.querySelector('[data-tab="delete"]') as HTMLButtonElement;
+    deleteTab.click();
+    await flushPromises();
+
+    expect(document.getElementById('batch-delete-table')).not.toBeNull();
+  });
+
+  it('only shows the active tab content panel', async () => {
+    const panel = new BatchPanel();
+    panel.initialize(container);
+
+    const deleteTab = container.querySelector('[data-tab="delete"]') as HTMLButtonElement;
+    deleteTab.click();
+    await flushPromises();
+
+    expect(document.getElementById('batch-panel-insert')!.classList.contains('active')).toBe(false);
+    expect(document.getElementById('batch-panel-update')!.classList.contains('active')).toBe(false);
+    expect(document.getElementById('batch-panel-delete')!.classList.contains('active')).toBe(true);
+  });
+
+  it('surfaces sub-component completion messages via onStatusChange', async () => {
+    const onStatusChange = jest.fn();
+    const panel = new BatchPanel({ onStatusChange });
+    panel.initialize(container);
+    await flushPromises();
+
+    // Drive BatchInsert to a JSON-mode insert and confirm the panel-level
+    // status line reflects its onComplete callback.
+    const jsonModeBtn = document.querySelector('[data-mode="json"]') as HTMLButtonElement;
+    jsonModeBtn.click();
+    const select = document.getElementById('batch-insert-table') as HTMLSelectElement;
+    select.value = 'characters';
+    select.dispatchEvent(new Event('change'));
+    await flushPromises();
+
+    const textarea = document.getElementById('json-paste-area') as HTMLTextAreaElement;
+    textarea.value = JSON.stringify([{ name: 'Ada' }]);
+    (document.getElementById('json-parse-button') as HTMLButtonElement).click();
+    (document.getElementById('batch-insert-execute') as HTMLButtonElement).click();
+    await flushPromises();
+    await flushPromises();
+
+    expect(onStatusChange).toHaveBeenCalledWith(
+      expect.stringMatching(/inserted 1 record/i),
+      'success'
+    );
+
+    const statusEl = document.getElementById('batch-panel-status')!;
+    expect(statusEl.textContent).toMatch(/inserted 1 record/i);
+    expect(statusEl.className).toContain('success');
+  });
+
+  it('destroy() releases sub-component references without throwing', () => {
+    const panel = new BatchPanel();
+    panel.initialize(container);
+    expect(() => panel.destroy()).not.toThrow();
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchUpdate.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/__tests__/BatchUpdate.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for BatchUpdate (issue #128): where-condition selection, preview
+ * before execution, and the confirm + execute flow against
+ * databaseService.batchUpdate.
+ */
+
+import { BatchUpdate } from '../BatchUpdate';
+
+interface MockDatabaseAdmin {
+  listTables: jest.Mock;
+  listColumns: jest.Mock;
+  queryRecords: jest.Mock;
+  batchUpdate: jest.Mock;
+}
+
+function makeMockAPI(): MockDatabaseAdmin {
+  return {
+    listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: ['characters'] } }),
+    listColumns: jest.fn().mockResolvedValue({ success: true, data: { columns: ['id', 'name', 'status'] } }),
+    queryRecords: jest.fn().mockResolvedValue({
+      success: true,
+      data: { data: [{ id: 1, name: 'Ada', status: 'draft' }, { id: 2, name: 'Grace', status: 'draft' }], totalCount: 2 },
+    }),
+    batchUpdate: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('BatchUpdate', () => {
+  let container: HTMLElement;
+  let api: MockDatabaseAdmin;
+
+  beforeEach(() => {
+    api = makeMockAPI();
+    (window as any).electronAPI = { databaseAdmin: api };
+
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.id = 'batch-update-test-container';
+    document.body.appendChild(container);
+  });
+
+  function makeUpdate(options: ConstructorParameters<typeof BatchUpdate>[1] = {}) {
+    const update = new BatchUpdate('batch-update-test-container', options);
+    update.render();
+    return update;
+  }
+
+  async function selectTable(tableName = 'characters'): Promise<void> {
+    await flushPromises();
+    const select = document.getElementById('batch-update-table') as HTMLSelectElement;
+    select.value = tableName;
+    select.dispatchEvent(new Event('change'));
+    await flushPromises();
+  }
+
+  function addWhereRow(column: string, value: string): void {
+    (document.getElementById('add-where-condition') as HTMLButtonElement).click();
+    const row = document.querySelector('#where-conditions-list .condition-row') as HTMLElement;
+    (row.querySelector('.condition-column') as HTMLSelectElement).value = column;
+    (row.querySelector('.condition-value') as HTMLInputElement).value = value;
+  }
+
+  function addFieldRow(column: string, value: string): void {
+    (document.getElementById('add-update-field') as HTMLButtonElement).click();
+    const row = document.querySelector('#update-fields-list .update-field-row') as HTMLElement;
+    (row.querySelector('.update-field-column') as HTMLSelectElement).value = column;
+    (row.querySelector('.update-field-value') as HTMLInputElement).value = value;
+  }
+
+  it('loads tables and, once one is selected, its columns', async () => {
+    makeUpdate();
+    await selectTable();
+
+    expect(api.listTables).toHaveBeenCalledTimes(1);
+    expect(api.listColumns).toHaveBeenCalledWith({ table: 'characters' });
+  });
+
+  it('previews the matching selection (record count + rows) before any update runs', async () => {
+    makeUpdate();
+    await selectTable();
+
+    addWhereRow('status', 'draft');
+    (document.getElementById('preview-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(api.queryRecords).toHaveBeenCalledWith(expect.objectContaining({
+      table: 'characters',
+      where: { status: 'draft' },
+    }));
+
+    const previewDiv = document.getElementById('selection-preview')!;
+    expect(previewDiv.innerHTML).toMatch(/selected 2 record/i);
+  });
+
+  it('keeps the execute button disabled until a changes preview has been generated', async () => {
+    makeUpdate();
+    await selectTable();
+    addWhereRow('status', 'draft');
+    (document.getElementById('preview-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    const executeBtn = document.getElementById('batch-update-execute') as HTMLButtonElement;
+    expect(executeBtn.disabled).toBe(true);
+
+    addFieldRow('status', 'published');
+    (document.getElementById('preview-changes') as HTMLButtonElement).click();
+
+    expect(executeBtn.disabled).toBe(false);
+    const changesPreview = document.getElementById('changes-preview')!;
+    expect(changesPreview.innerHTML).toMatch(/will update 2 record/i);
+  });
+
+  it('asks for confirmation naming the record count, then calls batchUpdate on confirm', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const onComplete = jest.fn();
+    makeUpdate({ onComplete });
+    await selectTable();
+
+    addWhereRow('status', 'draft');
+    (document.getElementById('preview-selection') as HTMLButtonElement).click();
+    await flushPromises();
+
+    addFieldRow('status', 'published');
+    (document.getElementById('preview-changes') as HTMLButtonElement).click();
+
+    (document.getElementById('batch-update-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('2 record'));
+    expect(api.batchUpdate).toHaveBeenCalledWith({
+      table: 'characters',
+      updates: [{ where: { status: 'draft' }, data: { status: 'published' } }],
+    });
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ success: true, updated: 2 }));
+
+    confirmSpy.mockRestore();
+  });
+
+  it('does not call batchUpdate if the user cancels the confirmation', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    makeUpdate();
+    await selectTable();
+
+    addWhereRow('status', 'draft');
+    (document.getElementById('preview-selection') as HTMLButtonElement).click();
+    await flushPromises();
+    addFieldRow('status', 'published');
+    (document.getElementById('preview-changes') as HTMLButtonElement).click();
+
+    (document.getElementById('batch-update-execute') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(api.batchUpdate).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Batch/__tests__/CSVUploader.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Batch/__tests__/CSVUploader.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for CSVUploader (issue #128): CSV text parsing, type detection,
+ * malformed-row handling, and the drag/drop + file-input wiring that feeds
+ * BatchInsert's "CSV Upload" mode.
+ */
+
+import { CSVUploader } from '../CSVUploader';
+
+/**
+ * jsdom's Blob/File implementation doesn't provide `.text()` (only
+ * FileReader.readAsText works) -- a jsdom-environment gap, not a bug in
+ * CSVUploader.ts, which correctly relies on the standard File API and
+ * works as-is in the real Electron renderer (Chromium). Stub `.text()`
+ * per-instance in tests that need it.
+ */
+function makeFileWithText(content: string, name: string, type: string): File {
+  const file = new File([content], name, { type });
+  (file as any).text = () => Promise.resolve(content);
+  return file;
+}
+
+describe('CSVUploader', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.id = 'csv-uploader-test-container';
+    document.body.appendChild(container);
+  });
+
+  function makeUploader(options: ConstructorParameters<typeof CSVUploader>[1] = {}) {
+    const uploader = new CSVUploader('csv-uploader-test-container', options);
+    uploader.render();
+    return uploader;
+  }
+
+  describe('parseText', () => {
+    it('parses headers and rows, and can be inspected via parseText (public API)', () => {
+      const uploader = makeUploader();
+      const csv = 'name,age,active\nAda,30,true\nGrace,28,false';
+
+      const result = uploader.parseText(csv);
+
+      expect(result.success).toBe(true);
+      expect(result.headers).toEqual(['name', 'age', 'active']);
+      expect(result.rowCount).toBe(2);
+      expect(result.data[0]).toEqual({ name: 'Ada', age: 30, active: true });
+      expect(result.data[1]).toEqual({ name: 'Grace', age: 28, active: false });
+    });
+
+    it('type-detects numbers, booleans, and null/empty values', () => {
+      const uploader = makeUploader();
+      const csv = 'id,score,note\n1,3.14,\n2,0,null';
+
+      const result = uploader.parseText(csv);
+
+      expect(result.data[0]).toEqual({ id: 1, score: 3.14, note: null });
+      expect(result.data[1]).toEqual({ id: 2, score: 0, note: null });
+    });
+
+    it('handles quoted values containing commas and escaped quotes', () => {
+      const uploader = makeUploader();
+      const csv = 'name,bio\n"Doe, Jane","Says ""hi"" often"';
+
+      const result = uploader.parseText(csv);
+
+      expect(result.data[0]).toEqual({ name: 'Doe, Jane', bio: 'Says "hi" often' });
+    });
+
+    it('reports an error for an empty file', () => {
+      const uploader = makeUploader();
+      const result = uploader.parseText('');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/empty/i);
+    });
+
+    it('warns (but still succeeds) on rows with a column-count mismatch, skipping the bad row', () => {
+      const uploader = makeUploader();
+      const csv = 'a,b,c\n1,2,3\n4,5'; // second row has only 2 values
+
+      const result = uploader.parseText(csv);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(1);
+      expect(result.error).toMatch(/column count mismatch/i);
+    });
+  });
+
+  describe('file handling', () => {
+    it('rejects files with a disallowed extension via onError', () => {
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+      const onError = jest.fn();
+      makeUploader({ onError });
+
+      const badFile = new File(['not,a,csv'], 'notes.png', { type: 'image/png' });
+      const fileInput = document.getElementById('csv-file-input') as HTMLInputElement;
+
+      // jsdom lets us assign a FileList-like object for change events.
+      Object.defineProperty(fileInput, 'files', { value: [badFile], configurable: true });
+      fileInput.dispatchEvent(new Event('change'));
+
+      expect(onError).toHaveBeenCalledWith(expect.stringMatching(/invalid file type/i));
+      alertSpy.mockRestore();
+    });
+
+    it('parses a valid dropped/selected CSV file and calls onParsed', async () => {
+      const onParsed = jest.fn();
+      makeUploader({ onParsed });
+
+      const file = makeFileWithText('col1,col2\nval1,val2', 'data.csv', 'text/csv');
+      const fileInput = document.getElementById('csv-file-input') as HTMLInputElement;
+
+      Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+      fileInput.dispatchEvent(new Event('change'));
+
+      // file.text() resolves asynchronously
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(onParsed).toHaveBeenCalledTimes(1);
+      const result = onParsed.mock.calls[0][0];
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual([{ col1: 'val1', col2: 'val2' }]);
+    });
+
+    it('clearFile() resets the current file and hides the preview', () => {
+      const uploader = makeUploader();
+      const file = makeFileWithText('a,b\n1,2', 'data.csv', 'text/csv');
+      const fileInput = document.getElementById('csv-file-input') as HTMLInputElement;
+      Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+      fileInput.dispatchEvent(new Event('change'));
+
+      uploader.clearFile();
+
+      expect(uploader.getCurrentFile()).toBeNull();
+    });
+  });
+});

--- a/src/renderer/components/DatabaseTab.ts
+++ b/src/renderer/components/DatabaseTab.ts
@@ -12,17 +12,22 @@
 import { databaseService } from '../services/databaseService.js';
 import { BackupManager } from './DatabaseAdmin/Backup/BackupManager.js';
 import { CRUDPanel } from './DatabaseAdmin/CRUD/CRUDPanel.js';
+import { BatchPanel } from './DatabaseAdmin/Batch/BatchPanel.js';
 
 export class DatabaseTab {
   private container: HTMLElement | null = null;
   private availableTables: string[] = [];
   private backupManager: BackupManager | null = null;
   private crudPanel: CRUDPanel | null = null;
-  private currentView: 'overview' | 'backup' = 'overview';
+  private batchPanel: BatchPanel | null = null;
+  private currentView: 'overview' | 'backup' | 'batch' = 'overview';
   private currentActiveTab: 'schema' | 'data' = 'data'; // Default to data view
 
   constructor() {
     this.backupManager = new BackupManager();
+    this.batchPanel = new BatchPanel({
+      onStatusChange: (message, type) => console.log(`[Batch] [${type}] ${message}`),
+    });
   }
 
   /**
@@ -52,6 +57,8 @@ export class DatabaseTab {
 
     if (this.currentView === 'backup') {
       this.renderBackupView();
+    } else if (this.currentView === 'batch') {
+      this.renderBatchView();
     } else {
       this.renderOverviewView();
     }
@@ -126,6 +133,39 @@ export class DatabaseTab {
   }
 
   /**
+   * Render batch operations view (issue #128)
+   */
+  private renderBatchView(): void {
+    if (!this.container) return;
+
+    this.container.innerHTML = `
+      ${this.renderHeader()}
+      <div class="database-batch-view">
+        <div class="backup-view-header">
+          <button class="btn-back" id="back-to-overview-from-batch-btn">
+            <span class="btn-icon">←</span>
+            Back to Overview
+          </button>
+        </div>
+        <div id="batch-panel-container"></div>
+      </div>
+    `;
+
+    const backBtn = document.getElementById('back-to-overview-from-batch-btn');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        this.currentView = 'overview';
+        this.render();
+      });
+    }
+
+    const batchContainer = document.getElementById('batch-panel-container');
+    if (batchContainer && this.batchPanel) {
+      this.batchPanel.initialize(batchContainer);
+    }
+  }
+
+  /**
    * Render the header
    */
   private renderHeader(): string {
@@ -156,6 +196,10 @@ export class DatabaseTab {
         <button id="db-test-query" class="quick-action-btn-small" title="Test a simple query">
           <span class="action-icon">🔍</span>
           <span class="action-label">Test Query</span>
+        </button>
+        <button id="db-batch-operations" class="quick-action-btn-small" title="Bulk insert, update, or delete records">
+          <span class="action-icon">📦</span>
+          <span class="action-label">Batch Ops</span>
         </button>
         <div class="spacer"></div>
         <button id="db-manage-backups" class="quick-action-btn-small primary" title="Manage database backups">
@@ -207,6 +251,11 @@ export class DatabaseTab {
     const manageBackupsBtn = document.getElementById('db-manage-backups');
     if (manageBackupsBtn) {
       manageBackupsBtn.addEventListener('click', () => this.handleManageBackups());
+    }
+
+    const batchOpsBtn = document.getElementById('db-batch-operations');
+    if (batchOpsBtn) {
+      batchOpsBtn.addEventListener('click', () => this.handleBatchOperations());
     }
   }
 
@@ -283,6 +332,14 @@ export class DatabaseTab {
    */
   private async handleManageBackups(): Promise<void> {
     this.currentView = 'backup';
+    await this.render();
+  }
+
+  /**
+   * Handle batch operations button click (issue #128)
+   */
+  private async handleBatchOperations(): Promise<void> {
+    this.currentView = 'batch';
     await this.render();
   }
 

--- a/src/renderer/components/__tests__/DatabaseTab.batch.test.ts
+++ b/src/renderer/components/__tests__/DatabaseTab.batch.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for DatabaseTab's "Batch Ops" wiring (issue #128).
+ *
+ * Scoped narrowly to the batch view-switch: it does not re-test
+ * BackupManager/CRUDPanel (already covered elsewhere / by sibling issues
+ * #129 and #130's own suites) so it stays low-friction against concurrent
+ * edits to this same shared container file.
+ */
+
+import { DatabaseTab } from '../DatabaseTab';
+
+function makeMockAPI() {
+  return {
+    checkConnection: jest.fn().mockResolvedValue({ success: true }),
+    listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: ['characters'] } }),
+    listColumns: jest.fn().mockResolvedValue({ success: true, data: { columns: ['id', 'name'] } }),
+    queryRecords: jest.fn().mockResolvedValue({ success: true, data: { data: [], totalCount: 0 } }),
+    batchInsert: jest.fn().mockResolvedValue({ success: true }),
+    batchUpdate: jest.fn().mockResolvedValue({ success: true }),
+    batchDelete: jest.fn().mockResolvedValue({ success: true }),
+    getServerInfo: jest.fn().mockResolvedValue({ success: true }),
+    insertRecord: jest.fn().mockResolvedValue({ success: true }),
+    updateRecords: jest.fn().mockResolvedValue({ success: true }),
+    deleteRecords: jest.fn().mockResolvedValue({ success: true }),
+    getSchema: jest.fn().mockResolvedValue({ success: true }),
+    getRelationships: jest.fn().mockResolvedValue({ success: true }),
+    queryAuditLogs: jest.fn().mockResolvedValue({ success: true }),
+    getAuditSummary: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+function makeMockBackupAPI() {
+  return {
+    list: jest.fn().mockResolvedValue({ success: true, backups: [] }),
+    create: jest.fn().mockResolvedValue({ success: true }),
+    restore: jest.fn().mockResolvedValue({ success: true }),
+    delete: jest.fn().mockResolvedValue({ success: true }),
+    selectSaveLocation: jest.fn().mockResolvedValue(null),
+    selectRestoreFile: jest.fn().mockResolvedValue(null),
+    getDirectory: jest.fn().mockResolvedValue(''),
+    openDirectory: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+describe('DatabaseTab batch operations wiring (issue #128)', () => {
+  let container: HTMLElement;
+  let tab: DatabaseTab;
+
+  beforeEach(async () => {
+    (window as any).electronAPI = {
+      databaseAdmin: makeMockAPI(),
+      databaseBackup: makeMockBackupAPI(),
+    };
+
+    document.body.innerHTML = '<div id="database-card"></div>';
+    container = document.getElementById('database-card')!;
+
+    tab = new DatabaseTab();
+    await tab.initialize();
+    await flushPromises();
+  });
+
+  it('renders a "Batch Ops" quick action alongside the existing Backups action', () => {
+    const batchBtn = document.getElementById('db-batch-operations');
+    expect(batchBtn).not.toBeNull();
+    expect(batchBtn!.textContent).toMatch(/batch ops/i);
+
+    // Existing action must still be present -- confirms this is additive.
+    expect(document.getElementById('db-manage-backups')).not.toBeNull();
+  });
+
+  it('switches to the Batch Operations view and mounts BatchPanel when clicked', async () => {
+    const batchBtn = document.getElementById('db-batch-operations') as HTMLButtonElement;
+    batchBtn.click();
+    await flushPromises();
+
+    expect(document.querySelector('.batch-panel')).not.toBeNull();
+    expect(document.querySelectorAll('.batch-tab-button')).toHaveLength(3);
+  });
+
+  it('returns to the overview (table browser) via the back button', async () => {
+    (document.getElementById('db-batch-operations') as HTMLButtonElement).click();
+    await flushPromises();
+
+    const backBtn = document.getElementById('back-to-overview-from-batch-btn') as HTMLButtonElement;
+    expect(backBtn).not.toBeNull();
+    backBtn.click();
+    await flushPromises();
+
+    expect(document.querySelector('.batch-panel')).toBeNull();
+    expect(document.getElementById('database-table-list')).not.toBeNull();
+  });
+
+  it('does not disturb the Backup view wiring (sibling #130 surface stays intact)', async () => {
+    (document.getElementById('db-manage-backups') as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(document.getElementById('backup-manager-container')).not.toBeNull();
+  });
+});

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -19,6 +19,7 @@
     <!-- Legacy Styles (still needed for content) -->
     <link rel="stylesheet" href="styles/database.css">
     <link rel="stylesheet" href="styles/crud.css">
+    <link rel="stylesheet" href="styles/batch.css">
     <style>
         /* Legacy inline styles for compatibility - most styles now in layout.css */
         .welcome-card {

--- a/src/renderer/styles/batch.css
+++ b/src/renderer/styles/batch.css
@@ -1,0 +1,795 @@
+/**
+ * Batch Operations Styles (issue #128)
+ * Bulk Insert / Bulk Update / Bulk Delete panels rendered inside the
+ * Database tab's "Batch Ops" view. Follows the dark-glass conventions
+ * already established in database.css / crud.css (rgba panels, #00D4AA
+ * accent, 6-12px radii) so the batch view doesn't look bolted-on.
+ */
+
+/* Batch view wrapper (parallels .database-backup-view in database.css) */
+.database-batch-view {
+  width: 100%;
+}
+
+/* ===================
+   BatchPanel container
+   =================== */
+.batch-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.batch-panel-header h3 {
+  margin: 0 0 5px 0;
+  font-size: 1.3rem;
+  color: #fff;
+}
+
+.batch-panel-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.batch-panel-tabs {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 0;
+}
+
+.batch-tab-button {
+  padding: 10px 18px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.batch-tab-button:hover {
+  color: #fff;
+}
+
+.batch-tab-button.active {
+  color: #00D4AA;
+  border-bottom-color: #00D4AA;
+}
+
+.batch-panel-content {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.batch-panel-tab-content {
+  display: none;
+}
+
+.batch-panel-tab-content.active {
+  display: block;
+}
+
+.batch-panel-status {
+  min-height: 1.2em;
+  font-size: 0.9rem;
+  padding: 0 4px;
+}
+
+.batch-panel-status.success {
+  color: #4ade80;
+}
+
+.batch-panel-status.error {
+  color: #f87171;
+}
+
+.batch-panel-status.info {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* ===================
+   Shared form controls (Insert / Update / Delete)
+   =================== */
+.form-select {
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: rgba(0, 212, 170, 0.5);
+}
+
+.action-button.danger {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fff;
+}
+
+.action-button.danger:hover:not(:disabled) {
+  background: rgba(248, 113, 113, 0.35);
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.action-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.action-button.small {
+  padding: 6px 12px;
+  font-size: 0.8rem;
+}
+
+/* ===================
+   Batch Insert
+   =================== */
+.batch-insert-header,
+.batch-update-header,
+.batch-delete-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.batch-insert-header h3,
+.batch-update-header h3,
+.batch-delete-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #fff;
+}
+
+.batch-insert-mode-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.mode-button {
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.mode-button:hover {
+  color: #fff;
+}
+
+.mode-button.active {
+  background: rgba(0, 212, 170, 0.2);
+  border-color: rgba(0, 212, 170, 0.4);
+  color: #fff;
+}
+
+.batch-insert-table-selector,
+.batch-update-table-selector,
+.batch-delete-table-selector {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.batch-insert-table-selector label,
+.batch-update-table-selector label,
+.batch-delete-table-selector label {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.batch-insert-mode-panel {
+  display: none;
+}
+
+.batch-insert-mode-panel.active {
+  display: block;
+}
+
+.batch-insert-content {
+  margin-bottom: 15px;
+}
+
+/* Manual entry grid */
+.manual-entry-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.manual-entry-count {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.manual-grid-wrapper {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+}
+
+.manual-entry-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.manual-entry-table th,
+.manual-entry-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.manual-entry-table th {
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: nowrap;
+}
+
+.manual-cell-input {
+  width: 100%;
+  min-width: 90px;
+  padding: 5px 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+.delete-row-button {
+  background: transparent;
+  border: none;
+  color: rgba(248, 113, 113, 0.8);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 2px 8px;
+}
+
+.delete-row-button:hover {
+  color: #f87171;
+}
+
+.empty-grid {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 20px !important;
+}
+
+/* JSON paste mode */
+.json-paste-instructions {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 8px;
+}
+
+.json-paste-instructions code {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.json-paste-area {
+  width: 100%;
+  min-height: 160px;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #fff;
+  font-family: 'Consolas', 'Monaco', monospace;
+  font-size: 0.85rem;
+  resize: vertical;
+  margin-bottom: 10px;
+}
+
+.json-error {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.json-success {
+  color: #4ade80;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+/* Column mapping */
+.batch-column-mapping {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  padding: 12px 15px;
+  margin-bottom: 15px;
+}
+
+.batch-column-mapping h4 {
+  margin: 0 0 6px 0;
+  font-size: 0.95rem;
+  color: #00D4AA;
+}
+
+.column-mapping-hint {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 10px;
+}
+
+.column-mapping-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.source-column {
+  min-width: 120px;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.mapping-arrow {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.target-column-select {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+/* Batch size configuration */
+.batch-size-config {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.batch-size-config label {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.batch-size-input {
+  width: 90px;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.batch-size-hint {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Actions rows */
+.batch-insert-actions,
+.batch-update-actions,
+.batch-delete-actions {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+/* ===================
+   Progress + results (shared by Insert / Update / Delete)
+   =================== */
+.batch-progress {
+  margin-bottom: 15px;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 6px;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #00D4AA, #00b894);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+
+.batch-results-summary {
+  border-radius: 8px;
+  padding: 15px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.batch-results-summary.success {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.3);
+}
+
+.batch-results-summary.partial {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: rgba(248, 113, 113, 0.3);
+}
+
+.batch-results-summary h4 {
+  margin: 0 0 10px 0;
+  color: #fff;
+}
+
+.results-stats {
+  display: flex;
+  gap: 25px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.stat-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.stat-value.success {
+  color: #4ade80;
+}
+
+.stat-value.error {
+  color: #f87171;
+}
+
+.results-errors {
+  margin-top: 10px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.results-errors h5 {
+  margin: 0 0 6px 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.results-errors ul {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.more-errors {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin-top: 6px;
+}
+
+/* ===================
+   Batch Update / Batch Delete: where-conditions + selection preview
+   =================== */
+.batch-update-section,
+.batch-delete-section {
+  margin-bottom: 20px;
+}
+
+.batch-update-section h4,
+.batch-delete-section h4 {
+  margin: 0 0 10px 0;
+  font-size: 0.95rem;
+  color: #00D4AA;
+}
+
+.where-hint,
+.update-hint {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 10px;
+}
+
+.condition-row,
+.update-field-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.condition-column,
+.condition-operator,
+.update-field-column {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+.condition-value,
+.update-field-value {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+  flex: 1;
+  min-width: 100px;
+}
+
+.field-equals {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.delete-condition-button,
+.delete-field-button {
+  background: transparent;
+  border: none;
+  color: rgba(248, 113, 113, 0.8);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 2px 8px;
+}
+
+.delete-condition-button:hover,
+.delete-field-button:hover {
+  color: #f87171;
+}
+
+.selection-preview,
+.changes-preview {
+  margin-top: 10px;
+}
+
+.preview-info {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 8px;
+}
+
+.preview-error {
+  color: #f87171;
+  font-size: 0.85rem;
+}
+
+.preview-more,
+.preview-summary {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin-top: 6px;
+}
+
+.empty-preview {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.85rem;
+  padding: 10px 0;
+}
+
+.preview-table-wrapper,
+.changes-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.preview-table,
+.changes-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.preview-table th,
+.preview-table td,
+.changes-table th,
+.changes-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.preview-table th,
+.changes-table th {
+  background: rgba(0, 0, 0, 0.25);
+  color: rgba(255, 255, 255, 0.7);
+  position: sticky;
+  top: 0;
+}
+
+.change-item {
+  margin-bottom: 12px;
+}
+
+.change-header {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 4px;
+}
+
+.old-value {
+  color: #f87171;
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.new-value {
+  color: #4ade80;
+}
+
+/* Delete-specific warning banner */
+.delete-warning-banner {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ===================
+   CSV Uploader
+   =================== */
+.csv-upload-area {
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: 30px 20px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.csv-upload-area:hover,
+.csv-upload-area.csv-dragover {
+  border-color: rgba(0, 212, 170, 0.5);
+  background: rgba(0, 212, 170, 0.05);
+}
+
+.csv-upload-icon {
+  font-size: 2rem;
+  margin-bottom: 8px;
+}
+
+.csv-upload-text {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  margin-bottom: 6px;
+}
+
+.csv-upload-link {
+  color: #00D4AA;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.csv-upload-hint {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.csv-preview {
+  margin-top: 15px;
+}
+
+.csv-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.csv-preview-header h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #fff;
+}
+
+.csv-file-details {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 8px;
+}
+
+.csv-warning {
+  font-size: 0.8rem;
+  color: #fbbf24;
+  white-space: pre-line;
+  margin-bottom: 8px;
+}
+
+.csv-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.csv-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.csv-preview-table th,
+.csv-preview-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.csv-preview-table th {
+  background: rgba(0, 0, 0, 0.25);
+  color: rgba(255, 255, 255, 0.7);
+  position: sticky;
+  top: 0;
+}
+
+.csv-preview-more {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  padding: 6px 4px;
+}
+
+/* Responsive */
+@media (max-width: 700px) {
+  .condition-row,
+  .update-field-row {
+    flex-wrap: wrap;
+  }
+
+  .results-stats {
+    gap: 15px;
+  }
+}


### PR DESCRIPTION
## Summary

Issue #128 asked for a batch operations panel for bulk insert, update, and delete. PR #200's audit of the #126 foundation found the Batch scaffolding (`BatchInsert.ts`, `BatchUpdate.ts`, `CSVUploader.ts` from commit `3ec4248`) already existed in the tree but was **never imported anywhere** -- unwired. This PR completes and wires that scaffolding into the Database tab rather than rewriting it.

The full IPC surface (`database-admin:*` batchInsert/batchUpdate/batchDelete handlers, preload exposure, `databaseService.batchInsert/batchUpdate/batchDelete`) was already implemented end-to-end from the #126/#200 foundation -- this PR is renderer-UI-only.

## What changed

**Bug fix in the existing scaffolding**
- `BatchInsert.ts` / `BatchUpdate.ts` imported sibling modules without a `.js` extension (e.g. `from './CSVUploader'`). The renderer tsconfig (`module: ES2020`, loaded via `<script type="module">`) requires explicit extensions for relative ESM imports to resolve in the browser -- this bug never surfaced only because the files were never actually imported into the live module graph. Fixed both files; confirmed against the working convention already used by `CRUDPanel.ts`/`BackupManager.ts` (which do use `.js`) and `jest.config.cjs`'s `moduleNameMapper` comment, which documents this as the repo's standard.

**New: `BatchDelete.ts`**
- Filter-based record selection (reuses the same where-condition-row UI pattern as `BatchUpdate.ts`)
- Preview of affected records **and an exact count** before anything is deleted
- Confirmation dialog states the exact record count (`Are you sure you want to delete 12 record(s)...`)
- Any condition change after a preview invalidates it and re-disables Delete, so you can never execute against a stale preview
- Transaction-rollback-safe error accounting: a failed `batchDelete` call reports **zero** partial deletes (the whole matched set is treated as failed, since the server-side call is one transactional statement)

**New: `BatchPanel.ts`**
- Tabbed container (Bulk Insert / Bulk Update / Bulk Delete) that lazily constructs each sub-component the first time its tab is opened, then keeps it mounted so in-progress work isn't lost when switching tabs
- Shared status line surfaces each operation's completion message

**`BatchInsert.ts`: added a Batch Size control**
- The issue's feature list calls out "Batch size configuration"; the component already chunked inserts via a constructor option but had no UI for it. Added a numeric input (1-1000) wired to the existing chunking logic.

**`DatabaseTab.ts` (shared container -- kept additive, per the concurrent #129/#130 work also landing here)**
- New `batchPanel` field + `'batch'` view state, mirroring the existing `'backup'` view exactly
- New "Batch Ops" quick-action button
- `DatabaseView.ts` is untouched

**`batch.css` (new file)**
- The Batch/CSVUploader components had no styling at all (further evidence they were never rendered). One new `<link>` line in `index.html`; every other change lives inside the new file.

## Test plan
- [x] `npm run build` -- clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] 40 new unit tests (mocking `window.electronAPI.databaseAdmin`, no real DB/IPC):
  - `CSVUploader.test.ts` -- parsing (headers, type detection, quoted commas, malformed rows), drag/drop + file-input wiring
  - `BatchInsert.test.ts` -- table/column loading, JSON-paste mode, column mapping, the configurable batch-size input (250 records -> 100/100/50 chunks), progress callbacks, and per-row error handling with transaction-rollback semantics (a failed batch call fails ALL its rows, no partial credit)
  - `BatchUpdate.test.ts` -- where-condition selection, preview-before-execute gating, confirm-then-execute flow
  - `BatchDelete.test.ts` -- filter selection, preview with exact count, confirmation text, preview invalidation on condition change, transaction-rollback error accounting (both a `{success:false}` response and a rejected promise)
  - `BatchPanel.test.ts` -- tab rendering, lazy mounting, status-line propagation
  - `DatabaseTab.batch.test.ts` -- narrowly scoped to the new view-switch wiring (quick action renders, back button returns to overview, Backup view wiring is undisturbed)
- [x] Full `npx jest`: **613 passed / 25 failed / 3 skipped** vs. baseline (before this change) of **573 passed / 25 failed / 3 skipped** -- same pre-existing failures (issue #176: llm/provider-manager, adapter-integration, openai-adapter, build-orchestrator, repository-manager, ProviderSelector.a11y, VariableBrowser.a11y), zero new failures, 40 new passing tests
- [ ] Visual/manual verification -- this session has no GUI. Rebecca, please verify once built:
  - Database tab -> "Batch Ops" quick action opens a tabbed panel (Bulk Insert / Bulk Update / Bulk Delete) with a working Back button
  - **Bulk Insert**: pick a table, try all three modes (CSV drag-and-drop, manual entry grid, JSON paste), confirm column mapping appears when headers don't match table columns 1:1, confirm the Batch Size input is present and the progress bar advances
  - **Bulk Update**: add a filter condition, Preview Selection shows matching rows + count, add an update field, Preview Changes shows before/after, Execute prompts a confirm dialog naming the record count
  - **Bulk Delete**: add a filter condition, Preview Affected Records shows the count, changing the filter after previewing disables Delete again until re-previewed, Execute prompts a confirm dialog naming the exact count
  - Confirm switching tabs mid-flow doesn't lose in-progress work in the other tabs

## Notes for the concurrent #129/#130 agents
- `DatabaseTab.ts` / `index.html` changes here are additive only (new field, new `else if` branch, one new button, one new `<link>`) -- expect to rebase around them, not conflict on logic.
- Found (but did not fix, out of scope) the same missing-`.js`-extension pattern in `SchemaExplorer.ts`/`TableDetails.ts`/`RelationshipDiagram.ts` (also from commit `3ec4248`) -- worth checking when #129 wires those in, since it'll hit the same "works in `tsc`, silently 404s in the browser" failure mode this PR ran into.
- `schema.css` also isn't linked in `index.html` yet -- #129 will need to add that `<link>` too.

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)