### PR TITLE
feat(database): Backup Management UI -- table backups, scheduled-task browsing, real download/validate (#130)

### DIFF
--- a/src/main/__tests__/database-backup.test.ts
+++ b/src/main/__tests__/database-backup.test.ts
@@ -66,6 +66,14 @@ beforeEach(() => {
   });
   mockedFs.ensureDir.mockResolvedValue(undefined as any);
   mockedFs.pathExists.mockResolvedValue(true as any);
+  // Point the "scheduled task" directory at a fake path by default so tests
+  // that don't care about it (most of them) see it as present-but-empty via
+  // the shared readdir mock, instead of touching a real C:\Backups\fictionlab.
+  process.env.FICTIONLAB_SCHEDULED_BACKUP_DIR = 'C:/fake-scheduled-backups';
+});
+
+afterEach(() => {
+  delete process.env.FICTIONLAB_SCHEDULED_BACKUP_DIR;
 });
 
 describe('createBackup', () => {
@@ -128,6 +136,42 @@ describe('createBackup', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('container not found');
+    expect(mockedFs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('scopes the pg_dump command to specific tables via repeated -t flags (table-level backup, issue #130)', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'BINARYDUMP', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 2048 } as any);
+
+    const result = await databaseBackup.createBackup(undefined, true, ['characters', 'scenes']);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('characters');
+    expect(result.message).toContain('scenes');
+
+    const [command] = mockExecAsync.mock.calls[0];
+    expect(command).toContain('-t "characters"');
+    expect(command).toContain('-t "scenes"');
+  });
+
+  it('runs a full backup (no -t flags) when tables is an empty array', async () => {
+    mockExecAsync.mockResolvedValue({ stdout: 'BINARYDUMP', stderr: '' });
+    mockedFs.writeFile.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 2048 } as any);
+
+    await databaseBackup.createBackup(undefined, true, []);
+
+    const [command] = mockExecAsync.mock.calls[0];
+    expect(command).not.toContain('-t ');
+  });
+
+  it('rejects an unsafe table name without ever invoking pg_dump (injection guard)', async () => {
+    const result = await databaseBackup.createBackup(undefined, true, ['characters; DROP TABLE users; --']);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid table name');
+    expect(mockExecAsync).not.toHaveBeenCalled();
     expect(mockedFs.writeFile).not.toHaveBeenCalled();
   });
 });
@@ -211,7 +255,9 @@ describe('listBackups', () => {
     expect(result.backups).toHaveLength(2);
     expect(result.backups[0].filename).toBe('mcp_writing_db_2026-02-01.sql.gz');
     expect(result.backups[0].compressed).toBe(true);
+    expect(result.backups[0].source).toBe('app');
     expect(result.backups[1].compressed).toBe(false);
+    expect(result.backups[1].source).toBe('app');
   });
 
   it('returns an empty, successful result when the directory has no backups', async () => {
@@ -230,6 +276,95 @@ describe('listBackups', () => {
     expect(result.success).toBe(false);
     expect(result.backups).toEqual([]);
     expect(result.error).toContain('EACCES');
+  });
+});
+
+describe('listBackups -- scheduled-task merge (issue #130)', () => {
+  const APP_DIR_MARKER = 'fake-userdata';
+  const SCHEDULED_DIR = 'C:/fake-scheduled-backups';
+
+  it('merges backups from the app dir and the scheduled-task dir, tagging each source', async () => {
+    mockedFs.readdir.mockImplementation(async (dir: any) => {
+      const dirStr = String(dir);
+      if (dirStr.includes(APP_DIR_MARKER)) {
+        return ['mcp_writing_db_2026-01-01.sql'] as any;
+      }
+      if (dirStr === SCHEDULED_DIR) {
+        return [
+          'fictionlab-mcp_writing_db-20260201-030000.dump',
+          'fictionlab-globals-20260201-030000.sql', // must be excluded
+          'backup-log.txt', // must be excluded
+        ] as any;
+      }
+      return [] as any;
+    });
+    mockedFs.stat.mockImplementation(async (p: any) => {
+      const pathStr = String(p);
+      if (pathStr.includes('2026-01-01')) return { mtime: new Date('2026-01-01'), size: 111 } as any;
+      return { mtime: new Date('2026-02-01'), size: 222 } as any;
+    });
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result.success).toBe(true);
+    expect(result.backups).toHaveLength(2);
+
+    const scheduled = result.backups.find(b => b.source === 'scheduled-task');
+    expect(scheduled).toBeDefined();
+    expect(scheduled?.filename).toBe('fictionlab-mcp_writing_db-20260201-030000.dump');
+    expect(scheduled?.database).toBe('mcp_writing_db');
+    expect(scheduled?.compressed).toBe(true);
+
+    const appBackup = result.backups.find(b => b.source === 'app');
+    expect(appBackup).toBeDefined();
+    expect(appBackup?.filename).toBe('mcp_writing_db_2026-01-01.sql');
+
+    // Newest first regardless of source
+    expect(result.backups[0].source).toBe('scheduled-task');
+  });
+
+  it('does not fail listBackups when the scheduled-task directory does not exist', async () => {
+    mockedFs.pathExists.mockImplementation(async (p: any) => {
+      // App dir existence check (ensureBackupDirectory) should still say "true"-equivalent;
+      // fs-extra's ensureDir doesn't call pathExists, so this only affects the scheduled dir check.
+      return String(p) !== SCHEDULED_DIR;
+    });
+    mockedFs.readdir.mockResolvedValue(['mcp_writing_db_2026-01-01.sql'] as any);
+    mockedFs.stat.mockResolvedValue({ mtime: new Date('2026-01-01'), size: 100 } as any);
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result.success).toBe(true);
+    expect(result.backups).toHaveLength(1);
+    expect(result.backups[0].source).toBe('app');
+  });
+
+  it('does not fail listBackups when the scheduled-task directory cannot be read', async () => {
+    mockedFs.readdir.mockImplementation(async (dir: any) => {
+      if (String(dir) === SCHEDULED_DIR) {
+        throw new Error('EACCES: permission denied');
+      }
+      return ['mcp_writing_db_2026-01-01.sql'] as any;
+    });
+    mockedFs.stat.mockResolvedValue({ mtime: new Date('2026-01-01'), size: 100 } as any);
+
+    const result = await databaseBackup.listBackups();
+
+    expect(result.success).toBe(true);
+    expect(result.backups).toHaveLength(1);
+    expect(result.backups[0].source).toBe('app');
+  });
+});
+
+describe('getScheduledTaskBackupDirectory', () => {
+  it('defaults to C:\\Backups\\fictionlab when no override is set', () => {
+    delete process.env.FICTIONLAB_SCHEDULED_BACKUP_DIR;
+    expect(databaseBackup.getScheduledTaskBackupDirectory()).toBe('C:\\Backups\\fictionlab');
+  });
+
+  it('honors the FICTIONLAB_SCHEDULED_BACKUP_DIR override', () => {
+    process.env.FICTIONLAB_SCHEDULED_BACKUP_DIR = 'D:/custom/path';
+    expect(databaseBackup.getScheduledTaskBackupDirectory()).toBe('D:/custom/path');
   });
 });
 
@@ -290,5 +425,138 @@ describe('save/open dialogs', () => {
 describe('getBackupDirectoryPath', () => {
   it('resolves under the Electron userData directory', () => {
     expect(databaseBackup.getBackupDirectoryPath()).toBe(require('path').join('C:/fake-userdata', 'backups'));
+  });
+});
+
+describe('validateBackupFile (issue #130)', () => {
+  it('reports missing files as invalid without erroring', async () => {
+    mockedFs.pathExists.mockResolvedValue(false as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/missing.dump');
+
+    expect(result.success).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('reports empty files as invalid', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 0 } as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/empty.sql');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('empty');
+  });
+
+  it('accepts a .dump file with a valid PGDMP header', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from('PGDMP' + '\x00'.repeat(20)) as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/good.dump');
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a .dump file with a bad header', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from('NOT A DUMP FILE AT ALL') as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/corrupt.dump');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('custom-format header');
+  });
+
+  it('accepts a .gz file with a valid gzip header', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from([0x1f, 0x8b, 0x08, 0x00]) as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/good.sql.gz');
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a .gz file without a gzip header', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from('plain text, not gzip') as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/corrupt.sql.gz');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('gzip header');
+  });
+
+  it('accepts a plain .sql file with the standard pg_dump header comment', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from('--\n-- PostgreSQL database dump\n--\n\nSET statement_timeout = 0;\n') as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/good.sql');
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a plain .sql file that does not look like a pg_dump backup', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockResolvedValue(Buffer.from('this is just some random text file') as any);
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/notreally.sql');
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns a failure result (not a throw) if reading the file errors', async () => {
+    mockedFs.stat.mockResolvedValue({ size: 100 } as any);
+    mockedFs.readFile.mockRejectedValue(new Error('EIO'));
+
+    const result = await databaseBackup.validateBackupFile('C:/backups/broken.dump');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('EIO');
+  });
+});
+
+describe('downloadBackup (issue #130)', () => {
+  it('copies the backup to the chosen location and returns its new path/size', async () => {
+    mockShowSaveDialog.mockResolvedValue({ canceled: false, filePath: 'D:/exports/mine.sql.gz' });
+    mockedFs.copy.mockResolvedValue(undefined as any);
+    mockedFs.stat.mockResolvedValue({ size: 4096 } as any);
+
+    const result = await databaseBackup.downloadBackup('C:/backups/mcp_writing_db_2026-01-01.sql.gz');
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe('D:/exports/mine.sql.gz');
+    expect(result.size).toBe(4096);
+    expect(mockedFs.copy).toHaveBeenCalledWith('C:/backups/mcp_writing_db_2026-01-01.sql.gz', 'D:/exports/mine.sql.gz');
+  });
+
+  it('returns a canceled (not error) result when the save dialog is dismissed', async () => {
+    mockShowSaveDialog.mockResolvedValue({ canceled: true });
+
+    const result = await databaseBackup.downloadBackup('C:/backups/mine.sql.gz');
+
+    expect(result.success).toBe(false);
+    expect(result.canceled).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(mockedFs.copy).not.toHaveBeenCalled();
+  });
+
+  it('fails without prompting a dialog if the source backup no longer exists', async () => {
+    mockedFs.pathExists.mockResolvedValue(false as any);
+
+    const result = await databaseBackup.downloadBackup('C:/backups/gone.sql.gz');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+    expect(mockShowSaveDialog).not.toHaveBeenCalled();
+  });
+
+  it('returns a failure result (not a throw) if the copy fails', async () => {
+    mockShowSaveDialog.mockResolvedValue({ canceled: false, filePath: 'D:/exports/mine.sql.gz' });
+    mockedFs.copy.mockRejectedValue(new Error('disk full'));
+
+    const result = await databaseBackup.downloadBackup('C:/backups/mine.sql.gz');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('disk full');
   });
 });

--- a/src/main/database-backup.ts
+++ b/src/main/database-backup.ts
@@ -24,6 +24,8 @@ export interface BackupResult {
   path?: string;
   size?: number;
   error?: string;
+  /** True when the user dismissed a file picker instead of a real failure */
+  canceled?: boolean;
 }
 
 /**
@@ -45,6 +47,14 @@ export interface BackupMetadata {
   size: number;
   database: string;
   compressed: boolean;
+  /**
+   * Where this backup came from:
+   *  - 'app': created via this app's Backup Manager (userData/backups)
+   *  - 'scheduled-task': written by the separate "FictionLab DB Daily Backup"
+   *    Windows Scheduled Task (C:\Backups\fictionlab). This app only reads
+   *    from that directory -- it never writes to or manages the task itself.
+   */
+  source: 'app' | 'scheduled-task';
 }
 
 /**
@@ -53,6 +63,16 @@ export interface BackupMetadata {
 export interface ListBackupsResult {
   success: boolean;
   backups: BackupMetadata[];
+  error?: string;
+}
+
+/**
+ * Result of a lightweight backup integrity check
+ */
+export interface ValidateResult {
+  success: boolean;
+  valid: boolean;
+  message: string;
   error?: string;
 }
 
@@ -83,17 +103,39 @@ function generateBackupFilename(database: string, compressed: boolean = true): s
 }
 
 /**
+ * Validate a Postgres table name is a safe, unquoted identifier.
+ * Table names are passed to pg_dump via shell exec, so this rejects anything
+ * that isn't a plain identifier (guards against shell/SQL injection).
+ */
+function isValidTableIdentifier(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
  * Create a database backup
  * @param customPath Optional custom path for the backup file
  * @param compressed Whether to compress the backup (default: true)
+ * @param tables Optional list of table names to scope the backup to (table-level backup).
+ *               Omit or pass an empty array for a full database backup.
  */
 export async function createBackup(
   customPath?: string,
-  compressed: boolean = true
+  compressed: boolean = true,
+  tables?: string[]
 ): Promise<BackupResult> {
   logWithCategory('info', LogCategory.SYSTEM, 'Starting database backup...');
 
   try {
+    // Validate table names up front (before touching the filesystem or Docker)
+    let tableArgs = '';
+    if (tables && tables.length > 0) {
+      const invalidTable = tables.find((t) => !isValidTableIdentifier(t));
+      if (invalidTable) {
+        throw new Error(`Invalid table name: "${invalidTable}"`);
+      }
+      tableArgs = tables.map((t) => ` -t "${t}"`).join('');
+    }
+
     // Ensure backup directory exists
     await ensureBackupDirectory();
 
@@ -120,10 +162,10 @@ export async function createBackup(
     let dumpCommand: string;
     if (compressed) {
       // Custom format with compression (can be restored with pg_restore)
-      dumpCommand = `docker exec ${containerName} pg_dump -U ${user} -Fc -Z 9 -d ${database}`;
+      dumpCommand = `docker exec ${containerName} pg_dump -U ${user} -Fc -Z 9 -d ${database}${tableArgs}`;
     } else {
       // Plain SQL format
-      dumpCommand = `docker exec ${containerName} pg_dump -U ${user} -d ${database}`;
+      dumpCommand = `docker exec ${containerName} pg_dump -U ${user} -d ${database}${tableArgs}`;
     }
 
     logWithCategory('info', LogCategory.SYSTEM, `Executing: ${dumpCommand.replace(password, '****')}`);
@@ -152,9 +194,13 @@ export async function createBackup(
 
     logWithCategory('info', LogCategory.SYSTEM, `Backup completed successfully: ${backupPath} (${sizeInMB} MB)`);
 
+    const tableSuffix = tables && tables.length > 0
+      ? ` [${tables.length} table${tables.length !== 1 ? 's' : ''}: ${tables.join(', ')}]`
+      : '';
+
     return {
       success: true,
-      message: `Backup created successfully: ${filename} (${sizeInMB} MB)`,
+      message: `Backup created successfully: ${filename} (${sizeInMB} MB)${tableSuffix}`,
       path: backupPath,
       size: stats.size,
     };
@@ -287,7 +333,81 @@ export async function restoreBackup(
 }
 
 /**
- * List all available backups in the backup directory
+ * Directory used by the separate "FictionLab DB Daily Backup" Windows Scheduled Task
+ * (pg_dump of the fictionlab-postgres container / mcp_writing_db database, superuser
+ * `writer`, trust-auth local -- see shared/scripts/backup-fictionlab-db.ps1).
+ *
+ * This app NEVER writes here and never manages the scheduled task itself -- it only
+ * reads this directory so those backups can be browsed and restored from the same
+ * list as backups the app creates. Configurable via FICTIONLAB_SCHEDULED_BACKUP_DIR
+ * for non-default installs and tests.
+ */
+export function getScheduledTaskBackupDirectory(): string {
+  return process.env.FICTIONLAB_SCHEDULED_BACKUP_DIR || 'C:\\Backups\\fictionlab';
+}
+
+/**
+ * Parse a scheduled-task backup filename, e.g. `fictionlab-mcp_writing_db-20260101-030000.dump`.
+ * Returns null for anything that isn't a per-database dump -- in particular the task's
+ * `fictionlab-globals-*.sql` (roles-only, not a database backup) and `backup-log.txt`
+ * are intentionally excluded so they never show up as restorable "backups".
+ */
+function parseScheduledTaskFilename(filename: string): { database: string } | null {
+  if (!filename.endsWith('.dump')) return null;
+  const match = filename.match(/^fictionlab-(.+)-\d{8}-\d{6}\.dump$/);
+  return match ? { database: match[1] } : null;
+}
+
+/**
+ * List backups written by the "FictionLab DB Daily Backup" scheduled task.
+ * Read-only, best-effort: a missing directory (e.g. on a machine where the task
+ * hasn't run yet) or an unreadable directory yields an empty list rather than
+ * failing the whole listBackups() call.
+ */
+async function listScheduledTaskBackups(): Promise<BackupMetadata[]> {
+  const dir = getScheduledTaskBackupDirectory();
+  const backups: BackupMetadata[] = [];
+
+  if (!(await fs.pathExists(dir))) {
+    return backups;
+  }
+
+  try {
+    const files = await fs.readdir(dir);
+
+    for (const filename of files) {
+      const parsed = parseScheduledTaskFilename(filename);
+      if (!parsed) continue;
+
+      try {
+        const filePath = path.join(dir, filename);
+        const stats = await fs.stat(filePath);
+
+        backups.push({
+          filename,
+          path: filePath,
+          createdAt: stats.mtime.toISOString(),
+          size: stats.size,
+          database: parsed.database,
+          compressed: true, // scheduled task always dumps in custom format (-Fc)
+          source: 'scheduled-task',
+        });
+      } catch (error) {
+        logWithCategory('warn', LogCategory.SYSTEM, `Failed to get metadata for scheduled-task backup: ${filename}`);
+      }
+    }
+  } catch (error: any) {
+    logWithCategory('warn', LogCategory.SYSTEM, `Failed to read scheduled-task backup directory: ${error.message || error}`);
+  }
+
+  return backups;
+}
+
+/**
+ * List all available backups: the app's own (userData/backups) plus the ones
+ * written by the separate "FictionLab DB Daily Backup" Windows Scheduled Task
+ * (C:\Backups\fictionlab), merged into a single newest-first list. Each entry's
+ * `source` field distinguishes the two so the UI can label them accordingly.
  */
 export async function listBackups(): Promise<ListBackupsResult> {
   logWithCategory('info', LogCategory.SYSTEM, 'Listing available backups...');
@@ -320,16 +440,25 @@ export async function listBackups(): Promise<ListBackupsResult> {
           size: stats.size,
           database,
           compressed: filename.endsWith('.gz'),
+          source: 'app',
         });
       } catch (error) {
         logWithCategory('warn', LogCategory.SYSTEM, `Failed to get metadata for backup: ${filename}`);
       }
     }
 
+    // Merge in the scheduled task's backups so both sources show up in one list
+    const scheduledBackups = await listScheduledTaskBackups();
+    backups.push(...scheduledBackups);
+
     // Sort by creation date (newest first)
     backups.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-    logWithCategory('info', LogCategory.SYSTEM, `Found ${backups.length} backup(s)`);
+    logWithCategory(
+      'info',
+      LogCategory.SYSTEM,
+      `Found ${backups.length} backup(s) (${backups.length - scheduledBackups.length} app, ${scheduledBackups.length} scheduled-task)`
+    );
 
     return {
       success: true,
@@ -454,4 +583,111 @@ export async function openBackupDirectory(): Promise<void> {
   const backupDir = getBackupDirectory();
   await shell.openPath(backupDir);
   logWithCategory('info', LogCategory.SYSTEM, `Opened backup directory: ${backupDir}`);
+}
+
+/**
+ * Lightweight integrity check for a backup file, based on its format signature.
+ * Deliberately does NOT shell out to Docker/pg_restore -- it's meant to be a fast,
+ * safe check the UI can run without touching the live database or container:
+ *  - .dump  (pg_dump custom format): must start with the "PGDMP" magic bytes
+ *  - .gz    (gzip-compressed plain SQL): must start with the gzip magic bytes (0x1f 0x8b)
+ *  - .sql   (plain SQL): looks for the standard pg_dump header comment
+ */
+export async function validateBackupFile(backupPath: string): Promise<ValidateResult> {
+  logWithCategory('info', LogCategory.SYSTEM, `Validating backup: ${backupPath}`);
+
+  try {
+    if (!await fs.pathExists(backupPath)) {
+      return { success: true, valid: false, message: 'Backup file not found' };
+    }
+
+    const stats = await fs.stat(backupPath);
+    if (stats.size === 0) {
+      return { success: true, valid: false, message: 'Backup file is empty' };
+    }
+
+    const buffer = await fs.readFile(backupPath);
+    const lower = backupPath.toLowerCase();
+
+    if (lower.endsWith('.dump')) {
+      const isValid = buffer.subarray(0, 5).toString('ascii') === 'PGDMP';
+      return {
+        success: true,
+        valid: isValid,
+        message: isValid
+          ? 'Valid pg_dump custom-format backup (PGDMP header present)'
+          : 'File does not have a valid pg_dump custom-format header',
+      };
+    }
+
+    if (lower.endsWith('.gz')) {
+      const isValid = buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
+      return {
+        success: true,
+        valid: isValid,
+        message: isValid
+          ? 'Valid gzip-compressed backup (gzip header present)'
+          : 'File does not have a valid gzip header',
+      };
+    }
+
+    // Plain .sql -- look for the standard pg_dump header comment near the top of the file
+    const head = buffer.subarray(0, 4096).toString('utf-8');
+    const isValid = /postgresql database dump/i.test(head) || head.trimStart().startsWith('--');
+    return {
+      success: true,
+      valid: isValid,
+      message: isValid
+        ? 'Valid plain SQL backup (pg_dump header present)'
+        : 'File does not look like a pg_dump plain SQL backup',
+    };
+  } catch (error: any) {
+    const errorMessage = error.message || String(error);
+    logWithCategory('error', LogCategory.SYSTEM, 'Failed to validate backup', { error: errorMessage });
+    return { success: false, valid: false, message: 'Failed to validate backup', error: errorMessage };
+  }
+}
+
+/**
+ * Copy a backup file to a user-chosen location (native save dialog).
+ * Used by the "Download" action so backups can be exported off the machine.
+ */
+export async function downloadBackup(sourcePath: string): Promise<BackupResult> {
+  logWithCategory('info', LogCategory.SYSTEM, `Downloading backup: ${sourcePath}`);
+
+  try {
+    if (!await fs.pathExists(sourcePath)) {
+      throw new Error(`Backup file not found: ${sourcePath}`);
+    }
+
+    const defaultFilename = path.basename(sourcePath);
+    const result = await dialog.showSaveDialog({
+      title: 'Download Database Backup',
+      defaultPath: path.join(app.getPath('downloads'), defaultFilename),
+      filters: [
+        { name: 'Backup Files', extensions: ['gz', 'sql', 'dump'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, message: 'Download canceled', canceled: true };
+    }
+
+    await fs.copy(sourcePath, result.filePath);
+    const stats = await fs.stat(result.filePath);
+
+    logWithCategory('info', LogCategory.SYSTEM, `Backup downloaded to: ${result.filePath}`);
+
+    return {
+      success: true,
+      message: `Backup downloaded to ${result.filePath}`,
+      path: result.filePath,
+      size: stats.size,
+    };
+  } catch (error: any) {
+    const errorMessage = error.message || String(error);
+    logWithCategory('error', LogCategory.SYSTEM, 'Failed to download backup', { error: errorMessage });
+    return { success: false, message: 'Failed to download backup', error: errorMessage };
+  }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1164,9 +1164,19 @@ function setupIPC(): void {
   });
 
   // Database Backup/Restore IPC handlers
-  registerHandler('database-backup:create', "", async (_, customPath?: string, compressed?: boolean) => {
+  registerHandler('database-backup:create', "", async (_, customPath?: string, compressed?: boolean, tables?: string[]) => {
     logWithCategory('info', LogCategory.SYSTEM, 'IPC: Creating database backup...');
-    return await databaseBackup.createBackup(customPath, compressed);
+    return await databaseBackup.createBackup(customPath, compressed, tables);
+  });
+
+  registerHandler('database-backup:validate', "", async (_, backupPath: string) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: Validating backup ${backupPath}...`);
+    return await databaseBackup.validateBackupFile(backupPath);
+  });
+
+  registerHandler('database-backup:download', "", async (_, sourcePath: string) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: Downloading backup ${sourcePath}...`);
+    return await databaseBackup.downloadBackup(sourcePath);
   });
 
   registerHandler('database-backup:restore', "", async (_, backupPath: string, dropExisting?: boolean) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -378,6 +378,8 @@ interface BackupResult {
   path?: string;
   size?: number;
   error?: string;
+  /** True when the user dismissed a file picker instead of a real failure */
+  canceled?: boolean;
 }
 
 /**
@@ -399,6 +401,8 @@ interface BackupMetadata {
   size: number;
   database: string;
   compressed: boolean;
+  /** 'app' = created via this app; 'scheduled-task' = the Windows "FictionLab DB Daily Backup" task */
+  source: 'app' | 'scheduled-task';
 }
 
 /**
@@ -407,6 +411,16 @@ interface BackupMetadata {
 interface ListBackupsResult {
   success: boolean;
   backups: BackupMetadata[];
+  error?: string;
+}
+
+/**
+ * Backup integrity validation result
+ */
+interface ValidateBackupResult {
+  success: boolean;
+  valid: boolean;
+  message: string;
   error?: string;
 }
 
@@ -1657,10 +1671,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
    */
   databaseBackup: {
     /**
-     * Create a database backup
+     * Create a database backup. Pass `tables` to scope the backup to specific
+     * tables instead of the full database.
      */
-    create: (customPath?: string, compressed?: boolean): Promise<BackupResult> => {
-      return ipcRenderer.invoke('database-backup:create', customPath, compressed);
+    create: (customPath?: string, compressed?: boolean, tables?: string[]): Promise<BackupResult> => {
+      return ipcRenderer.invoke('database-backup:create', customPath, compressed, tables);
     },
 
     /**
@@ -1710,6 +1725,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
      */
     openDirectory: (): Promise<void> => {
       return ipcRenderer.invoke('database-backup:open-directory');
+    },
+
+    /**
+     * Lightweight integrity check for a backup file (format signature check;
+     * does not touch Docker or the live database).
+     */
+    validate: (backupPath: string): Promise<ValidateBackupResult> => {
+      return ipcRenderer.invoke('database-backup:validate', backupPath);
+    },
+
+    /**
+     * Copy a backup file to a user-chosen location (native save dialog).
+     */
+    download: (sourcePath: string): Promise<BackupResult> => {
+      return ipcRenderer.invoke('database-backup:download', sourcePath);
     },
   },
 

--- a/src/renderer/components/DatabaseAdmin/Backup/BackupList.ts
+++ b/src/renderer/components/DatabaseAdmin/Backup/BackupList.ts
@@ -16,6 +16,8 @@ export interface BackupMetadata {
   size: number;
   database: string;
   compressed: boolean;
+  /** 'app' = created via this app's Backup Manager; 'scheduled-task' = the Windows "FictionLab DB Daily Backup" task */
+  source: 'app' | 'scheduled-task';
 }
 
 export interface BackupListCallbacks {
@@ -70,7 +72,8 @@ export class BackupList {
       this.filteredBackups = this.backups.filter(backup =>
         backup.filename.toLowerCase().includes(this.searchQuery) ||
         backup.database.toLowerCase().includes(this.searchQuery) ||
-        this.formatDate(backup.createdAt).toLowerCase().includes(this.searchQuery)
+        this.formatDate(backup.createdAt).toLowerCase().includes(this.searchQuery) ||
+        this.sourceLabel(backup.source).toLowerCase().includes(this.searchQuery)
       );
     }
     this.updateDisplay();
@@ -144,6 +147,11 @@ export class BackupList {
     const timeFormatted = this.formatTime(backup.createdAt);
     const typeLabel = backup.compressed ? 'Compressed' : 'Plain SQL';
     const typeClass = backup.compressed ? 'badge-compressed' : 'badge-plain';
+    const sourceLabel = this.sourceLabel(backup.source);
+    const sourceClass = backup.source === 'scheduled-task' ? 'badge-source-scheduled' : 'badge-source-app';
+    const sourceTitle = backup.source === 'scheduled-task'
+      ? 'Written by the Windows "FictionLab DB Daily Backup" scheduled task (C:\\Backups\\fictionlab)'
+      : 'Created from this app\'s Backup Manager';
 
     return `
       <div class="backup-card" data-backup-path="${this.escapeHtml(backup.path)}">
@@ -152,6 +160,9 @@ export class BackupList {
           <div class="backup-title">
             <h4>${this.escapeHtml(backup.filename)}</h4>
             <span class="backup-database">${this.escapeHtml(backup.database)}</span>
+          </div>
+          <div class="backup-badge backup-badge-source ${sourceClass}" title="${this.escapeHtml(sourceTitle)}">
+            ${sourceLabel}
           </div>
         </div>
 
@@ -246,6 +257,13 @@ export class BackupList {
         this.callbacks.onDelete(backup);
         break;
     }
+  }
+
+  /**
+   * Human-readable label for a backup's source
+   */
+  private sourceLabel(source: BackupMetadata['source']): string {
+    return source === 'scheduled-task' ? 'Scheduled Task' : 'App';
   }
 
   /**

--- a/src/renderer/components/DatabaseAdmin/Backup/BackupManager.ts
+++ b/src/renderer/components/DatabaseAdmin/Backup/BackupManager.ts
@@ -204,14 +204,16 @@ export class BackupManager {
    * Handle backup creation
    */
   private async handleCreateBackup(options: BackupOptions): Promise<void> {
-    this.showInfo('Creating backup...');
+    const stopTimer = this.showProgress(
+      options.type === 'tables' ? `Creating backup of ${options.tables?.length || 0} table(s)...` : 'Creating full backup...'
+    );
 
     try {
-      // Note: Current backend only supports full database backups
-      // Table-level backup would require backend enhancement
+      const tables = options.type === 'tables' ? options.tables : undefined;
       const result = await window.electronAPI.databaseBackup.create(
         options.customPath,
-        options.compressed
+        options.compressed,
+        tables
       );
 
       if (result.success) {
@@ -222,6 +224,8 @@ export class BackupManager {
       }
     } catch (error: any) {
       this.showError('Error creating backup: ' + error.message);
+    } finally {
+      stopTimer();
     }
   }
 
@@ -248,7 +252,8 @@ export class BackupManager {
           createdAt: new Date().toISOString(),
           size: 0,
           database: 'unknown',
-          compressed: filePath.endsWith('.gz'),
+          compressed: filePath.endsWith('.gz') || filePath.endsWith('.dump'),
+          source: 'app',
         };
         this.restoreStep = 1;
         this.showRestoreWizardDialog();
@@ -321,22 +326,22 @@ export class BackupManager {
         </div>
 
         <div class="restore-wizard-section">
-          <h3>Conflict Resolution</h3>
-          <p class="section-description">Choose how to handle existing data</p>
+          <h3>Restore Mode</h3>
+          <p class="section-description">Both options are destructive to any tables included in this backup -- there is no non-destructive "merge".</p>
 
           <label class="restore-option">
             <input type="radio" name="restore-mode" value="merge" checked />
             <div class="option-content">
-              <strong>Merge with existing data</strong>
-              <p>Add backup data to existing database (safer option)</p>
+              <strong>Restore In-Place</strong>
+              <p class="warning">⚠️ Tables present in this backup are dropped and replaced with the backup's contents. Databases/tables NOT in this backup are left untouched.</p>
             </div>
           </label>
 
           <label class="restore-option">
             <input type="radio" name="restore-mode" value="replace" />
             <div class="option-content">
-              <strong>Replace existing database</strong>
-              <p class="warning">⚠️ This will DELETE all current data and replace it with backup</p>
+              <strong>Full Replace</strong>
+              <p class="warning">⚠️ Drops and recreates the ENTIRE database first, then restores from backup. ALL current data is permanently lost, including anything not in this backup.</p>
             </div>
           </label>
         </div>
@@ -345,11 +350,18 @@ export class BackupManager {
           <div class="restore-warning-box">
             <div class="warning-icon">⚠️</div>
             <div class="warning-content">
-              <strong>Important:</strong>
+              <strong>This is a destructive operation.</strong>
               <p>Make sure the MCP system is stopped or no active connections are using the database before restoring.</p>
-              <p>It's recommended to create a backup of the current database before proceeding.</p>
+              <p>It's strongly recommended to create a fresh backup of the current database before proceeding.</p>
             </div>
           </div>
+        </div>
+
+        <div class="restore-wizard-section">
+          <label class="restore-confirm-checkbox">
+            <input type="checkbox" id="restore-confirm-checkbox" />
+            <span>I understand this will overwrite existing data and cannot be undone.</span>
+          </label>
         </div>
       </div>
     `;
@@ -362,7 +374,7 @@ export class BackupManager {
     return `
       <div class="wizard-footer">
         <button class="btn-secondary" id="restore-wizard-cancel-btn">Cancel</button>
-        <button class="btn-primary" id="restore-wizard-confirm-btn">
+        <button class="btn-danger" id="restore-wizard-confirm-btn" disabled>
           <span class="btn-icon">↻</span>
           Restore Database
         </button>
@@ -380,8 +392,17 @@ export class BackupManager {
     const cancelBtn = document.getElementById('restore-wizard-cancel-btn');
     cancelBtn?.addEventListener('click', () => this.hideRestoreWizard());
 
-    const confirmBtn = document.getElementById('restore-wizard-confirm-btn');
+    const confirmBtn = document.getElementById('restore-wizard-confirm-btn') as HTMLButtonElement | null;
     confirmBtn?.addEventListener('click', () => this.handleRestoreConfirm());
+
+    // The destructive restore action stays disabled until the user explicitly
+    // acknowledges the "cannot be undone" checkbox.
+    const confirmCheckbox = document.getElementById('restore-confirm-checkbox') as HTMLInputElement | null;
+    confirmCheckbox?.addEventListener('change', () => {
+      if (confirmBtn) {
+        confirmBtn.disabled = !confirmCheckbox.checked;
+      }
+    });
   }
 
   /**
@@ -401,6 +422,13 @@ export class BackupManager {
   private async handleRestoreConfirm(): Promise<void> {
     if (!this.selectedRestoreBackup) return;
 
+    // Defense in depth: the button is already disabled until this is checked,
+    // but never proceed with a destructive restore without it.
+    const confirmCheckbox = document.getElementById('restore-confirm-checkbox') as HTMLInputElement | null;
+    if (!confirmCheckbox?.checked) {
+      return;
+    }
+
     const modeRadios = document.querySelectorAll('input[name="restore-mode"]');
     let dropExisting = false;
     modeRadios.forEach(radio => {
@@ -409,15 +437,18 @@ export class BackupManager {
       }
     });
 
-    // Confirm if replacing
-    if (dropExisting) {
-      if (!confirm('Are you sure you want to REPLACE the entire database? This will DELETE all current data!')) {
-        return;
-      }
+    // Restore is ALWAYS destructive to overlapping data -- always require an
+    // explicit native confirmation on top of the checkbox, worded for the chosen mode.
+    const confirmMessage = dropExisting
+      ? 'This will DROP AND RECREATE the entire database, permanently deleting ALL current data, then restore from the selected backup. This cannot be undone. Continue?'
+      : 'This will restore in-place: tables in the selected backup are dropped and replaced with the backup\'s contents. This cannot be undone. Continue?';
+
+    if (!confirm(confirmMessage)) {
+      return;
     }
 
     this.hideRestoreWizard();
-    this.showInfo('Restoring database...');
+    const stopTimer = this.showProgress('Restoring database...');
 
     try {
       const result = await window.electronAPI.databaseBackup.restore(
@@ -432,44 +463,59 @@ export class BackupManager {
       }
     } catch (error: any) {
       this.showError('Error restoring database: ' + error.message);
+    } finally {
+      stopTimer();
     }
   }
 
   /**
-   * Handle backup download
+   * Handle backup download -- copies the backup file to a user-chosen location
+   * via a native save dialog (see database-backup:download IPC handler).
    */
   private async handleDownload(backup: BackupMetadata): Promise<void> {
+    const stopTimer = this.showProgress(`Downloading ${backup.filename}...`);
+
     try {
-      const savePath = await window.electronAPI.databaseBackup.selectSaveLocation();
-      if (!savePath) return;
+      const result = await window.electronAPI.databaseBackup.download(backup.path);
 
-      this.showInfo('Copying backup to selected location...');
+      if (result.canceled) {
+        // User dismissed the save dialog -- not an error, nothing to report.
+        return;
+      }
 
-      // Copy the backup file to the selected location
-      // Note: Would need to add a copy IPC handler or use native file system
-      // For now, show the path to the user
-      this.showInfo(`Backup location: ${backup.path}`);
+      if (result.success) {
+        this.showSuccess(result.message || `Backup downloaded to ${result.path}`);
+      } else {
+        this.showError('Download failed: ' + (result.error || 'Unknown error'));
+      }
     } catch (error: any) {
       this.showError('Error downloading backup: ' + error.message);
+    } finally {
+      stopTimer();
     }
   }
 
   /**
-   * Handle backup validation
+   * Handle backup validation -- runs the backend's format-signature integrity
+   * check (PGDMP/gzip/pg_dump-header) rather than just checking file size client-side.
    */
   private async handleValidate(backup: BackupMetadata): Promise<void> {
-    this.showInfo('Validating backup integrity...');
+    const stopTimer = this.showProgress(`Validating ${backup.filename}...`);
 
     try {
-      // Basic validation: check if file exists and has content
-      // More advanced validation would require backend support
-      if (backup.size === 0) {
-        this.showError('Backup file appears to be empty');
+      const result = await window.electronAPI.databaseBackup.validate(backup.path);
+
+      if (!result.success) {
+        this.showError('Validation error: ' + (result.error || 'Unknown error'));
+      } else if (result.valid) {
+        this.showSuccess(result.message || 'Backup file validation passed');
       } else {
-        this.showSuccess('Backup file validation passed');
+        this.showError(result.message || 'Backup file failed validation');
       }
     } catch (error: any) {
       this.showError('Error validating backup: ' + error.message);
+    } finally {
+      stopTimer();
     }
   }
 
@@ -527,6 +573,43 @@ export class BackupManager {
    */
   private showInfo(message: string): void {
     this.showToast('info', message);
+  }
+
+  /**
+   * Show a persistent progress banner with a live elapsed-time counter for a
+   * long-running operation (backup create/restore/download/validate). pg_dump
+   * and pg_restore don't expose byte-level progress over the exec channel this
+   * app uses, so this is an honest indeterminate indicator (spinner + elapsed
+   * seconds) rather than a fake percentage bar.
+   *
+   * Returns a function that stops the timer and removes the banner; always
+   * call it in a `finally` block.
+   */
+  private showProgress(message: string): () => void {
+    const banner = document.createElement('div');
+    banner.className = 'backup-progress-banner';
+    banner.innerHTML = `
+      <span class="progress-banner-spinner"></span>
+      <span class="progress-banner-message">${this.escapeHtml(message)}</span>
+      <span class="progress-banner-elapsed">0s</span>
+    `;
+    document.body.appendChild(banner);
+
+    const startedAt = Date.now();
+    const elapsedEl = banner.querySelector('.progress-banner-elapsed');
+    const intervalId = window.setInterval(() => {
+      if (elapsedEl) {
+        elapsedEl.textContent = `${Math.round((Date.now() - startedAt) / 1000)}s`;
+      }
+    }, 1000);
+
+    let stopped = false;
+    return () => {
+      if (stopped) return;
+      stopped = true;
+      window.clearInterval(intervalId);
+      banner.remove();
+    };
   }
 
   /**

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -255,6 +255,7 @@ interface BackupResult {
   path?: string;
   size?: number;
   error?: string;
+  canceled?: boolean;
 }
 
 interface RestoreResult {
@@ -270,11 +271,19 @@ interface BackupMetadata {
   size: number;
   database: string;
   compressed: boolean;
+  source: 'app' | 'scheduled-task';
 }
 
 interface ListBackupsResult {
   success: boolean;
   backups: BackupMetadata[];
+  error?: string;
+}
+
+interface ValidateBackupResult {
+  success: boolean;
+  valid: boolean;
+  message: string;
   error?: string;
 }
 
@@ -372,7 +381,7 @@ interface ElectronAPI {
     removeProgressListener: () => void;
   };
   databaseBackup: {
-    create: (customPath?: string, compressed?: boolean) => Promise<BackupResult>;
+    create: (customPath?: string, compressed?: boolean, tables?: string[]) => Promise<BackupResult>;
     restore: (backupPath: string, dropExisting?: boolean) => Promise<RestoreResult>;
     list: () => Promise<ListBackupsResult>;
     delete: (backupPath: string) => Promise<BackupResult>;
@@ -380,6 +389,8 @@ interface ElectronAPI {
     selectRestoreFile: () => Promise<string | null>;
     getDirectory: () => Promise<string>;
     openDirectory: () => Promise<void>;
+    validate: (backupPath: string) => Promise<ValidateBackupResult>;
+    download: (sourcePath: string) => Promise<BackupResult>;
   };
   databaseAdmin: {
     checkConnection: () => Promise<any>;

--- a/src/renderer/styles/database.css
+++ b/src/renderer/styles/database.css
@@ -311,12 +311,867 @@
   .quick-actions-bar {
     flex-wrap: wrap;
   }
-  
+
   .spacer {
     display: none;
   }
-  
+
   .quick-action-btn-small {
     flex: 1 0 40%;
+  }
+}
+
+/* ============================================================
+   Backup Management UI (issue #130)
+   Styles for BackupManager / BackupList / BackupWizard, and the
+   shared button/toast primitives those components rely on.
+   ============================================================ */
+
+/* Shared button primitives */
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 18px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.btn-primary {
+  background: rgba(0, 212, 170, 0.25);
+  border-color: rgba(0, 212, 170, 0.5);
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: rgba(0, 212, 170, 0.4);
+  border-color: rgba(0, 212, 170, 0.7);
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.btn-danger {
+  background: rgba(220, 53, 69, 0.25);
+  border-color: rgba(220, 53, 69, 0.55);
+  color: #fff;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: rgba(220, 53, 69, 0.4);
+  border-color: rgba(220, 53, 69, 0.75);
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled,
+.btn-danger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.btn-small {
+  padding: 5px 10px;
+  font-size: 0.8rem;
+}
+
+/* Backup Manager */
+.backup-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.backup-manager-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.header-title h2 {
+  margin: 0 0 4px 0;
+  font-size: 1.4rem;
+  color: #fff;
+}
+
+.header-title p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.backup-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.loading-spinner,
+.progress-spinner,
+.progress-banner-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #00D4AA;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 12px;
+}
+
+.backup-main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+/* Backup List */
+.backup-list-container {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.backup-search-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 220px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: rgba(0, 212, 170, 0.5);
+}
+
+.backup-count {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.backup-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 50px 20px;
+  color: rgba(255, 255, 255, 0.5);
+  text-align: center;
+}
+
+.backup-empty-state .empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 15px;
+  opacity: 0.6;
+}
+
+.backup-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 15px;
+}
+
+.backup-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: border-color 0.2s ease;
+}
+
+.backup-card:hover {
+  border-color: rgba(0, 212, 170, 0.3);
+}
+
+.backup-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.backup-icon {
+  font-size: 1.5rem;
+}
+
+.backup-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.backup-title h4 {
+  margin: 0 0 3px 0;
+  font-size: 0.95rem;
+  color: #fff;
+  overflow-wrap: break-word;
+}
+
+.backup-database {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.backup-card-metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.backup-badge {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 5px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.badge-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.badge-value {
+  color: #fff;
+  font-weight: 500;
+}
+
+.backup-badge-type.badge-compressed {
+  background: rgba(0, 212, 170, 0.15);
+}
+
+.backup-badge-type.badge-plain {
+  background: rgba(255, 193, 7, 0.15);
+}
+
+.backup-badge-source {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.backup-badge-source.badge-source-app {
+  background: rgba(0, 212, 170, 0.2);
+  color: #00D4AA;
+}
+
+.backup-badge-source.badge-source-scheduled {
+  background: rgba(139, 92, 246, 0.2);
+  color: #b794f6;
+}
+
+.backup-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.backup-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.backup-action-btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
+.backup-action-btn.btn-restore:hover {
+  background: rgba(0, 212, 170, 0.2);
+  border-color: rgba(0, 212, 170, 0.4);
+}
+
+.backup-action-btn.btn-delete:hover {
+  background: rgba(220, 53, 69, 0.2);
+  border-color: rgba(220, 53, 69, 0.4);
+}
+
+/* Backup Wizard / Restore Wizard (modal) */
+.backup-wizard-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.backup-wizard-modal {
+  background: #1a1f2e;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  width: 100%;
+  max-width: 560px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.wizard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.wizard-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #fff;
+}
+
+.wizard-close-btn {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.wizard-close-btn:hover {
+  color: #fff;
+}
+
+.wizard-steps {
+  display: flex;
+  padding: 15px 22px;
+  gap: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wizard-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0.5;
+}
+
+.wizard-step.active,
+.wizard-step.completed {
+  opacity: 1;
+}
+
+.step-number {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: #fff;
+}
+
+.wizard-step.active .step-number {
+  background: #00D4AA;
+  color: #0a0e17;
+  font-weight: 700;
+}
+
+.wizard-step.completed .step-number {
+  background: rgba(0, 212, 170, 0.4);
+}
+
+.step-label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.wizard-content {
+  padding: 20px 22px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.wizard-content h3 {
+  margin: 0 0 6px 0;
+  color: #fff;
+  font-size: 1.05rem;
+}
+
+.wizard-content > p,
+.section-description {
+  margin: 0 0 15px 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+}
+
+.wizard-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 22px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.wizard-nav-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+/* Backup type / table selection (BackupWizard) */
+.backup-type-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.backup-type-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.backup-type-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.backup-type-option.selected {
+  border-color: rgba(0, 212, 170, 0.5);
+  background: rgba(0, 212, 170, 0.08);
+}
+
+.backup-type-option.option-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.option-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex: 1;
+}
+
+.option-icon {
+  font-size: 1.3rem;
+}
+
+.option-details strong {
+  display: block;
+  color: #fff;
+  font-size: 0.9rem;
+  margin-bottom: 3px;
+}
+
+.option-details p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.8rem;
+}
+
+.table-selection-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.selected-count {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+  margin-left: auto;
+}
+
+.table-selection-list {
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 15px;
+}
+
+.table-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.table-checkbox-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.empty-message {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+  padding: 10px;
+}
+
+.config-section {
+  margin-bottom: 18px;
+}
+
+.config-label {
+  display: block;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+}
+
+.config-input {
+  width: 100%;
+  padding: 9px 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 7px;
+  color: #fff;
+  font-size: 0.85rem;
+  box-sizing: border-box;
+}
+
+.config-input:focus {
+  outline: none;
+  border-color: rgba(0, 212, 170, 0.5);
+}
+
+.config-input-group {
+  display: flex;
+  gap: 8px;
+}
+
+.config-input-group .config-input {
+  flex: 1;
+}
+
+.config-hint {
+  display: block;
+  margin-top: 5px;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.75rem;
+}
+
+.config-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+/* Confirmation summary (BackupWizard step 3) */
+.backup-summary {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 15px;
+}
+
+.backup-summary h4,
+.selected-tables-preview h5 {
+  margin: 0 0 10px 0;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.summary-list {
+  margin: 0;
+  padding-left: 18px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.85rem;
+}
+
+.summary-list li {
+  margin-bottom: 4px;
+}
+
+.selected-tables-preview {
+  margin-top: 15px;
+}
+
+.tables-preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.table-tag {
+  padding: 3px 9px;
+  background: rgba(0, 212, 170, 0.15);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: #00D4AA;
+}
+
+.backup-progress {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  margin-top: 15px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* Restore Wizard specifics */
+.restore-wizard-section {
+  margin-bottom: 20px;
+}
+
+.restore-wizard-section:last-child {
+  margin-bottom: 0;
+}
+
+.restore-backup-info {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  padding: 12px 15px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 0;
+  font-size: 0.85rem;
+}
+
+.info-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.info-value {
+  color: #fff;
+  font-weight: 500;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.restore-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  margin-bottom: 10px;
+}
+
+.restore-option:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.restore-option .option-content strong {
+  display: block;
+  color: #fff;
+  font-size: 0.88rem;
+  margin-bottom: 3px;
+}
+
+.restore-option .option-content p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.restore-option .option-content p.warning {
+  color: #ffb74d;
+}
+
+.restore-warning-box {
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  background: rgba(220, 53, 69, 0.12);
+  border: 1px solid rgba(220, 53, 69, 0.35);
+  border-radius: 8px;
+}
+
+.warning-icon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.warning-content strong {
+  display: block;
+  color: #ff8a80;
+  margin-bottom: 4px;
+}
+
+.warning-content p {
+  margin: 3px 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.82rem;
+}
+
+.restore-confirm-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  background: rgba(220, 53, 69, 0.08);
+  border: 1px dashed rgba(220, 53, 69, 0.4);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #fff;
+}
+
+.restore-confirm-checkbox input {
+  margin-top: 2px;
+}
+
+/* Toast notifications */
+.backup-toast {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  padding: 14px 20px;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.9rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  z-index: 2000;
+  max-width: 400px;
+  animation: toast-slide-in 0.25s ease;
+}
+
+@keyframes toast-slide-in {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.backup-toast.toast-fade-out {
+  animation: toast-fade-out 0.3s ease forwards;
+}
+
+@keyframes toast-fade-out {
+  to { opacity: 0; transform: translateY(10px); }
+}
+
+.backup-toast.toast-success {
+  background: rgba(0, 180, 120, 0.95);
+}
+
+.backup-toast.toast-error {
+  background: rgba(220, 53, 69, 0.95);
+}
+
+.backup-toast.toast-info {
+  background: rgba(60, 130, 220, 0.95);
+}
+
+/* Progress banner (elapsed-time indicator for create/restore/download/validate) */
+.backup-progress-banner {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: rgba(20, 24, 34, 0.95);
+  border: 1px solid rgba(0, 212, 170, 0.4);
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.85rem;
+  z-index: 2100;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.backup-progress-banner .progress-banner-spinner {
+  width: 16px;
+  height: 16px;
+  margin-bottom: 0;
+  border-width: 2px;
+}
+
+.backup-progress-banner .progress-banner-elapsed {
+  color: rgba(255, 255, 255, 0.5);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 600px) {
+  .backup-cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .backup-manager-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    justify-content: stretch;
+  }
+
+  .header-actions .btn-primary,
+  .header-actions .btn-secondary {
+    flex: 1;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary

Builds the Database Backup Management UI (issue #130) on top of the `database-backup:*` IPC handlers added for #126 (PR #200, 21 tests). The `BackupManager`/`BackupList`/`BackupWizard` component family already existed in the tree and was wired into `DatabaseTab` (from an earlier scaffold commit covering #127-130), but several pieces were incomplete stubs or entirely unstyled. This PR closes those gaps.

**Zero changes to `src/renderer/components/DatabaseTab.ts`** (the shared container #128/#129 are concurrently wiring into) -- every edit is scoped to the Backup component family, `database-backup.ts`, and the IPC/preload plumbing feeding it.

## What was actually broken/missing

- **Table-level backup didn't work.** The wizard already had full table-selection UI, but `BackupManager.handleCreateBackup` had a comment: *"Current backend only supports full database backups"* and silently discarded the selection. `createBackup()` now accepts a `tables` list and scopes `pg_dump` via repeated `-t` flags. Table names are validated against a strict identifier regex before being interpolated into the shell command (injection guard).
- **No visibility into the separate "FictionLab DB Daily Backup" Windows Scheduled Task.** That task `pg_dump`s `fictionlab-postgres`/`mcp_writing_db` to `C:\Backups\fictionlab` (superuser `writer`, trust-auth local) on its own schedule, and the app's `listBackups()` only ever looked at Electron's `userData/backups`. `listBackups()` now also reads `C:\Backups\fictionlab` (overridable via `FICTIONLAB_SCHEDULED_BACKUP_DIR`), merges those backups into one newest-first list, and tags each entry `source: 'app' | 'scheduled-task'` (shown as a badge in the UI). Globals-only dumps (`fictionlab-globals-*.sql`, roles only) and the task's `backup-log.txt` are intentionally excluded so they never show up as restorable "backups". The app still never writes to that directory or manages the scheduled task itself.
- **"Download" was a no-op.** It called `selectSaveLocation()` and then just toasted the original file's path back at the user -- no file was ever copied. Added a `database-backup:download` IPC handler that copies the file to the chosen location.
- **"Validate" was fake.** It only checked `backup.size === 0` client-side. Added a `database-backup:validate` handler doing a real (but deliberately cheap, no Docker/pg_restore) signature check: PGDMP magic header for `.dump`, gzip magic bytes for `.gz`, pg_dump header comment for plain `.sql`.
- **Restore wasn't honestly "destructive-labeled".** The wizard's two restore modes were "Merge with existing data (safer option)" vs "Replace" -- but `restoreBackup()` always invokes `pg_restore` with `--clean --if-exists` regardless of mode, so there is no actual non-destructive merge; the copy was misleading. Relabeled to "Restore In-Place" vs "Full Replace" with accurate descriptions, added a required "I understand this cannot be undone" checkbox that gates the restore button, and made the native confirmation dialog always fire (previously only for "Replace") with mode-specific wording.
- **No progress indicator beyond a static spinner.** Added an elapsed-time progress banner for create/restore/download/validate. `pg_dump`/`pg_restore` over the `docker exec` channel this app uses don't expose byte-level progress, so this is an honest indeterminate indicator (spinner + elapsed seconds), not a fake percentage bar.
- **Zero CSS.** `BackupManager`/`BackupList`/`BackupWizard` reference ~90 classes (`.backup-card`, `.wizard-*`, `.btn-primary`, etc.) and none of them were styled in `database.css` -- the whole feature would have rendered as unstyled default buttons and inputs. Added a full stylesheet section matching the existing dark/teal design language.

## Acceptance criteria (from #130)

- [x] Can create full backup
- [x] Can create table backup
- [x] Backup list displays correctly (now includes scheduled-task backups, badged by source)
- [x] Can restore from backup (explicit, checkbox + dialog confirmed, honestly labeled destructive)
- [x] Progress tracking works (elapsed-time indicator; no false percentage)

## Test plan

- [x] `npm run build` -- clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] Extended `src/main/__tests__/database-backup.test.ts` with 21 new cases, all passing (42/42 in that file): table-scoped `pg_dump` command construction, injection guard on invalid table names, scheduled-task merge/exclusion (globals + log file)/missing-dir/unreadable-dir handling, `validateBackupFile` signature checks for all three formats, `downloadBackup` copy/cancel/missing-source/copy-error paths. All I/O (`fs-extra`, `child_process`, Electron dialogs) is mocked -- no real `pg_dump`/`pg_restore`/Docker/DB access.
- [x] Full `npx jest`: 594 passed / 25 failed / 3 skipped -- the 25 failures are the pre-existing baseline (issue #176: LLM adapter tests, a11y tests, `repository-manager`/`build-orchestrator` tests), all unrelated to this change. Zero new failures.
- [ ] Visual/manual verification needed (no GUI in this session) -- see checklist below.

### Visual checks (manual, once built)

- [ ] Database tab -> Backups: card grid renders with size/type/date/time badges plus a new colored "App" / "Scheduled Task" source badge
- [ ] "Scheduled Task" backups from `C:\Backups\fictionlab` appear in the list alongside app-created ones, newest first
- [ ] Create Backup wizard, "Table-Level Backup" -> select 1-2 tables -> Create: resulting file is a scoped dump (verify with `pg_restore --list` if desired) and the success toast mentions the table names
- [ ] Restore wizard: "Restore Database" button stays disabled until the "cannot be undone" checkbox is ticked; a native confirm() fires with mode-specific wording for both "Restore In-Place" and "Full Replace"
- [ ] Download action on a card opens a native save dialog and actually produces a copied file at the chosen path
- [ ] Validate action reports pass/fail based on the file's real header, not just size
- [ ] Progress banner (spinner + elapsed seconds, top-center) appears during create/restore/download/validate and disappears on completion

## Caveats

- Dashboard (`src/renderer/dashboard-handlers.ts`) still has its own older, parallel backup/restore buttons calling the same `databaseBackup.*` IPC surface -- the issue mentioned "move existing backup functionality from Dashboard" but consolidating/removing that UI was left out of scope here to keep this PR's blast radius limited to the Backup family, per the concurrent-agent constraints on this shared tab.
- Did not touch CI workflow files.

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)