### PR TITLE
feat(database): Database Schema Explorer UI (Issue #129)

### DIFF
--- a/src/renderer/components/DatabaseAdmin/Schema/RelationshipDiagram.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/RelationshipDiagram.ts
@@ -50,7 +50,10 @@ export class RelationshipDiagram {
   private highlightedTable: string | null = null;
 
   // Layout constants
-  private readonly TABLE_WIDTH = 200;
+  // Wide enough to fit schema-qualified names (e.g. "fictionlab.workflow_definitions")
+  // without the header text overflowing the node -- tables aren't assumed to
+  // all live in the (short) "public" namespace.
+  private readonly TABLE_WIDTH = 220;
   private readonly ROW_HEIGHT = 25;
   private readonly HEADER_HEIGHT = 35;
   private readonly PADDING = 50;
@@ -120,6 +123,20 @@ export class RelationshipDiagram {
     // Parse from explicit relationships array
     if (Array.isArray(relationships)) {
       for (const rel of relationships) {
+        // A caller (SchemaExplorer) may already hand these in this class's own
+        // Relationship shape (`{ from: { table, column }, to: { table, column } }`)
+        // -- use it directly rather than looking for flat from_table/fromTable
+        // keys that would never match and silently drop every relationship.
+        if (rel?.from && typeof rel.from === 'object' && rel?.to && typeof rel.to === 'object') {
+          parsed.push({
+            from: { table: rel.from.table || '', column: rel.from.column || '' },
+            to: { table: rel.to.table || '', column: rel.to.column || '' },
+            type: rel.type || 'one-to-many',
+          });
+          continue;
+        }
+
+        // Flat/alternate shape fallback.
         parsed.push({
           from: {
             table: rel.from_table || rel.fromTable || rel.table || '',
@@ -157,8 +174,26 @@ export class RelationshipDiagram {
         }
       }
 
-      // Check constraints
-      if (schema.constraints) {
+      // Check constraints. The real db_get_schema response groups constraints
+      // by type (`{ primary_key: [...], foreign_key: [...], ... }`) rather
+      // than a flat iterable array -- iterating it directly used to throw
+      // "constraints is not iterable" as soon as any schema with real
+      // constraints was passed in. A flat-array shape is still tolerated for
+      // forward/alternate-shape compatibility.
+      if (Array.isArray(schema.constraints?.foreign_key)) {
+        for (const fk of schema.constraints.foreign_key) {
+          if (fk.references_table || fk.referencedTable) {
+            parsed.push({
+              from: { table: tableName, column: fk.column || fk.columnName || '' },
+              to: {
+                table: fk.references_table || fk.referencedTable || '',
+                column: fk.references_column || fk.referencedColumn || '',
+              },
+              type: 'one-to-many',
+            });
+          }
+        }
+      } else if (Array.isArray(schema.constraints)) {
         for (const constraint of schema.constraints) {
           if (constraint.type === 'FOREIGN KEY' || constraint.constraintType === 'FOREIGN KEY') {
             parsed.push({
@@ -452,7 +487,7 @@ export class RelationshipDiagram {
           fill="white"
           font-weight="bold"
           font-size="14"
-        >${this.escapeHtml(table.name)}</text>
+        ><title>${this.escapeHtml(table.name)}</title>${this.escapeHtml(this.formatTableName(table.name))}</text>
 
         <!-- Columns -->
         ${table.columns.map((col, idx) => this.renderColumn(table, col, idx)).join('')}
@@ -506,6 +541,20 @@ export class RelationshipDiagram {
       return type.substring(0, 12) + '...';
     }
     return type;
+  }
+
+  /**
+   * Format a (possibly schema-qualified) table name for the node header.
+   * Long qualified names (e.g. "fictionlab.workflow_definitions") are
+   * truncated to fit the node width; the full name is still available via
+   * the SVG <title> tooltip so accuracy isn't lost, only display space.
+   */
+  private formatTableName(name: string): string {
+    const maxChars = 22;
+    if (name.length > maxChars) {
+      return name.substring(0, maxChars - 3) + '...';
+    }
+    return name;
   }
 
   /**

--- a/src/renderer/components/DatabaseAdmin/Schema/SchemaExplorer.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/SchemaExplorer.ts
@@ -12,19 +12,34 @@
 import { databaseService, DatabaseOperationResult } from '../../../services/databaseService';
 import { TableDetails } from './TableDetails';
 import { RelationshipDiagram } from './RelationshipDiagram';
+import { parseQualifiedTableName } from './schema-utils';
+
+export { parseQualifiedTableName };
 
 export interface TableMetadata {
+  /** Table name as returned by the backend -- schema-qualified for non-public
+   *  schemas (e.g. "fictionlab.workflow_definitions"), bare for public (e.g. "authors"). */
   name: string;
+  /** Actual Postgres schema this table lives in ("public", "fictionlab", ...).
+   *  Always read from the backend -- never assumed. */
+  dbSchema: string;
+  tableType?: string;
+  comment?: string | null;
   recordCount?: number;
+  columnCount?: number;
+  sizeHuman?: string;
   lastUpdated?: string;
+  /** Detailed schema info (columns/constraints/indexes) from db_get_schema, lazily loaded + cached. */
   schema?: any;
-  columns?: any[];
   relationships?: any[];
 }
 
 export interface SchemaCache {
   tables: Map<string, TableMetadata>;
-  relationships: any[];
+  /** db_get_relationships is scoped to a single table (returns that table's
+   *  parents/children) -- there is no bulk "every relationship" tool -- so
+   *  the cache is keyed per table rather than holding one flat list. */
+  relationshipsByTable: Map<string, any[]>;
   lastRefresh: Date;
 }
 
@@ -43,7 +58,7 @@ export class SchemaExplorer {
   constructor() {
     this.cache = {
       tables: new Map(),
-      relationships: [],
+      relationshipsByTable: new Map(),
       lastRefresh: new Date(),
     };
   }
@@ -141,7 +156,13 @@ export class SchemaExplorer {
   }
 
   /**
-   * Render table list items
+   * Render table list items, grouped by their actual database schema.
+   *
+   * The MCP database-admin server backs onto a Postgres instance with more
+   * than one schema in active use (e.g. "fictionlab" alongside the legacy
+   * "public" schema). db_list_tables reports each table's real schema --
+   * we group and label by that reported value rather than assuming every
+   * table lives in "public".
    */
   private renderTableList(): string {
     if (this.isLoading) {
@@ -160,20 +181,47 @@ export class SchemaExplorer {
       return '<div class="empty-message">No tables match search</div>';
     }
 
-    return filtered.map(table => `
+    // Group by the schema the backend actually reported for each table.
+    const bySchema = new Map<string, TableMetadata[]>();
+    for (const table of filtered) {
+      const group = bySchema.get(table.dbSchema) || [];
+      group.push(table);
+      bySchema.set(table.dbSchema, group);
+    }
+
+    const schemaNames = Array.from(bySchema.keys()).sort();
+
+    return schemaNames.map(schemaName => `
+      <div class="schema-group" data-schema="${this.escapeHtml(schemaName)}">
+        <div class="schema-group-header">
+          <span class="schema-badge schema-badge-${this.escapeHtml(schemaName)}">${this.escapeHtml(schemaName)}</span>
+          <span class="schema-group-count">${bySchema.get(schemaName)!.length} table${bySchema.get(schemaName)!.length === 1 ? '' : 's'}</span>
+        </div>
+        ${bySchema.get(schemaName)!.map(table => this.renderTableListItem(table)).join('')}
+      </div>
+    `).join('');
+  }
+
+  /**
+   * Render a single table's sidebar entry
+   */
+  private renderTableListItem(table: TableMetadata): string {
+    const { shortName } = parseQualifiedTableName(table.name);
+
+    return `
       <div class="table-list-item ${this.selectedTable === table.name ? 'selected' : ''}"
            data-table="${this.escapeHtml(table.name)}">
         <div class="table-item-header">
           <span class="table-icon">📊</span>
-          <span class="table-name">${this.escapeHtml(table.name)}</span>
+          <span class="table-name">${this.escapeHtml(shortName)}</span>
         </div>
-        ${table.recordCount !== undefined ? `
-          <div class="table-item-meta">
-            <span class="record-count">${table.recordCount} rows</span>
-          </div>
-        ` : ''}
+        <div class="table-item-meta">
+          ${table.recordCount !== undefined ? `<span class="record-count">${table.recordCount} rows</span>` : ''}
+          ${table.columnCount !== undefined ? `<span class="column-count">${table.columnCount} cols</span>` : ''}
+          ${table.sizeHuman ? `<span class="table-size">${this.escapeHtml(table.sizeHuman)}</span>` : ''}
+        </div>
       </div>
-    `).join('');
+    `;
   }
 
   /**
@@ -224,7 +272,13 @@ export class SchemaExplorer {
   }
 
   /**
-   * Load tables from database
+   * Load tables from database.
+   *
+   * db_list_tables returns an array of table *objects*
+   * (`{ name, schema, type, comment, column_count, size_bytes, size_human }`),
+   * not bare strings -- `name` is only schema-qualified for non-public
+   * schemas. Each object's own `schema` field is preserved into the cache so
+   * the UI can label tables by their real schema instead of assuming public.
    */
   private async loadTables(): Promise<void> {
     this.isLoading = true;
@@ -234,15 +288,19 @@ export class SchemaExplorer {
       const result = await databaseService.listTables();
 
       if (result.success && result.data) {
-        const tables = result.data.tables || result.data;
-        const tableNames = Array.isArray(tables) ? tables : [];
+        const rawTables = result.data.tables || result.data;
+        const tableInfos = Array.isArray(rawTables) ? rawTables : [];
 
         // Load metadata for each table
-        for (const tableName of tableNames) {
-          await this.loadTableMetadata(tableName);
+        for (const tableInfo of tableInfos) {
+          this.loadTableMetadata(tableInfo);
         }
 
-        console.log(`Loaded ${tableNames.length} tables`);
+        // Row counts require a separate query per table -- fetch them
+        // concurrently so a large table list doesn't serialize N round trips.
+        await Promise.all(tableInfos.map((tableInfo: any) => this.loadRecordCount(this.tableInfoName(tableInfo))));
+
+        console.log(`Loaded ${tableInfos.length} tables`);
       } else {
         console.error('Failed to load tables:', result.error);
       }
@@ -255,28 +313,56 @@ export class SchemaExplorer {
   }
 
   /**
-   * Load metadata for a single table
+   * Extract the table name from either a raw table-info object or a plain string
+   * (defensive: tolerates a server returning bare name strings).
    */
-  private async loadTableMetadata(tableName: string): Promise<void> {
+  private tableInfoName(tableInfo: any): string {
+    return typeof tableInfo === 'string' ? tableInfo : tableInfo?.name;
+  }
+
+  /**
+   * Store the metadata db_list_tables already gave us for a single table.
+   * Merges onto any existing cache entry so a previously-loaded detailed
+   * schema (from db_get_schema) survives a table-list refresh.
+   */
+  private loadTableMetadata(tableInfo: any): void {
+    const name = this.tableInfoName(tableInfo);
+    if (!name) return;
+
+    const existing = this.cache.tables.get(name);
+    const dbSchema = tableInfo?.schema || parseQualifiedTableName(name).dbSchema;
+
+    const metadata: TableMetadata = {
+      ...existing,
+      name,
+      dbSchema,
+      tableType: tableInfo?.type,
+      comment: tableInfo?.comment ?? null,
+      columnCount: tableInfo?.column_count,
+      sizeHuman: tableInfo?.size_human,
+      lastUpdated: new Date().toISOString(),
+    };
+
+    this.cache.tables.set(name, metadata);
+  }
+
+  /**
+   * Fetch and store the accurate row count for a single table (via a cheap
+   * COUNT query -- see databaseService.getCount()).
+   */
+  private async loadRecordCount(tableName: string): Promise<void> {
+    if (!tableName) return;
+
     try {
-      // Get record count
-      const countResult = await databaseService.getCount(tableName);
-
-      // Store in cache
-      const metadata: TableMetadata = {
-        name: tableName,
-        recordCount: countResult,
-        lastUpdated: new Date().toISOString(),
-      };
-
-      this.cache.tables.set(tableName, metadata);
+      const recordCount = await databaseService.getCount(tableName);
+      const existing = this.cache.tables.get(tableName);
+      if (existing) {
+        existing.recordCount = recordCount;
+        this.cache.tables.set(tableName, existing);
+        this.updateTableList();
+      }
     } catch (error: any) {
-      console.error(`Error loading metadata for ${tableName}:`, error.message);
-
-      // Store basic info even if metadata fetch fails
-      this.cache.tables.set(tableName, {
-        name: tableName,
-      });
+      console.error(`Error loading record count for ${tableName}:`, error.message);
     }
   }
 
@@ -300,7 +386,10 @@ export class SchemaExplorer {
 
       if (result.success && result.data) {
         // Update cache
-        const metadata = this.cache.tables.get(tableName) || { name: tableName };
+        const metadata = this.cache.tables.get(tableName) || {
+          name: tableName,
+          dbSchema: parseQualifiedTableName(tableName).dbSchema,
+        };
         metadata.schema = result.data;
         this.cache.tables.set(tableName, metadata);
 
@@ -314,31 +403,97 @@ export class SchemaExplorer {
   }
 
   /**
-   * Load relationships for all tables (with caching)
+   * Load relationships for a single table (with caching).
+   *
+   * db_get_relationships is scoped to ONE table -- it returns that table's
+   * `parents` (tables it holds foreign keys to) and `children` (tables that
+   * hold a foreign key back to it), not a whole-database relationship list;
+   * there is no bulk "all relationships" tool. `table` is also a required
+   * argument server-side, so this must always be called with a real table name.
    */
-  private async loadRelationships(): Promise<any[]> {
-    // Return cached relationships if available
-    if (this.cache.relationships.length > 0) {
-      return this.cache.relationships;
+  private async loadRelationships(tableName: string): Promise<any[]> {
+    if (!tableName) return [];
+
+    const cached = this.cache.relationshipsByTable.get(tableName);
+    if (cached) {
+      return cached;
     }
 
     try {
-      const result = await databaseService.getRelationships();
+      const result = await databaseService.getRelationships(tableName);
 
       if (result.success && result.data) {
-        const relationships = result.data.relationships || result.data || [];
-        this.cache.relationships = Array.isArray(relationships) ? relationships : [];
-        return this.cache.relationships;
+        const relationships = this.parseTableRelationships(tableName, result.data);
+        this.cache.relationshipsByTable.set(tableName, relationships);
+        return relationships;
       }
     } catch (error: any) {
-      console.error('Error loading relationships:', error.message);
+      console.error(`Error loading relationships for ${tableName}:`, error.message);
     }
 
     return [];
   }
 
   /**
-   * Filter tables based on search term
+   * Convert db_get_relationships' `{ parents, children }` shape (see
+   * RelationshipMapper.getRelationships in MCP-Writing-Servers) into the
+   * flat `{ from, to }` list RelationshipDiagram renders.
+   *  - parents: this table holds the foreign key ("from" = this table)
+   *  - children: the other table holds the foreign key ("from" = that table)
+   */
+  private parseTableRelationships(tableName: string, data: any): any[] {
+    const relationships: any[] = [];
+
+    for (const parent of data.parents || []) {
+      relationships.push({
+        from: { table: tableName, column: parent.column },
+        to: { table: parent.references_table, column: parent.references_column },
+        type: 'one-to-many',
+      });
+    }
+
+    for (const child of data.children || []) {
+      relationships.push({
+        from: { table: child.table, column: child.column },
+        to: { table: tableName, column: child.references_column },
+        type: 'one-to-many',
+      });
+    }
+
+    return relationships;
+  }
+
+  /**
+   * Collect the schemas needed to render an ERD focused on `focusTable`:
+   * the focus table itself plus every table directly related to it (its
+   * db_get_relationships parents/children). Deliberately scoped rather than
+   * loading every table's schema -- with dozens of tables in the database
+   * that would mean dozens of extra db_get_schema round trips just to draw
+   * one table's neighborhood.
+   */
+  private async buildErdSchemas(focusTable: string, relationships: any[]): Promise<Map<string, any>> {
+    const relatedTableNames = new Set<string>([focusTable]);
+    for (const rel of relationships) {
+      if (rel.from?.table) relatedTableNames.add(rel.from.table);
+      if (rel.to?.table) relatedTableNames.add(rel.to.table);
+    }
+
+    const tableSchemas = new Map<string, any>();
+    for (const name of relatedTableNames) {
+      const schema = await this.loadTableSchema(name);
+      if (schema) {
+        tableSchemas.set(name, schema);
+      }
+    }
+
+    return tableSchemas;
+  }
+
+  /**
+   * Filter tables based on search term.
+   * Matches against the full qualified name (e.g. "fictionlab.workflow_definitions"),
+   * the short table name, and the schema name -- so searching "fictionlab" surfaces
+   * that whole group and searching a bare table name still works regardless of schema.
    */
   private filterTables(tables: TableMetadata[]): TableMetadata[] {
     if (!this.searchTerm) {
@@ -346,9 +501,14 @@ export class SchemaExplorer {
     }
 
     const term = this.searchTerm.toLowerCase();
-    return tables.filter(table =>
-      table.name.toLowerCase().includes(term)
-    );
+    return tables.filter(table => {
+      const { shortName } = parseQualifiedTableName(table.name);
+      return (
+        table.name.toLowerCase().includes(term) ||
+        shortName.toLowerCase().includes(term) ||
+        table.dbSchema.toLowerCase().includes(term)
+      );
+    });
   }
 
   /**
@@ -393,21 +553,8 @@ export class SchemaExplorer {
     if (this.viewMode === 'table-details' && this.tableDetails) {
       await this.tableDetails.displayTable(tableName, schema);
     } else if (this.viewMode === 'erd' && this.relationshipDiagram) {
-      // For ERD, we need to load all relationships
-      const relationships = await this.loadRelationships();
-
-      // Get all table schemas for ERD
-      const tableSchemas = new Map<string, any>();
-      for (const [name, metadata] of this.cache.tables) {
-        if (!metadata.schema) {
-          await this.loadTableSchema(name);
-        }
-        const updatedMetadata = this.cache.tables.get(name);
-        if (updatedMetadata?.schema) {
-          tableSchemas.set(name, updatedMetadata.schema);
-        }
-      }
-
+      const relationships = await this.loadRelationships(tableName);
+      const tableSchemas = await this.buildErdSchemas(tableName, relationships);
       await this.relationshipDiagram.displayDiagram(tableSchemas, relationships, tableName);
     }
   }
@@ -438,20 +585,8 @@ export class SchemaExplorer {
 
     // If switching to ERD and we have a selected table, display it
     if (mode === 'erd' && this.selectedTable && this.relationshipDiagram) {
-      const relationships = await this.loadRelationships();
-
-      // Get all table schemas
-      const tableSchemas = new Map<string, any>();
-      for (const [name, metadata] of this.cache.tables) {
-        if (!metadata.schema) {
-          await this.loadTableSchema(name);
-        }
-        const updatedMetadata = this.cache.tables.get(name);
-        if (updatedMetadata?.schema) {
-          tableSchemas.set(name, updatedMetadata.schema);
-        }
-      }
-
+      const relationships = await this.loadRelationships(this.selectedTable);
+      const tableSchemas = await this.buildErdSchemas(this.selectedTable, relationships);
       await this.relationshipDiagram.displayDiagram(tableSchemas, relationships, this.selectedTable);
     } else if (mode === 'table-details' && this.selectedTable && this.tableDetails) {
       const schema = await this.loadTableSchema(this.selectedTable);
@@ -466,7 +601,7 @@ export class SchemaExplorer {
     // Clear cache
     this.cache = {
       tables: new Map(),
-      relationships: [],
+      relationshipsByTable: new Map(),
       lastRefresh: new Date(),
     };
 
@@ -512,7 +647,7 @@ export class SchemaExplorer {
       this.relationshipDiagram.destroy();
     }
     this.cache.tables.clear();
-    this.cache.relationships = [];
+    this.cache.relationshipsByTable.clear();
     console.log('SchemaExplorer destroyed');
   }
 }

--- a/src/renderer/components/DatabaseAdmin/Schema/TableDetails.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/TableDetails.ts
@@ -10,6 +10,7 @@
  */
 
 import { databaseService } from '../../../services/databaseService';
+import { parseQualifiedTableName } from './schema-utils';
 
 export interface ColumnInfo {
   name: string;
@@ -129,11 +130,21 @@ export class TableDetails {
 
   /**
    * Render header
+   *
+   * Shows the table's actual database schema as a badge next to its name
+   * (e.g. "fictionlab" or "public") rather than assuming every table lives
+   * in "public" -- `currentTable` may be schema-qualified (e.g.
+   * "fictionlab.workflow_definitions") or bare (e.g. "authors").
    */
   private renderHeader(): string {
+    const { dbSchema, shortName } = parseQualifiedTableName(this.currentTable || '');
+
     return `
       <div class="table-details-header">
-        <h4>${this.escapeHtml(this.currentTable || '')}</h4>
+        <div class="table-details-title">
+          <span class="schema-badge schema-badge-${this.escapeHtml(dbSchema)}">${this.escapeHtml(dbSchema)}</span>
+          <h4>${this.escapeHtml(shortName)}</h4>
+        </div>
         <div class="table-stats">
           ${this.currentSchema?.columns?.length ? `
             <span class="stat-item">
@@ -161,6 +172,12 @@ export class TableDetails {
 
   /**
    * Render columns tab
+   *
+   * db_get_schema's column objects carry no per-column PK/FK flags -- that
+   * info only exists in `constraints.primary_key` / `constraints.foreign_key`
+   * (see getPrimaryKeys()/getForeignKeys()). Resolve those once per render
+   * and cross-reference by column name so the Columns tab still highlights
+   * keys correctly against the real backend shape.
    */
   private renderColumnsTab(): string {
     if (!this.currentSchema?.columns || this.currentSchema.columns.length === 0) {
@@ -172,6 +189,8 @@ export class TableDetails {
     }
 
     const columns = this.currentSchema.columns;
+    const primaryKeyNames = new Set(this.getPrimaryKeys());
+    const foreignKeyNames = new Set(this.getForeignKeys().map(fk => fk.column));
 
     return `
       <div class="tab-content" data-tab="columns">
@@ -186,7 +205,7 @@ export class TableDetails {
             </tr>
           </thead>
           <tbody>
-            ${columns.map((col: any) => this.renderColumnRow(col)).join('')}
+            ${columns.map((col: any) => this.renderColumnRow(col, primaryKeyNames, foreignKeyNames)).join('')}
           </tbody>
         </table>
       </div>
@@ -196,14 +215,17 @@ export class TableDetails {
   /**
    * Render a single column row
    */
-  private renderColumnRow(column: any): string {
+  private renderColumnRow(column: any, primaryKeyNames: Set<string>, foreignKeyNames: Set<string>): string {
     const constraints: string[] = [];
 
-    if (column.isPrimaryKey || column.primary_key) {
+    // Prefer a per-column flag if a caller/schema shape provides one, but the
+    // real MCP database-admin server never does -- fall back to the
+    // constraints-derived name sets so keys still get highlighted correctly.
+    if (column.isPrimaryKey || column.primary_key || primaryKeyNames.has(column.name)) {
       constraints.push('<span class="badge badge-primary">PRIMARY KEY</span>');
     }
 
-    if (column.isForeignKey || column.foreign_key) {
+    if (column.isForeignKey || column.foreign_key || foreignKeyNames.has(column.name)) {
       constraints.push('<span class="badge badge-info">FOREIGN KEY</span>');
     }
 
@@ -365,9 +387,20 @@ export class TableDetails {
   }
 
   /**
-   * Get primary keys from schema
+   * Get primary keys from schema.
+   *
+   * The MCP database-admin server's db_get_schema groups constraints by type
+   * (`{ primary_key: [{ name, column, ... }], foreign_key: [...], ... }`) --
+   * column objects themselves carry no isPrimaryKey/primary_key flag. Read
+   * that grouped shape first; a flat per-column-flag fallback is kept for
+   * forward/alternate-shape compatibility, not because the real server uses it.
    */
   private getPrimaryKeys(): string[] {
+    const grouped = this.currentSchema?.constraints?.primary_key;
+    if (Array.isArray(grouped) && grouped.length > 0) {
+      return grouped.map((pk: any) => pk.column || pk.columnName).filter(Boolean);
+    }
+
     if (!this.currentSchema?.columns) return [];
 
     return this.currentSchema.columns
@@ -376,25 +409,49 @@ export class TableDetails {
   }
 
   /**
-   * Get foreign keys from schema
+   * Get foreign keys from schema.
+   *
+   * Same grouped-constraints shape as getPrimaryKeys(). Note: the current
+   * db_get_schema query (MCP-Writing-Servers) doesn't join to
+   * information_schema.constraint_column_usage, so it reports the FK's own
+   * column but not what it references -- shown honestly rather than invented.
    */
   private getForeignKeys(): Array<{ column: string; references: string }> {
-    if (!this.currentSchema?.columns) return [];
-
     const foreignKeys: Array<{ column: string; references: string }> = [];
 
-    for (const col of this.currentSchema.columns) {
-      if (col.isForeignKey || col.foreign_key) {
-        const ref = col.foreignKeyRef || col.foreign_key_ref || {};
-        foreignKeys.push({
-          column: col.name,
-          references: `${ref.table || '?'}.${ref.column || '?'}`,
-        });
+    const grouped = this.currentSchema?.constraints?.foreign_key;
+    if (Array.isArray(grouped)) {
+      for (const fk of grouped) {
+        const column = fk.column || fk.columnName || '?';
+        const references =
+          fk.referencedTable && fk.referencedColumn
+            ? `${fk.referencedTable}.${fk.referencedColumn}`
+            : '(target not reported by server)';
+        foreignKeys.push({ column, references });
       }
     }
 
-    // Also check constraints if available
-    if (this.currentSchema.constraints) {
+    if (foreignKeys.length > 0) {
+      return foreignKeys;
+    }
+
+    // Fallback: tolerate a flatter/alternate schema shape with per-column FK
+    // metadata (not what the real server currently returns).
+    if (this.currentSchema?.columns) {
+      for (const col of this.currentSchema.columns) {
+        if (col.isForeignKey || col.foreign_key) {
+          const ref = col.foreignKeyRef || col.foreign_key_ref || {};
+          foreignKeys.push({
+            column: col.name,
+            references: `${ref.table || '?'}.${ref.column || '?'}`,
+          });
+        }
+      }
+    }
+
+    if (Array.isArray(this.currentSchema?.constraints)) {
+      // Tolerate a flat constraints array shape too, in case a future/alternate
+      // server version returns one instead of the grouped object.
       for (const constraint of this.currentSchema.constraints) {
         if (constraint.type === 'FOREIGN KEY' || constraint.constraintType === 'FOREIGN KEY') {
           foreignKeys.push({

--- a/src/renderer/components/DatabaseAdmin/Schema/__tests__/DatabaseTab.schema-view.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/__tests__/DatabaseTab.schema-view.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the Schema Explorer's wiring into DatabaseTab (Issue #129).
+ *
+ * DatabaseTab.ts is a shared container that Issues #128 (batch ops) and
+ * #130 (backup UI) also wire into; this file only covers the additive
+ * "Schema" quick-action button this issue introduced (mirroring the
+ * pre-existing "Backups" button/view pattern) so it doesn't collide with
+ * those issues' own test coverage. The real SchemaExplorer is mocked here --
+ * its own behavior is covered by SchemaExplorer.test.ts.
+ */
+
+import { DatabaseTab } from '../../../DatabaseTab';
+import { SchemaExplorer } from '../SchemaExplorer';
+
+jest.mock('../SchemaExplorer', () => ({
+  SchemaExplorer: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn(),
+  })),
+}));
+
+const MockedSchemaExplorer = SchemaExplorer as unknown as jest.Mock;
+
+describe('DatabaseTab -> Schema view wiring', () => {
+  let tab: DatabaseTab;
+  let mockInitialize: jest.Mock;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="database-card"></div>';
+    (window as any).electronAPI = {
+      databaseAdmin: {
+        listTables: jest.fn().mockResolvedValue({ success: true, data: { tables: [] } }),
+      },
+    };
+    MockedSchemaExplorer.mockClear();
+    tab = new DatabaseTab();
+    await tab.initialize();
+    // DatabaseTab constructs its SchemaExplorer once in its own constructor
+    // (called above, inside `new DatabaseTab()`); grab that instance's mock.
+    mockInitialize = MockedSchemaExplorer.mock.results[0].value.initialize;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a Schema quick-action button on the overview', () => {
+    expect(document.getElementById('db-view-schema')).not.toBeNull();
+  });
+
+  it('switches to the schema view and mounts the schema explorer container', async () => {
+    (document.getElementById('db-view-schema') as HTMLElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.getElementById('schema-explorer-container')).not.toBeNull();
+    expect(mockInitialize).toHaveBeenCalledWith('schema-explorer-container');
+  });
+
+  it('returns to the overview from the schema view via the back button', async () => {
+    (document.getElementById('db-view-schema') as HTMLElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const backBtn = document.getElementById('back-to-overview-from-schema-btn') as HTMLElement;
+    expect(backBtn).not.toBeNull();
+    backBtn.click();
+
+    expect(document.getElementById('schema-explorer-container')).toBeNull();
+    expect(document.getElementById('db-manage-backups')).not.toBeNull();
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Schema/__tests__/RelationshipDiagram.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/__tests__/RelationshipDiagram.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for RelationshipDiagram (Issue #129: Database Schema Explorer UI).
+ *
+ * Covers the ERD acceptance criteria: table nodes render, relationships
+ * (derived from foreign keys) render as connecting lines, and zoom/pan
+ * controls are interactive. Also covers the display fix for long
+ * schema-qualified table names (e.g. "fictionlab.workflow_definitions")
+ * so they don't overflow the node header -- the full name must still be
+ * recoverable (via the SVG <title> tooltip), only the on-node label is
+ * shortened.
+ */
+
+import { RelationshipDiagram } from '../RelationshipDiagram';
+
+const TABLE_SCHEMAS = new Map<string, any>([
+  [
+    'fictionlab.workflow_definitions',
+    {
+      columns: [
+        { name: 'workflow_id', type: 'uuid', isPrimaryKey: true },
+        {
+          name: 'created_by',
+          type: 'uuid',
+          isForeignKey: true,
+          foreignKeyRef: { table: 'authors', column: 'id' },
+        },
+      ],
+    },
+  ],
+  [
+    'authors',
+    {
+      columns: [{ name: 'id', type: 'uuid', isPrimaryKey: true }],
+    },
+  ],
+]);
+
+describe('RelationshipDiagram', () => {
+  let diagram: RelationshipDiagram;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="erd-root"></div>';
+    diagram = new RelationshipDiagram();
+    await diagram.initialize('erd-root');
+  });
+
+  afterEach(() => {
+    diagram.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('shows an empty state before a diagram is displayed', () => {
+    expect(document.querySelector('.erd-empty')).not.toBeNull();
+  });
+
+  describe('after displaying a diagram', () => {
+    beforeEach(async () => {
+      await diagram.displayDiagram(TABLE_SCHEMAS, [], 'fictionlab.workflow_definitions');
+    });
+
+    it('renders a table node for every table', () => {
+      expect(document.querySelectorAll('.table-node')).toHaveLength(2);
+    });
+
+    it('derives a relationship line from the foreign key and renders it', () => {
+      const line = document.querySelector('.relationship-line');
+      expect(line).not.toBeNull();
+      expect(line!.getAttribute('data-from')).toBe('fictionlab.workflow_definitions');
+      expect(line!.getAttribute('data-to')).toBe('authors');
+    });
+
+    it('truncates a long schema-qualified name on the node but keeps the full name recoverable via tooltip', () => {
+      const nameEl = document.querySelector('g[data-table="fictionlab.workflow_definitions"] text.table-name')!;
+      const titleEl = nameEl.querySelector('title')!;
+      expect(titleEl.textContent).toBe('fictionlab.workflow_definitions');
+
+      const visibleText = Array.from(nameEl.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+      expect(visibleText?.textContent).toBe('fictionlab.workflow...');
+      expect(visibleText?.textContent!.length).toBeLessThan('fictionlab.workflow_definitions'.length);
+    });
+
+    it('does not truncate a short table name', () => {
+      const nameEl = document.querySelector('g[data-table="authors"] text.table-name')!;
+      const visibleText = Array.from(nameEl.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+      expect(visibleText?.textContent).toBe('authors');
+    });
+
+    it('supports zoom in/out via the control buttons', () => {
+      const mainGroup = document.getElementById('erd-main-group')!;
+      expect(mainGroup.getAttribute('transform')).toBe('translate(0, 0) scale(1)');
+
+      (document.getElementById('erd-zoom-in') as HTMLElement).click();
+      expect(mainGroup.getAttribute('transform')).toBe('translate(0, 0) scale(1.2)');
+
+      (document.getElementById('erd-reset-view') as HTMLElement).click();
+      expect(mainGroup.getAttribute('transform')).toBe('translate(0, 0) scale(1)');
+    });
+
+    it('highlights a table and its relationship lines on hover', () => {
+      const node = document.querySelector('g[data-table="authors"]') as HTMLElement;
+      node.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+      expect(node.classList.contains('highlighted')).toBe(true);
+      const line = document.querySelector('.relationship-line')!;
+      expect(line.getAttribute('stroke')).toBe('#2196F3');
+    });
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Schema/__tests__/SchemaExplorer.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/__tests__/SchemaExplorer.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for SchemaExplorer (Issue #129: Database Schema Explorer UI).
+ *
+ * SchemaExplorer existed as unwired scaffolding before this issue (see PR #200's
+ * audit). These tests guard the fixes made to actually wire it up correctly:
+ *
+ *  - db_list_tables returns an array of table *objects*
+ *    (`{ name, schema, type, column_count, size_human }`), not bare name
+ *    strings -- the original scaffolding treated each entry as if it were
+ *    already a string, so every per-table lookup broke silently.
+ *  - The live database has real tables outside the "public" schema (e.g.
+ *    "fictionlab"). The explorer must label/group tables by the schema the
+ *    backend actually reports, never assume "public".
+ *  - Record counts, search/filter, view-mode toggle, and schema caching
+ *    (acceptance criteria from the issue).
+ */
+
+import { SchemaExplorer } from '../SchemaExplorer';
+import { databaseService } from '../../../../services/databaseService';
+
+jest.mock('../../../../services/databaseService', () => ({
+  databaseService: {
+    listTables: jest.fn(),
+    getCount: jest.fn(),
+    getSchema: jest.fn(),
+    getRelationships: jest.fn(),
+    queryRecords: jest.fn(),
+  },
+}));
+
+const mockedDatabaseService = databaseService as jest.Mocked<typeof databaseService>;
+
+/** A realistic db_list_tables response spanning both a "public" legacy table
+ *  and a "fictionlab" (the real, actively-used schema) table. */
+const LIST_TABLES_RESPONSE = {
+  success: true,
+  data: {
+    success: true,
+    count: 2,
+    total_in_database: 2,
+    tables: [
+      {
+        name: 'authors',
+        schema: 'public',
+        type: 'BASE TABLE',
+        comment: null,
+        column_count: 5,
+        size_bytes: 8192,
+        size_human: '8 KB',
+        is_whitelisted: true,
+      },
+      {
+        name: 'fictionlab.workflow_definitions',
+        schema: 'fictionlab',
+        type: 'BASE TABLE',
+        comment: null,
+        column_count: 12,
+        size_bytes: 16384,
+        size_human: '16 KB',
+        is_whitelisted: true,
+      },
+    ],
+  },
+};
+
+describe('SchemaExplorer', () => {
+  let explorer: SchemaExplorer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="schema-root"></div>';
+    mockedDatabaseService.listTables.mockResolvedValue(LIST_TABLES_RESPONSE as any);
+    mockedDatabaseService.getCount.mockImplementation(async (table: string) => {
+      return table === 'authors' ? 42 : 7;
+    });
+    mockedDatabaseService.getSchema.mockResolvedValue({
+      success: true,
+      data: { table: 'authors', columns: [], constraints: {}, indexes: [] },
+    } as any);
+    // Real shape: db_get_relationships is scoped to ONE table and returns
+    // { table, depth, parents, children } -- see RelationshipMapper.getRelationships
+    // in MCP-Writing-Servers. There is no bulk "all relationships" tool.
+    mockedDatabaseService.getRelationships.mockResolvedValue({
+      success: true,
+      data: {
+        table: 'fictionlab.workflow_definitions',
+        depth: 1,
+        parents: [],
+        children: [],
+      },
+    } as any);
+    explorer = new SchemaExplorer();
+  });
+
+  afterEach(() => {
+    explorer.destroy();
+    document.body.innerHTML = '';
+  });
+
+  describe('loading tables', () => {
+    it('displays all tables returned by the backend', async () => {
+      await explorer.initialize('schema-root');
+
+      const items = document.querySelectorAll('.table-list-item');
+      expect(items).toHaveLength(2);
+    });
+
+    it('groups tables by their real database schema instead of assuming public', async () => {
+      await explorer.initialize('schema-root');
+
+      const badges = Array.from(document.querySelectorAll('.schema-group .schema-badge')).map(
+        (el) => el.textContent
+      );
+      expect(badges.sort()).toEqual(['fictionlab', 'public']);
+    });
+
+    it('displays the short table name (without schema prefix) in the sidebar', async () => {
+      await explorer.initialize('schema-root');
+
+      const names = Array.from(document.querySelectorAll('.table-list-item .table-name')).map(
+        (el) => el.textContent
+      );
+      expect(names).toContain('authors');
+      expect(names).toContain('workflow_definitions');
+      // The qualified prefix should not leak into the displayed short name.
+      expect(names).not.toContain('fictionlab.workflow_definitions');
+    });
+
+    it('keeps the fully-qualified name in data-table so downstream lookups stay correct', async () => {
+      await explorer.initialize('schema-root');
+
+      const qualifiedItem = document.querySelector('[data-table="fictionlab.workflow_definitions"]');
+      expect(qualifiedItem).not.toBeNull();
+    });
+
+    it('fetches and displays an accurate record count per table', async () => {
+      await explorer.initialize('schema-root');
+
+      expect(document.body.textContent).toContain('42 rows');
+      expect(document.body.textContent).toContain('7 rows');
+    });
+
+    it('shows column counts and human-readable size from db_list_tables', async () => {
+      await explorer.initialize('schema-root');
+
+      expect(document.body.textContent).toContain('5 cols');
+      expect(document.body.textContent).toContain('8 KB');
+    });
+  });
+
+  describe('selecting a table', () => {
+    it('requests the schema using the fully-qualified table name (not "[object Object]")', async () => {
+      await explorer.initialize('schema-root');
+
+      const item = document.querySelector('[data-table="fictionlab.workflow_definitions"]') as HTMLElement;
+      item.click();
+      await flushPromises();
+
+      expect(mockedDatabaseService.getSchema).toHaveBeenCalledWith(
+        expect.objectContaining({ table: 'fictionlab.workflow_definitions' })
+      );
+    });
+  });
+
+  describe('search/filter', () => {
+    it('filters the visible tables by short name', async () => {
+      await explorer.initialize('schema-root');
+
+      const searchInput = document.getElementById('schema-search-input') as HTMLInputElement;
+      searchInput.value = 'workflow';
+      searchInput.dispatchEvent(new Event('input'));
+
+      const items = document.querySelectorAll('.table-list-item');
+      expect(items).toHaveLength(1);
+      expect(items[0].getAttribute('data-table')).toBe('fictionlab.workflow_definitions');
+    });
+
+    it('filters by schema name so searching "fictionlab" surfaces that whole group', async () => {
+      await explorer.initialize('schema-root');
+
+      const searchInput = document.getElementById('schema-search-input') as HTMLInputElement;
+      searchInput.value = 'fictionlab';
+      searchInput.dispatchEvent(new Event('input'));
+
+      const items = document.querySelectorAll('.table-list-item');
+      expect(items).toHaveLength(1);
+      expect(items[0].getAttribute('data-table')).toBe('fictionlab.workflow_definitions');
+    });
+  });
+
+  describe('view mode toggle', () => {
+    it('toggles the ERD panel active', async () => {
+      await explorer.initialize('schema-root');
+
+      const erdBtn = document.getElementById('view-erd') as HTMLElement;
+      erdBtn.click();
+      await flushPromises();
+
+      expect(document.getElementById('view-erd')!.classList.contains('active')).toBe(true);
+      expect(document.getElementById('schema-erd-panel')!.classList.contains('active')).toBe(true);
+    });
+
+    it('requests relationships scoped to the selected table (db_get_relationships takes no bulk mode)', async () => {
+      await explorer.initialize('schema-root');
+
+      const item = document.querySelector('[data-table="fictionlab.workflow_definitions"]') as HTMLElement;
+      item.click();
+      await flushPromises();
+
+      const erdBtn = document.getElementById('view-erd') as HTMLElement;
+      erdBtn.click();
+      await flushPromises();
+
+      expect(mockedDatabaseService.getRelationships).toHaveBeenCalledWith('fictionlab.workflow_definitions');
+    });
+
+    it('renders the focus table plus its related tables in the ERD, derived from parents/children', async () => {
+      mockedDatabaseService.getRelationships.mockResolvedValueOnce({
+        success: true,
+        data: {
+          table: 'fictionlab.workflow_definitions',
+          depth: 1,
+          parents: [{ column: 'created_by', references_table: 'authors', references_column: 'id' }],
+          children: [],
+        },
+      } as any);
+
+      await explorer.initialize('schema-root');
+
+      const item = document.querySelector('[data-table="fictionlab.workflow_definitions"]') as HTMLElement;
+      item.click();
+      await flushPromises();
+
+      const erdBtn = document.getElementById('view-erd') as HTMLElement;
+      erdBtn.click();
+      await flushPromises();
+
+      const nodes = document.querySelectorAll('#schema-erd-panel .table-node');
+      const nodeNames = Array.from(nodes).map((n) => n.getAttribute('data-table'));
+      expect(nodeNames).toContain('fictionlab.workflow_definitions');
+      expect(nodeNames).toContain('authors');
+      expect(document.querySelector('#schema-erd-panel .relationship-line')).not.toBeNull();
+    });
+  });
+
+  describe('caching', () => {
+    it('does not re-fetch schema for an already-selected table', async () => {
+      await explorer.initialize('schema-root');
+
+      const item = document.querySelector('[data-table="authors"]') as HTMLElement;
+      item.click();
+      await flushPromises();
+      item.click();
+      await flushPromises();
+
+      expect(mockedDatabaseService.getSchema).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports cache stats reflecting the loaded tables', async () => {
+      await explorer.initialize('schema-root');
+      expect(explorer.getCacheStats().tableCount).toBe(2);
+    });
+
+    it('clears the cache on refresh and reloads tables', async () => {
+      await explorer.initialize('schema-root');
+      mockedDatabaseService.listTables.mockClear();
+
+      const refreshBtn = document.getElementById('schema-refresh-btn') as HTMLElement;
+      refreshBtn.click();
+      await flushPromises();
+
+      expect(mockedDatabaseService.listTables).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/src/renderer/components/DatabaseAdmin/Schema/__tests__/TableDetails.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/__tests__/TableDetails.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for TableDetails (Issue #129: Database Schema Explorer UI).
+ *
+ * Covers the acceptance criteria this component is responsible for: column
+ * list with types/constraints, primary/foreign keys highlighted, indexes,
+ * and a sample data preview -- plus the schema-accuracy fix: the header
+ * must label a table with its *real* database schema (e.g. "fictionlab"),
+ * never assume "public".
+ */
+
+import { TableDetails } from '../TableDetails';
+import { databaseService } from '../../../../services/databaseService';
+
+jest.mock('../../../../services/databaseService', () => ({
+  databaseService: {
+    queryRecords: jest.fn(),
+  },
+}));
+
+const mockedDatabaseService = databaseService as jest.Mocked<typeof databaseService>;
+
+/**
+ * Shaped exactly like a real db_get_schema response (see
+ * MCP-Writing-Servers/src/mcps/database-admin-server/handlers/schema-handlers.js
+ * handleGetSchema/_groupConstraints): column objects carry no PK/FK flags at
+ * all -- that lives only in the grouped `constraints` object. Using the real
+ * shape here (rather than an idealized one) is what caught the
+ * "constraints is not iterable" crash in the original scaffolding.
+ */
+const SAMPLE_SCHEMA = {
+  table: 'fictionlab.workflow_definitions',
+  columns: [
+    { name: 'workflow_id', type: 'uuid', nullable: false, default: null },
+    { name: 'name', type: 'character varying', nullable: false, default: null },
+    { name: 'created_by', type: 'uuid', nullable: true, default: null },
+  ],
+  constraints: {
+    primary_key: [{ name: 'workflow_definitions_pkey', column: 'workflow_id' }],
+    foreign_key: [{ name: 'workflow_definitions_created_by_fkey', column: 'created_by' }],
+    unique: [],
+    check: [],
+  },
+  indexes: [{ name: 'workflow_definitions_pkey', columns: ['workflow_id'], unique: true }],
+};
+
+describe('TableDetails', () => {
+  let details: TableDetails;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="details-root"></div>';
+    mockedDatabaseService.queryRecords.mockResolvedValue({
+      success: true,
+      data: { data: [{ workflow_id: '1', name: 'demo', created_by: null }] },
+    } as any);
+    details = new TableDetails();
+    await details.initialize('details-root');
+  });
+
+  afterEach(() => {
+    details.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('shows an empty state before a table is selected', () => {
+    expect(document.querySelector('.table-details-empty')).not.toBeNull();
+  });
+
+  describe('after displaying a schema-qualified table', () => {
+    beforeEach(async () => {
+      await details.displayTable('fictionlab.workflow_definitions', SAMPLE_SCHEMA);
+    });
+
+    it('labels the header with the real schema, not "public"', () => {
+      const badge = document.querySelector('.table-details-header .schema-badge');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe('fictionlab');
+      expect(badge!.className).toContain('schema-badge-fictionlab');
+    });
+
+    it('shows only the short table name in the title', () => {
+      const heading = document.querySelector('.table-details-header h4');
+      expect(heading!.textContent).toBe('workflow_definitions');
+    });
+
+    it('renders columns with primary/foreign key badges resolved from grouped constraints', () => {
+      const rows = document.querySelectorAll('.tab-content[data-tab="columns"] tbody tr');
+      expect(rows).toHaveLength(3);
+      expect(document.querySelector('.badge-primary')!.textContent).toBe('PRIMARY KEY');
+      expect(document.querySelector('.badge-info')!.textContent).toBe('FOREIGN KEY');
+    });
+
+    it('lists primary/foreign keys in the Keys tab without crashing on the grouped constraints shape', () => {
+      const keysBtn = document.querySelector('[data-tab="keys"]') as HTMLElement;
+      keysBtn.click();
+
+      const keysContent = document.querySelector('.tab-content[data-tab="keys"]')!;
+      expect(keysContent.textContent).toContain('workflow_id');
+      expect(keysContent.textContent).toContain('created_by');
+    });
+
+    it('reports honestly when the server does not provide an FK reference target, rather than inventing one', () => {
+      const keysBtn = document.querySelector('[data-tab="keys"]') as HTMLElement;
+      keysBtn.click();
+
+      const keysContent = document.querySelector('.tab-content[data-tab="keys"]')!;
+      expect(keysContent.textContent).toContain('(target not reported by server)');
+      expect(keysContent.textContent).not.toContain('?.?');
+    });
+
+    it('renders the sample data preview', () => {
+      const sampleTab = document.querySelector('.tab-content[data-tab="sample-data"]')!;
+      expect(sampleTab.textContent).toContain('demo');
+    });
+
+    it('switches tabs on click', () => {
+      const keysBtn = document.querySelector('[data-tab="keys"]') as HTMLElement;
+      keysBtn.click();
+
+      const keysContent = document.querySelector('.tab-content[data-tab="keys"]') as HTMLElement;
+      const columnsContent = document.querySelector('.tab-content[data-tab="columns"]') as HTMLElement;
+      expect(keysContent.style.display).toBe('block');
+      expect(columnsContent.style.display).toBe('none');
+    });
+  });
+
+  describe('a bare (unqualified) table name', () => {
+    it('labels the header as "public"', async () => {
+      await details.displayTable('authors', { ...SAMPLE_SCHEMA, table: 'authors' });
+
+      const badge = document.querySelector('.table-details-header .schema-badge');
+      expect(badge!.textContent).toBe('public');
+    });
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Schema/__tests__/schema-utils.test.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/__tests__/schema-utils.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for schema-utils (Issue #129: Database Schema Explorer UI).
+ *
+ * parseQualifiedTableName is the single source of truth the whole Schema
+ * Explorer family uses to decide which Postgres schema a table belongs to.
+ * It must never assume "public" except as the documented fallback for a
+ * bare (unqualified) name -- see the DB facts in the issue: the live
+ * database has real tables living outside "public" (e.g. "fictionlab").
+ */
+
+import { parseQualifiedTableName } from '../schema-utils';
+
+describe('parseQualifiedTableName', () => {
+  it('splits a schema-qualified name into schema and short name', () => {
+    expect(parseQualifiedTableName('fictionlab.workflow_definitions')).toEqual({
+      dbSchema: 'fictionlab',
+      shortName: 'workflow_definitions',
+    });
+  });
+
+  it('defaults a bare (unqualified) name to the public schema', () => {
+    expect(parseQualifiedTableName('authors')).toEqual({
+      dbSchema: 'public',
+      shortName: 'authors',
+    });
+  });
+
+  it('only splits on the first dot (table names never contain dots)', () => {
+    expect(parseQualifiedTableName('fictionlab.workflow_definitions')).toEqual({
+      dbSchema: 'fictionlab',
+      shortName: 'workflow_definitions',
+    });
+  });
+
+  it('handles an empty string without throwing', () => {
+    expect(parseQualifiedTableName('')).toEqual({ dbSchema: 'public', shortName: '' });
+  });
+});

--- a/src/renderer/components/DatabaseAdmin/Schema/schema-utils.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/schema-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared helpers for the Schema Explorer component family.
+ * Kept in their own module (rather than living on SchemaExplorer.ts) so
+ * TableDetails/RelationshipDiagram can use them without a circular import.
+ */
+
+/**
+ * Split a (possibly) schema-qualified table name into its schema and short name.
+ *
+ * The MCP database-admin server's db_list_tables only qualifies tables that
+ * live outside the "public" schema (e.g. "fictionlab.workflow_definitions");
+ * bare names (e.g. "authors") are always "public". A bare name therefore
+ * defaults to "public" here -- but that is reading the backend's own
+ * convention, not assuming every table is public.
+ */
+export function parseQualifiedTableName(qualifiedName: string): { dbSchema: string; shortName: string } {
+  const dotIndex = qualifiedName.indexOf('.');
+  if (dotIndex === -1) {
+    return { dbSchema: 'public', shortName: qualifiedName };
+  }
+  return { dbSchema: qualifiedName.substring(0, dotIndex), shortName: qualifiedName.substring(dotIndex + 1) };
+}

--- a/src/renderer/components/DatabaseTab.ts
+++ b/src/renderer/components/DatabaseTab.ts
@@ -12,17 +12,20 @@
 import { databaseService } from '../services/databaseService.js';
 import { BackupManager } from './DatabaseAdmin/Backup/BackupManager.js';
 import { CRUDPanel } from './DatabaseAdmin/CRUD/CRUDPanel.js';
+import { SchemaExplorer } from './DatabaseAdmin/Schema/SchemaExplorer.js';
 
 export class DatabaseTab {
   private container: HTMLElement | null = null;
   private availableTables: string[] = [];
   private backupManager: BackupManager | null = null;
   private crudPanel: CRUDPanel | null = null;
-  private currentView: 'overview' | 'backup' = 'overview';
+  private schemaExplorer: SchemaExplorer | null = null;
+  private currentView: 'overview' | 'backup' | 'schema' = 'overview';
   private currentActiveTab: 'schema' | 'data' = 'data'; // Default to data view
 
   constructor() {
     this.backupManager = new BackupManager();
+    this.schemaExplorer = new SchemaExplorer();
   }
 
   /**
@@ -52,6 +55,8 @@ export class DatabaseTab {
 
     if (this.currentView === 'backup') {
       this.renderBackupView();
+    } else if (this.currentView === 'schema') {
+      this.renderSchemaView();
     } else {
       this.renderOverviewView();
     }
@@ -126,6 +131,40 @@ export class DatabaseTab {
   }
 
   /**
+   * Render schema explorer view (Issue #129)
+   */
+  private async renderSchemaView(): Promise<void> {
+    if (!this.container) return;
+
+    this.container.innerHTML = `
+      ${this.renderHeader()}
+      <div class="database-schema-view">
+        <div class="backup-view-header">
+          <button class="btn-back" id="back-to-overview-from-schema-btn">
+            <span class="btn-icon">←</span>
+            Back to Overview
+          </button>
+        </div>
+        <div id="schema-explorer-container" class="schema-explorer-container"></div>
+      </div>
+    `;
+
+    // Attach back button listener
+    const backBtn = document.getElementById('back-to-overview-from-schema-btn');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        this.currentView = 'overview';
+        this.render();
+      });
+    }
+
+    // Initialize schema explorer
+    if (this.schemaExplorer) {
+      await this.schemaExplorer.initialize('schema-explorer-container');
+    }
+  }
+
+  /**
    * Render the header
    */
   private renderHeader(): string {
@@ -156,6 +195,10 @@ export class DatabaseTab {
         <button id="db-test-query" class="quick-action-btn-small" title="Test a simple query">
           <span class="action-icon">🔍</span>
           <span class="action-label">Test Query</span>
+        </button>
+        <button id="db-view-schema" class="quick-action-btn-small" title="Explore database schema">
+          <span class="action-icon">🗂️</span>
+          <span class="action-label">Schema</span>
         </button>
         <div class="spacer"></div>
         <button id="db-manage-backups" class="quick-action-btn-small primary" title="Manage database backups">
@@ -207,6 +250,11 @@ export class DatabaseTab {
     const manageBackupsBtn = document.getElementById('db-manage-backups');
     if (manageBackupsBtn) {
       manageBackupsBtn.addEventListener('click', () => this.handleManageBackups());
+    }
+
+    const viewSchemaBtn = document.getElementById('db-view-schema');
+    if (viewSchemaBtn) {
+      viewSchemaBtn.addEventListener('click', () => this.handleViewSchema());
     }
   }
 
@@ -283,6 +331,14 @@ export class DatabaseTab {
    */
   private async handleManageBackups(): Promise<void> {
     this.currentView = 'backup';
+    await this.render();
+  }
+
+  /**
+   * Handle view schema button click (Issue #129)
+   */
+  private async handleViewSchema(): Promise<void> {
+    this.currentView = 'schema';
     await this.render();
   }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -19,6 +19,7 @@
     <!-- Legacy Styles (still needed for content) -->
     <link rel="stylesheet" href="styles/database.css">
     <link rel="stylesheet" href="styles/crud.css">
+    <link rel="stylesheet" href="styles/schema.css">
     <style>
         /* Legacy inline styles for compatibility - most styles now in layout.css */
         .welcome-card {

--- a/src/renderer/services/__tests__/databaseService.test.ts
+++ b/src/renderer/services/__tests__/databaseService.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for databaseService.getCount() (surfaced while implementing Issue
+ * #129, the Database Schema Explorer, whose "record counts" acceptance
+ * criterion depends on it).
+ *
+ * Bug fixed here: getCount() read `result.data.totalCount` (camelCase), but
+ * the MCP database-admin server's db_query_records tool actually returns
+ * `total_count` (snake_case) -- see
+ * MCP-Writing-Servers/src/mcps/database-admin-server/handlers/database-handlers.js
+ * (`{ table, count, total_count, records }`). getCount() therefore always
+ * returned 0 previously. It's also now passed `limit: 1` so the server
+ * computes the count via a cheap COUNT(*) query instead of fetching every
+ * row just to measure the response length.
+ */
+
+import { databaseService } from '../databaseService';
+
+describe('databaseService.getCount', () => {
+  beforeEach(() => {
+    (window as any).electronAPI = {
+      databaseAdmin: {
+        queryRecords: jest.fn(),
+      },
+    };
+  });
+
+  it('passes limit: 1 so the server computes an accurate total via COUNT(*)', async () => {
+    (window as any).electronAPI.databaseAdmin.queryRecords.mockResolvedValue({
+      success: true,
+      data: { table: 'authors', count: 1, total_count: 250, records: [{ id: 1 }] },
+    });
+
+    const count = await databaseService.getCount('authors');
+
+    expect((window as any).electronAPI.databaseAdmin.queryRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ table: 'authors', limit: 1 })
+    );
+    expect(count).toBe(250);
+  });
+
+  it('falls back to totalCount (camelCase) if present', async () => {
+    (window as any).electronAPI.databaseAdmin.queryRecords.mockResolvedValue({
+      success: true,
+      data: { totalCount: 12 },
+    });
+
+    expect(await databaseService.getCount('authors')).toBe(12);
+  });
+
+  it('falls back to count if neither total_count nor totalCount is present', async () => {
+    (window as any).electronAPI.databaseAdmin.queryRecords.mockResolvedValue({
+      success: true,
+      data: { count: 3 },
+    });
+
+    expect(await databaseService.getCount('authors')).toBe(3);
+  });
+
+  it('returns 0 when the query fails', async () => {
+    (window as any).electronAPI.databaseAdmin.queryRecords.mockResolvedValue({
+      success: false,
+      error: 'boom',
+    });
+
+    expect(await databaseService.getCount('authors')).toBe(0);
+  });
+
+  it('forwards the where clause unchanged', async () => {
+    (window as any).electronAPI.databaseAdmin.queryRecords.mockResolvedValue({
+      success: true,
+      data: { total_count: 1 },
+    });
+
+    await databaseService.getCount('authors', { status: 'active' });
+
+    expect((window as any).electronAPI.databaseAdmin.queryRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ table: 'authors', where: { status: 'active' }, limit: 1 })
+    );
+  });
+});

--- a/src/renderer/services/databaseService.ts
+++ b/src/renderer/services/databaseService.ts
@@ -206,9 +206,13 @@ export class DatabaseService {
   }
 
   /**
-   * Get table relationships
+   * Get a table's foreign key relationships (its parents/children).
+   *
+   * `table` is required -- the underlying db_get_relationships MCP tool is
+   * scoped to a single table (there is no "get every relationship in the
+   * database" tool) and rejects a missing/empty table name server-side.
    */
-  async getRelationships(table?: string): Promise<DatabaseOperationResult> {
+  async getRelationships(table: string): Promise<DatabaseOperationResult> {
     return window.electronAPI.databaseAdmin.getRelationships({ table });
   }
 
@@ -254,11 +258,21 @@ export class DatabaseService {
 
   /**
    * Get count of records in a table
+   *
+   * Passes `limit: 1` so the admin server computes an accurate total via a
+   * COUNT(*) query instead of fetching every row just to measure the
+   * response length. Reads `total_count` (the field the MCP database-admin
+   * tool actually returns, e.g. `{ table, count, total_count, records }`),
+   * falling back to `totalCount`/`count` for resilience against older or
+   * alternate response shapes.
    */
   async getCount(table: string, where?: Record<string, any>): Promise<number> {
-    const result = await this.queryRecords({ table, where });
-    if (result.success && result.data?.totalCount !== undefined) {
-      return result.data.totalCount;
+    const result = await this.queryRecords({ table, where, limit: 1 });
+    if (result.success && result.data) {
+      const data = result.data;
+      if (data.total_count !== undefined) return data.total_count;
+      if (data.totalCount !== undefined) return data.totalCount;
+      if (data.count !== undefined) return data.count;
     }
     return 0;
   }

--- a/src/renderer/styles/database.css
+++ b/src/renderer/styles/database.css
@@ -286,6 +286,19 @@
   transform: translateX(-3px);
 }
 
+/* Schema Explorer View Styles (Issue #129) */
+.database-schema-view {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.schema-explorer-container {
+  flex: 1;
+  min-height: 500px;
+}
+
 /* Responsive Design */
 @media (max-width: 900px) {
   .database-layout {

--- a/src/renderer/styles/schema.css
+++ b/src/renderer/styles/schema.css
@@ -139,6 +139,68 @@
 }
 
 /* ===========================
+   Schema Badges & Groups
+   =========================== */
+
+/* Labels each table with the real Postgres schema it lives in (as reported
+   by db_list_tables) -- never assumed to be "public". */
+.schema-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.schema-badge-public {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.schema-badge-fictionlab {
+  background: rgba(0, 212, 170, 0.25);
+  color: #00D4AA;
+  border: 1px solid rgba(0, 212, 170, 0.5);
+}
+
+/* Any other/unknown schema name falls back to an accent color distinct from
+   both public and fictionlab, so a new schema is still visibly labeled. */
+.schema-badge:not(.schema-badge-public):not(.schema-badge-fictionlab) {
+  background: rgba(255, 193, 7, 0.2);
+  color: #FFC107;
+  border: 1px solid rgba(255, 193, 7, 0.5);
+}
+
+.schema-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.schema-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 2px;
+}
+
+.schema-group-count {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.table-details-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* ===========================
    Table List
    =========================== */
 
@@ -189,9 +251,14 @@
   margin-top: 6px;
   padding-top: 6px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.record-count {
+.record-count,
+.column-count,
+.table-size {
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.7);
 }


### PR DESCRIPTION
## Summary

Issue #129 asked for a Database Schema Explorer UI: table list with search
and record counts, table details (columns/keys/indexes/sample data), and an
interactive ERD.

PR #200's audit found `SchemaExplorer`/`TableDetails`/`RelationshipDiagram`
already existed under `src/renderer/components/DatabaseAdmin/Schema/` as
unwired scaffolding (from commit `3ec4248`) — not imported anywhere outside
their own directory. This PR wires that scaffolding in and fixes several
correctness bugs the scaffolding never surfaced, because nothing had ever
exercised it against the real MCP database-admin server:

- **`db_list_tables` returns table objects, not name strings.** It returns
  `{ name, schema, type, column_count, size_human, ... }` per table (schema
  is only shown as a prefix in `name` for non-public schemas). The original
  scaffolding treated each entry as if it were already a bare name string, so
  every per-table lookup (record count, schema load) was silently broken.
  Tables are now grouped and badged by the schema the backend actually
  reports (e.g. "fictionlab") instead of assuming "public" — per the DB
  facts for this issue, the live database has real tables outside `public`.
- **`db_get_schema`'s `constraints` is a grouped object
  (`{ primary_key: [...], foreign_key: [...] }`), not an iterable array.**
  `TableDetails`/`RelationshipDiagram` crashed with `TypeError: constraints
  is not iterable` as soon as a table with real constraints was selected —
  this reproduced with a single click in the test suite. Primary/foreign key
  badges are now resolved from the real shape, with an honest
  `"(target not reported by server)"` instead of inventing a foreign-key
  reference target the server's `db_get_schema` query doesn't actually join
  for.
- **`db_get_relationships` is scoped to one table and requires `table`.**
  It returns `{ table, parents, children }` for a single table — there is no
  bulk "every relationship in the database" tool. The scaffolding called it
  with no table at all, which the server would reject, and then looked for a
  `.relationships` field that doesn't exist in the response either way. The
  ERD now loads relationships (and schemas) for the focused table's
  neighborhood, matching the tool's actual per-table shape.
- **`databaseService.getCount()` read the wrong field.** It read
  `result.data.totalCount` (camelCase) with no `limit`, but the admin server
  returns `total_count` (snake_case) and only computes it cheaply when a
  `limit` is passed — otherwise it fetches every row just to measure the
  response length. Fixed to pass `limit: 1` and read `total_count` (with
  fallbacks). This was silently returning 0 for every table's record count.
- **`schema.css` existed but was never linked from `index.html`** — added.

## What this PR changes

- `src/renderer/components/DatabaseAdmin/Schema/{SchemaExplorer,TableDetails,RelationshipDiagram}.ts` —
  bug fixes above, schema-accurate labeling/grouping, per-table-scoped ERD
  relationship loading.
- `src/renderer/components/DatabaseAdmin/Schema/schema-utils.ts` (new) —
  shared `parseQualifiedTableName()` helper (avoids a circular import between
  `SchemaExplorer` and `TableDetails`).
- `src/renderer/services/databaseService.ts` — `getCount()` field-name fix;
  `getRelationships(table)` made required (it always was, server-side).
- `src/renderer/components/DatabaseTab.ts` — **minimal, additive** change:
  one new "Schema" quick-action button + `renderSchemaView()`, mirroring the
  existing "Backups" button/view pattern exactly, since #128 (batch ops) and
  #130 (backup UI) are concurrently wiring into this same shared container.
- `src/renderer/index.html`, `src/renderer/styles/{database,schema}.css` —
  link `schema.css`; small additive CSS for schema badges/groups and the new
  view container.
- Unit tests (mock DB/IPC) for all of the above, including regression tests
  for the crash/shape-mismatch bugs found while implementing this.

## Out of scope (flagged, not touched)

- `databaseService.listColumns()` calls MCP tool name `db_list_columns`, but
  the server registers `db_list_table_columns` — a real mismatch, but it's
  only used by the Batch (#128) components, not Schema, so left alone to
  avoid colliding with that concurrent work.
- `db_get_schema`'s foreign-key constraints don't include the referenced
  table/column (the query doesn't join `constraint_column_usage`) — a
  MCP-Writing-Servers (separate repo) limitation, shown honestly in the UI
  rather than worked around here.

## Test plan

- [x] `npm run build` — clean (`tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json`)
- [x] New/updated tests: `npx jest src/renderer/components/DatabaseAdmin/Schema/__tests__ src/renderer/services/__tests__/databaseService.test.ts` — 43/43 passing
- [x] Full `npx jest` — 616 passed / 25 failed / 3 skipped, vs. baseline (before this change) of ~520 passed / 25 failed / 3 skipped — same pre-existing failures (issue #176, all in unrelated `llm/`, `build-orchestrator`, `repository-manager`, `*.a11y` suites), zero new failures
- [ ] Visual/manual verification — this session has no GUI. Rebecca, please verify once built:
  - [ ] Database tab → "Schema" quick-action button appears next to "Backups"
  - [ ] Clicking it shows a table list sidebar grouped by schema, with a colored badge per group (e.g. "fictionlab" vs "public") and a "Back to Overview" button
  - [ ] Each table row shows record count / column count / size
  - [ ] Selecting a table shows Columns / Keys / Indexes / Sample Data tabs, with PRIMARY KEY / FOREIGN KEY badges on the right columns
  - [ ] Switching to "ERD" view renders the selected table plus its directly related tables as boxes with a connecting line, with working zoom in/out/reset buttons and mouse-drag panning
  - [ ] No console errors when clicking through tables, especially ones with foreign keys (this used to throw a "constraints is not iterable" crash)

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)