### PR TITLE
Playwright Electron E2E smoke test gating release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
         run: |
           echo "::warning::Full suite (npm test) has pre-existing failures tracked in issue #176; not blocking this release build. The required gate above (npm run test:ci) covers the currently-green suites and does block on regressions there. See the 'Run full test suite' step log for detail."
 
+      - name: Install Playwright browsers
+        run: |
+          npx playwright install chromium --with-deps
+
+      - name: Run Electron E2E smoke test (issue #208)
+        run: |
+          npm run test:e2e
+
       - name: Build Windows app
         run: npm run package:win
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,12 @@ userlist.txt
 coverage/
 .nyc_output/
 
+# Playwright E2E (issue #208)
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # Optional npm cache directory
 .npm
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Electron smoke test (Issue #208)
+ *
+ * Launches the BUILT app with Playwright's Electron support and asserts that
+ * the main window actually renders. This is the gate that would have caught
+ * the 2026-07-08 blue-screen (#186): a broken renderer ESM import passes
+ * `tsc` and `npm run build` cleanly but produces a dead renderer module graph
+ * at load time - nothing short of actually opening the window and watching
+ * the console catches that class of failure.
+ *
+ * Runs in FICTIONLAB_E2E_SMOKE=1 mode (see src/main/index.ts), which skips the
+ * Docker/Postgres readiness gate, first-run wizard routing, database pool
+ * init, and plugin discovery, and goes straight to the main application
+ * window. That backend is a separate concern from "does the renderer boot" -
+ * see the #187/#208 issue threads. The window must render regardless of
+ * backend availability, matching the pre-any-backend #186 failure mode.
+ *
+ * ELECTRON_RUN_AS_NODE gotcha (shared-store lesson
+ * electron-gui-blocked-in-agent-sessions, 2026-07-07): Claude Code / CI agent
+ * sessions run with ELECTRON_RUN_AS_NODE=1 in the environment. If that var is
+ * inherited by the spawned Electron process, Electron starts in plain-Node
+ * mode and NO window ever opens - the test then hangs or fails mysteriously
+ * on firstWindow(). We must explicitly strip it from the launch env.
+ */
+import { test, expect, _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import * as path from 'path';
+
+const APP_ROOT = path.resolve(__dirname, '..');
+
+function launchEnv(): NodeJS.ProcessEnv {
+  // Copy process.env and explicitly delete ELECTRON_RUN_AS_NODE - do not rely
+  // on it simply being "falsy", an inherited "1" (or any value) short-circuits
+  // Electron's normal bootstrap into plain-Node mode with no window.
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  env.FICTIONLAB_E2E_SMOKE = '1';
+  return env;
+}
+
+let electronApp: ElectronApplication;
+let window: Page;
+let closed = false;
+const consoleErrors: string[] = [];
+const pageErrors: string[] = [];
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  electronApp = await electron.launch({
+    args: ['.'],
+    cwd: APP_ROOT,
+    env: launchEnv(),
+  });
+
+  window = await electronApp.firstWindow({ timeout: 30_000 });
+
+  window.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+  window.on('pageerror', (err) => {
+    pageErrors.push(err.message);
+  });
+
+  // Let the renderer finish its initial boot (Sidebar.initialize(), view
+  // mount, etc.) so any deferred console.error/pageerror has a chance to fire
+  // before we assert on the collected arrays.
+  await window.waitForLoadState('domcontentloaded');
+  await window.waitForTimeout(2_000);
+});
+
+test.afterAll(async () => {
+  if (electronApp && !closed) {
+    await electronApp.close();
+    closed = true;
+  }
+});
+
+test('main window appears with the correct title', async () => {
+  expect(window).toBeTruthy();
+  const title = await window.title();
+  expect(title).toBe('FictionLab');
+});
+
+test('renderer boots with zero console.error / pageerror events', async () => {
+  // This is the assertion that catches the #186-class renderer module-load
+  // failure: tsc/build succeed, but a wrong import (e.g. a named import of a
+  // default export) throws at module-evaluation time and the window is left
+  // blank while the console fills with errors.
+  expect(consoleErrors, `console.error events during load:\n${consoleErrors.join('\n')}`).toEqual([]);
+  expect(pageErrors, `pageerror events during load:\n${pageErrors.join('\n')}`).toEqual([]);
+});
+
+test('sidebar (root UI element) is visible', async () => {
+  const sidebar = window.locator('#sidebar');
+  await expect(sidebar).toBeVisible({ timeout: 10_000 });
+
+  // The Sidebar component renders its nav tree into a `.sidebar-navigation`
+  // element once Sidebar.initialize() completes - confirms the renderer did
+  // real work, not just that an empty shell element exists in index.html.
+  const nav = window.locator('#sidebar .sidebar-navigation');
+  await expect(nav).toBeVisible({ timeout: 10_000 });
+
+  const dashboardItem = window.locator('#sidebar [data-view-id="dashboard"]');
+  await expect(dashboardItem).toBeVisible();
+});
+
+test('app closes cleanly', async () => {
+  // Capture the child process handle before closing - once electronApp.close()
+  // tears down the CDP connection, electronApp.process() is no longer safe to
+  // call.
+  const child = electronApp.process();
+  expect(child.killed).toBe(false);
+
+  await electronApp.close();
+  closed = true;
+
+  // Give the OS a beat to reap the process, then confirm it actually exited
+  // rather than being merely detached (guards against orphaned Electron
+  // processes lingering after the test run).
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  expect(child.killed || child.exitCode !== null).toBe(true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "vm2": "^3.10.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -165,7 +166,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1637,6 +1637,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1869,7 +1885,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2204,7 +2221,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2215,7 +2231,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2435,7 +2450,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2592,6 +2606,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -2611,6 +2626,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -2633,6 +2649,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2648,7 +2665,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -2656,6 +2674,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3013,7 +3032,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3443,6 +3461,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -3563,6 +3582,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -3576,6 +3596,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -3719,7 +3740,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4003,7 +4023,6 @@
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -4096,7 +4115,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4220,6 +4240,7 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -4233,6 +4254,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5430,7 +5452,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -5563,7 +5586,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6775,6 +6797,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -6788,6 +6811,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6803,7 +6827,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -6811,6 +6836,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6876,28 +6902,32 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -6918,7 +6948,8 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -6955,6 +6986,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7522,7 +7554,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -7650,6 +7681,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7718,6 +7796,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7733,6 +7812,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7745,7 +7825,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -7890,7 +7971,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7900,7 +7980,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7913,7 +7992,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-config-file": {
       "version": "6.3.2",
@@ -7963,6 +8043,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -8949,7 +9030,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9292,7 +9372,6 @@
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9418,6 +9497,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -9433,6 +9513,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:integration": "jest --testPathPatterns=integration",
     "test:a11y": "jest --testPathPatterns=a11y",
     "test:a11y:watch": "jest --watch --testPathPatterns=a11y",
-    "test:ci": "jest --config jest.config.ci.cjs"
+    "test:ci": "jest --config jest.config.ci.cjs",
+    "test:e2e": "npm run build && playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
@@ -51,6 +52,7 @@
     "vm2": "^3.10.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright config for the Electron E2E smoke test (Issue #208).
+ *
+ * This is a separate, self-contained test harness from jest (which has never
+ * been configured in this repo - out of scope, see shared-store lesson
+ * mcp-electron-app-jest-never-configured). It only drives e2e/*.spec.ts.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2943,6 +2943,26 @@ app.whenReady().then(async () => {
     app.setAppUserModelId('net.fictionlab.studio');
   }
 
+  // E2E SMOKE TEST MODE (Issue #208): the Playwright smoke test only verifies that
+  // the renderer boots and the window renders without console errors (the #186
+  // blue-screen bug class) - it does not stand up Docker/Postgres. Skip the Docker
+  // readiness gate, first-run wizard routing, database pool init, migrations check,
+  // and plugin discovery entirely and go straight to the main window so the smoke
+  // test isn't blocked by backend prerequisites it never claims to satisfy.
+  if (process.env.FICTIONLAB_E2E_SMOKE === '1') {
+    logWithCategory('info', LogCategory.SYSTEM,
+      'FICTIONLAB_E2E_SMOKE=1 set - skipping Docker/DB/wizard gates, launching main window directly');
+    setupIPC();
+    createMenu();
+    createWindow();
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        createWindow();
+      }
+    });
+    return;
+  }
+
   // CRITICAL: Check Docker before initializing database and MCP client
   // Docker is a core dependency - MCP servers run in Docker containers
   try {

--- a/src/renderer/components/DatabaseAdmin/Schema/SchemaExplorer.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/SchemaExplorer.ts
@@ -9,10 +9,10 @@
  * - Record counts and metadata display
  */
 
-import { databaseService, DatabaseOperationResult } from '../../../services/databaseService';
-import { TableDetails } from './TableDetails';
-import { RelationshipDiagram } from './RelationshipDiagram';
-import { parseQualifiedTableName } from './schema-utils';
+import { databaseService, DatabaseOperationResult } from '../../../services/databaseService.js';
+import { TableDetails } from './TableDetails.js';
+import { RelationshipDiagram } from './RelationshipDiagram.js';
+import { parseQualifiedTableName } from './schema-utils.js';
 
 export { parseQualifiedTableName };
 

--- a/src/renderer/components/DatabaseAdmin/Schema/TableDetails.ts
+++ b/src/renderer/components/DatabaseAdmin/Schema/TableDetails.ts
@@ -9,8 +9,8 @@
  * - Sample data preview
  */
 
-import { databaseService } from '../../../services/databaseService';
-import { parseQualifiedTableName } from './schema-utils';
+import { databaseService } from '../../../services/databaseService.js';
+import { parseQualifiedTableName } from './schema-utils.js';
 
 export interface ColumnInfo {
   name: string;


### PR DESCRIPTION
## Summary
- Adds `e2e/smoke.spec.ts` using Playwright's Electron support (`_electron.launch`) against the **built** app. Asserts: main window appears with the correct title, **zero** `console.error`/`pageerror` events during load (the assertion that catches the #186 blue-screen class of renderer module-load failure), the sidebar (root UI element) is visible, and the app closes cleanly with no orphaned process.
- Adds `npm run test:e2e` (`npm run build && playwright test`).
- Wires the smoke test into `.github/workflows/release.yml`'s Windows build job, running after `npm run build` and before `npm run package:win` (artifact publish), so a broken renderer blocks the release build.
- Adds a `FICTIONLAB_E2E_SMOKE=1` bootstrap branch in `src/main/index.ts` that skips the Docker/Postgres readiness gate, first-run wizard routing, and DB pool init, going straight to the main window. The app has a hard Docker-first launch gate today (`app.whenReady()` blocks on Docker before any window is ever created), and would otherwise never render a window in CI or in an agent session without Docker Desktop running. The #186 bug was a renderer module-load failure that predates any backend dependency, so the smoke test only needs the window to render — this flag makes that possible without standing up Postgres/Docker in CI.
- **Bonus catch**: the smoke test's console-error assertion immediately failed against the current `develop` HEAD (post issue #129/#206 Schema Explorer merge) — `SchemaExplorer.ts` and `TableDetails.ts` had relative imports missing `.js` extensions. `tsc` doesn't require extensions on relative imports (`moduleResolution: node`), but the browser's native ESM loader does, so these modules 404'd and threw real `console.error`s on **every** app launch, not just when navigating to the Database view (they're statically imported into the eager renderer entry graph). Fixed both files (4 import lines total) as part of this PR — this is a live demonstration of exactly the bug class #208 exists to catch.

## Deviations from the spec
- Only wired the E2E gate into the `build-windows` job of `release.yml` (native Electron execution, no `xvfb-run` needed), matching where the existing `npm run test:ci` gate already lives in that file and the repo's stated Windows-primary environment. Did not add it to `build-macos`/`build-linux` in `release.yml`, nor to the separate `.github/workflows/build.yml` PR/push CI matrix (which also runs on `ubuntu-latest`/`macos-latest` and would need `xvfb-run` on Linux) — recommend a follow-up issue if per-PR coverage on all three platforms is wanted; `npm run test:e2e` runs identically there once Playwright browsers are installed.
- Did not add a second "navigate to Kanban view" spec (issue plan step 4, marked "post-#189") — out of scope per the issue's own note.
- jest remains untouched and out of scope per the task brief (never configured in this repo; `npm run test:ci`/`npm test` behavior unchanged).

## Local verification (worktree: `C:/github/MCP-Electron-App-worktrees/issue-208-playwright-e2e`)

**Pass** (`npm run test:e2e`, clean build):
```
Running 4 tests using 1 worker

  ok 1 e2e\smoke.spec.ts:81:5 › main window appears with the correct title (10ms)
  ok 2 e2e\smoke.spec.ts:87:5 › renderer boots with zero console.error / pageerror events (2ms)
  ok 3 e2e\smoke.spec.ts:96:5 › sidebar (root UI element) is visible (48ms)
  ok 4 e2e\smoke.spec.ts:110:5 › app closes cleanly (2.6s)

  4 passed (12.6s)
```
No orphaned Electron processes after the run (`Get-Process *electron*` empty).

**Deliberate-break acceptance check**: temporarily changed `renderer.ts`'s `import { Sidebar } from './components/Sidebar.js'` to `'./components/Sidebar'` (missing extension — the same #186-class break the fix above corrects, and it passes `tsc`/`npm run build` cleanly, confirming it's invisible to the existing gate). Result:
```
Running 4 tests using 1 worker

  ok 1 e2e\smoke.spec.ts:81:5 › main window appears with the correct title (10ms)
  x  2 e2e\smoke.spec.ts:87:5 › renderer boots with zero console.error / pageerror events (3ms)
  -  3 e2e\smoke.spec.ts:96:5 › sidebar (root UI element) is visible
  -  4 e2e\smoke.spec.ts:110:5 › app closes cleanly

  Error: console.error events during load:
  Failed to load resource: net::ERR_FILE_NOT_FOUND
  1 failed
```
Confirmed the smoke test fails specifically on the console-error assertion, exactly as required. Reverted the break afterward (`git diff` on `renderer.ts` is clean).

`ELECTRON_RUN_AS_NODE` was in fact `1` in this agent session, confirming the env-strip in `launchEnv()` is load-bearing here, not theoretical.

## Test plan
- [x] `npm run test:e2e` passes on a clean checkout/build
- [x] Deliberate #186-class break makes the console-error assertion fail
- [x] No orphaned Electron processes after the run
- [x] Release workflow YAML validated (`yaml.safe_load`) and E2E step placed before artifact packaging/upload

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)