### PR TITLE
[Cleanup] Remove the Typing Mind card from Settings > Services

### DIFF
--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -6,7 +6,6 @@
  * - PostgreSQL database management with connection details and real controls
  * - Individual MCP server management (Connector + Writing Servers): status,
  *   port, start/stop/restart, and per-server logs
- * - Typing Mind card: cloud app status via its local MCP Connector dependency
  * - Docker Desktop lifecycle management with real version info
  * - Per-service log viewing (with credential redaction)
  * - Real resource usage monitoring via `docker stats`
@@ -23,7 +22,6 @@ interface ContainerHealth {
 }
 
 interface ServiceUrls {
-  typingMind?: string;
   mcpConnector?: string;
   postgres?: string;
 }
@@ -187,9 +185,6 @@ export class ServicesTab {
 
     // Individual MCP server controls (Connector + Writing Servers)
     this.setupMCPServersListeners();
-
-    // Typing Mind controls
-    this.setupTypingMindListeners();
 
     // Docker Desktop controls
     this.setupDockerListeners();
@@ -501,26 +496,6 @@ export class ServicesTab {
   }
 
   /**
-   * Setup Typing Mind service listeners. Typing Mind itself is a cloud web
-   * app; its lifecycle controls act on the local MCP Connector it depends on.
-   */
-  private setupTypingMindListeners(): void {
-    const startBtn = document.getElementById('typing-mind-start');
-    const stopBtn = document.getElementById('typing-mind-stop');
-    const restartBtn = document.getElementById('typing-mind-restart');
-    const viewLogsBtn = document.getElementById('typing-mind-view-logs');
-    const openBrowserBtn = document.getElementById('typing-mind-open-browser');
-    const configureBtn = document.getElementById('typing-mind-configure');
-
-    if (startBtn) startBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'start'));
-    if (stopBtn) stopBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'stop'));
-    if (restartBtn) restartBtn.addEventListener('click', () => this.handleServiceControl('mcp-connector', 'MCP Connector', 'restart'));
-    if (viewLogsBtn) viewLogsBtn.addEventListener('click', () => this.handleViewLogs('mcp-connector', 'MCP Connector (Typing Mind)'));
-    if (openBrowserBtn) openBrowserBtn.addEventListener('click', () => this.handleOpenTypingMind());
-    if (configureBtn) configureBtn.addEventListener('click', () => this.handleConfigureTypingMind());
-  }
-
-  /**
    * Setup Docker Desktop listeners
    */
   private setupDockerListeners(): void {
@@ -606,7 +581,6 @@ export class ServicesTab {
       await Promise.all([
         this.updatePostgreSQLCard(services, config),
         this.updateMCPServersCard(services),
-        this.updateTypingMindCard(services),
         this.updateDockerCard(),
       ]);
 
@@ -786,48 +760,6 @@ export class ServicesTab {
   }
 
   /**
-   * Update Typing Mind card. Typing Mind is a cloud web app -- its status
-   * reflects the local MCP Connector it depends on.
-   */
-  private async updateTypingMindCard(services: DetailedServiceStatusEntry[]): Promise<void> {
-    try {
-      const connector = this.findService(services, 'mcp-connector');
-      const isUp = this.isServiceUp(connector);
-
-      const badge = document.getElementById('typing-mind-status-badge');
-      if (badge) {
-        if (connector?.status === 'healthy' || connector?.status === 'running') {
-          badge.className = 'service-status-badge status-healthy';
-          badge.textContent = 'Ready';
-        } else if (connector?.status === 'starting') {
-          badge.className = 'service-status-badge status-starting';
-          badge.textContent = 'Starting';
-        } else {
-          badge.className = 'service-status-badge status-offline';
-          badge.textContent = 'Offline';
-        }
-      }
-
-      const urls: ServiceUrls = await window.electronAPI.mcpSystem.getUrls();
-      const urlDisplay = document.getElementById('typing-mind-url-info');
-      if (urlDisplay) {
-        urlDisplay.textContent = urls.typingMind || 'https://www.typingmind.com';
-      }
-
-      const portDisplay = document.getElementById('typing-mind-port-info');
-      if (portDisplay) {
-        portDisplay.textContent = connector?.port !== undefined
-          ? `Connector Port: ${connector.port}`
-          : 'Connector Port: --';
-      }
-
-      this.updateServiceControls('typing-mind', isUp);
-    } catch (error) {
-      console.error('Error updating Typing Mind card:', error);
-    }
-  }
-
-  /**
    * Update Docker Desktop service card
    */
   private async updateDockerCard(): Promise<void> {
@@ -932,48 +864,6 @@ export class ServicesTab {
     } catch (error) {
       console.error('Error checking MCP Servers health:', error);
       this.showNotification('Failed to check health status', 'error');
-    }
-  }
-
-  /**
-   * Handle opening Typing Mind in browser
-   */
-  private async handleOpenTypingMind(): Promise<void> {
-    try {
-      const urls = await window.electronAPI.mcpSystem.getUrls();
-      const url = urls.typingMind || 'https://www.typingmind.com';
-
-      // Use the Typing Mind window opener from the API
-      const result = await window.electronAPI.typingMind.openWindow(url);
-
-      if (result.success) {
-        this.showNotification('Opening Typing Mind...', 'info');
-      } else {
-        this.showNotification(`Failed to open Typing Mind: ${result.error}`, 'error');
-      }
-    } catch (error) {
-      console.error('Error opening Typing Mind:', error);
-      this.showNotification('Failed to open Typing Mind', 'error');
-    }
-  }
-
-  /**
-   * Handle configuring Typing Mind
-   */
-  private async handleConfigureTypingMind(): Promise<void> {
-    try {
-      this.showNotification('Configuring Typing Mind...', 'info');
-
-      const result = await window.electronAPI.typingMind.autoConfigure();
-
-      if (result.success) {
-        this.showNotification('Typing Mind configured successfully!', 'success');
-      } else {
-        this.showNotification(`Configuration failed: ${result.message}`, 'error');
-      }
-    } catch (error) {
-      console.error('Error configuring Typing Mind:', error);
-      this.showNotification('Failed to configure Typing Mind', 'error');
     }
   }
 

--- a/src/renderer/components/__tests__/ServicesTab.test.ts
+++ b/src/renderer/components/__tests__/ServicesTab.test.ts
@@ -44,10 +44,6 @@ interface MockAPI {
   prerequisites: {
     getDockerVersion: jest.Mock;
   };
-  typingMind: {
-    openWindow: jest.Mock;
-    autoConfigure: jest.Mock;
-  };
 }
 
 const CONFIG_FIXTURE = {
@@ -111,7 +107,6 @@ function makeMockAPI(): MockAPI {
       restart: jest.fn().mockResolvedValue({ success: true, message: 'restarted' }),
       getDetailedStatus: jest.fn().mockResolvedValue(makeDetailedStatusFixture()),
       getUrls: jest.fn().mockResolvedValue({
-        typingMind: 'https://www.typingmind.com',
         mcpConnector: 'http://localhost:50880',
         postgres: 'postgres://fictionlab_user:****@localhost:5432/fictionlab',
       }),
@@ -138,10 +133,6 @@ function makeMockAPI(): MockAPI {
     },
     prerequisites: {
       getDockerVersion: jest.fn().mockResolvedValue({ installed: true, running: true, version: '27.4.0' }),
-    },
-    typingMind: {
-      openWindow: jest.fn().mockResolvedValue({ success: true }),
-      autoConfigure: jest.fn().mockResolvedValue({ success: true }),
     },
   };
 }
@@ -192,14 +183,13 @@ describe('Services tab (issue #124)', () => {
     return el;
   }
 
-  it('renders all four service cards, both MCP server rows, and the ports table', async () => {
+  it('renders all three service cards, both MCP server rows, and the ports table', async () => {
     await mountView();
 
     expect(container.textContent).toContain('PostgreSQL Database');
     expect(container.textContent).toContain('MCP Servers');
     expect(container.textContent).toContain('MCP Connector');
     expect(container.textContent).toContain('MCP Writing Servers');
-    expect(container.textContent).toContain('Typing Mind');
     expect(container.textContent).toContain('Docker Desktop');
 
     const portRows = document.querySelectorAll('#ports-table-body tr');
@@ -276,11 +266,6 @@ describe('Services tab (issue #124)', () => {
     button('mcp-connector-stop').click();
     await flushPromises();
     expect(api.mcpSystem.controlService).toHaveBeenCalledWith('mcp-connector', 'stop');
-
-    // Typing Mind's lifecycle buttons act on its local MCP Connector dependency
-    button('typing-mind-restart').click();
-    await flushPromises();
-    expect(api.mcpSystem.controlService).toHaveBeenCalledWith('mcp-connector', 'restart');
   });
 
   it('opens a per-server logs dialog with credentials redacted', async () => {
@@ -307,17 +292,6 @@ describe('Services tab (issue #124)', () => {
 
     expect(api.prerequisites.getDockerVersion).toHaveBeenCalled();
     expect(text('docker-version-info')).toBe('Version: Docker 27.4.0');
-  });
-
-  it('reflects the MCP Connector state on the Typing Mind card and opens the browser', async () => {
-    await mountView();
-
-    expect(text('typing-mind-status-badge')).toBe('Ready');
-    expect(text('typing-mind-port-info')).toBe('Connector Port: 50880');
-
-    button('typing-mind-open-browser').click();
-    await flushPromises();
-    expect(api.typingMind.openWindow).toHaveBeenCalledWith('https://www.typingmind.com');
   });
 
   it('handles the top bar Start All / Stop All / Restart All window events', async () => {

--- a/src/renderer/views/ServicesView.ts
+++ b/src/renderer/views/ServicesView.ts
@@ -4,8 +4,8 @@
  * Implements View interface for ViewRouter compatibility
  *
  * Content rewrite for issue #124 -- detailed per-service controls for
- * PostgreSQL, the two MCP servers (Connector + Writing Servers), Typing
- * Mind, and Docker Desktop, plus the pre-existing Ports settings section.
+ * PostgreSQL, the two MCP servers (Connector + Writing Servers), and
+ * Docker Desktop, plus the pre-existing Ports settings section.
  */
 
 import type { View } from '../components/ViewRouter.js';
@@ -57,7 +57,6 @@ export class ServicesView implements View {
           <div class="service-cards" style="grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px;">
             ${this.renderPostgreSQLCard()}
             ${this.renderMCPServersCard()}
-            ${this.renderTypingMindCard()}
             ${this.renderDockerCard()}
           </div>
 
@@ -204,42 +203,6 @@ export class ServicesView implements View {
 
           <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 8px;">
             <button id="mcp-servers-health-check" class="service-action-btn" title="Check health status of all MCP servers">Health Check</button>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  /**
-   * Typing Mind Card: Typing Mind itself is a cloud web app with nothing
-   * local to run, so its status/start/stop/restart/logs reflect the local
-   * MCP Connector it depends on to reach FictionLab's MCP servers.
-   */
-  private renderTypingMindCard(): string {
-    return `
-      <div class="service-card" style="border: 2px solid rgba(255, 255, 255, 0.2);">
-        <div class="service-card-header">
-          <div class="service-name">
-            <h4>Typing Mind</h4>
-          </div>
-          <span id="typing-mind-status-badge" class="service-status-badge status-offline">Not Configured</span>
-        </div>
-        <div class="service-card-body">
-          <div class="service-info" style="margin-bottom: 15px;">
-            <div class="service-detail" id="typing-mind-url-info">https://www.typingmind.com</div>
-            <div class="service-detail" id="typing-mind-port-info">Connector Port: --</div>
-          </div>
-          <p style="font-size: 0.8rem; opacity: 0.8; margin-bottom: 10px;">
-            Typing Mind runs in the cloud. Start/Stop/Restart and Logs below control the local
-            MCP Connector that Typing Mind talks to.
-          </p>
-          <div class="service-actions" style="display: flex; flex-wrap: wrap; gap: 8px;">
-            <button id="typing-mind-start" class="service-action-btn" title="Start the MCP Connector">Start</button>
-            <button id="typing-mind-stop" class="service-action-btn" title="Stop the MCP Connector">Stop</button>
-            <button id="typing-mind-restart" class="service-action-btn" title="Restart the MCP Connector">Restart</button>
-            <button id="typing-mind-view-logs" class="service-action-btn" title="View MCP Connector logs">View Logs</button>
-            <button id="typing-mind-open-browser" class="service-action-btn" title="Open in browser">Open Browser</button>
-            <button id="typing-mind-configure" class="service-action-btn" title="Configure Typing Mind">Configure</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Removes the redundant Typing Mind card from Settings > Services (`ServicesView.ts`: injection + `renderTypingMindCard()`; `ServicesTab.ts`: listener wiring, `updateTypingMindCard()`, and the now-dead `handleOpenTypingMind()`/`handleConfigureTypingMind()` that were only reachable from this card's buttons)
- Kept `src/main/typingmind-auto-config.ts`, the `typingmind:*` IPC handlers, the preload `typingMind` bridge, and the Dashboard's Open/Configure Typing Mind quick actions — `dashboard-handlers.ts` has its own independent `handleOpenTypingMind`/`handleConfigureTypingMind`, untouched
- Updated `ServicesTab.test.ts` to drop the assertions/mocks tied to the deleted card

## Test plan
- [x] `npm run build` passes
- [x] `npx jest Services` — 2 suites, 15 tests pass
- [x] `npx jest Dashboard` — 2 suites, 22 tests pass (confirms Dashboard's Typing Mind quick actions are untouched)
- [x] Grepped `typing-mind`/`typingMind`/`TypingMind` in `ServicesView.ts` and `ServicesTab.ts` — zero hits
- [x] Grepped `getElementById('typing-mind-*')` repo-wide — only remaining hits are in `dashboard-handlers.ts` (Dashboard's own `typing-mind-card`/`typing-mind-status-icon`/`typing-mind-status-text`, distinct DOM ids from the deleted Services card)
- [ ] Manual: Settings > Services shows PostgreSQL, MCP Servers, Docker Desktop only; Dashboard's Open/Configure Typing Mind buttons still work (not yet manually clicked through the running app)

Full `npx jest` run has 7 pre-existing failing suites (LLM provider adapters, a11y tests, build-orchestrator, repository-manager) unrelated to this change — confirmed untouched by this diff's file scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)