### PR TITLE
fix(sidebar): stop attachEventListeners() from stacking duplicate delegated listeners

### DIFF
--- a/src/renderer/components/Sidebar.ts
+++ b/src/renderer/components/Sidebar.ts
@@ -42,6 +42,15 @@ export class Sidebar {
   private pluginNavItems: Array<{ id: string; label: string; icon: string }> = [];
   private mobileToggleButton: HTMLButtonElement | null = null;
   private readonly MOBILE_BREAKPOINT = 767;
+  // Guards attachEventListeners() against stacking duplicate delegated
+  // listeners. attachEventListeners() is called from 6 places (constructor,
+  // pinned-plugins-changed, pinPlugin, unpinPlugin, updateBadge,
+  // setPluginNavItems) — every call aborts the previous batch of listeners
+  // (container click/keydown, document keydown, window
+  // pinned-plugins-changed) before attaching a fresh one, so exactly one
+  // copy is ever live. Also lets destroy() release the document/window
+  // listeners, which used to leak past destroy(). See issue #211.
+  private eventsController: AbortController | null = null;
 
   // Storage keys
   private readonly STORAGE_ACTIVE_VIEW = 'fictionlab-active-view';
@@ -238,6 +247,12 @@ export class Sidebar {
    * Attach event listeners
    */
   private attachEventListeners(): void {
+    // Abort any listeners attached by a previous call before attaching a
+    // fresh set — prevents the duplicate-listener stacking bug (#211).
+    this.eventsController?.abort();
+    this.eventsController = new AbortController();
+    const { signal } = this.eventsController;
+
     // Navigation item clicks
     this.container.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
@@ -283,7 +298,7 @@ export class Sidebar {
       if (target.closest('[data-action="toggle-collapse"]')) {
         this.toggleCollapse();
       }
-    });
+    }, { signal });
 
     // Keyboard navigation
     this.container.addEventListener('keydown', (e) => {
@@ -307,7 +322,7 @@ export class Sidebar {
           (items[nextIndex] as HTMLElement).focus();
         }
       }
-    });
+    }, { signal });
 
     // Global keyboard shortcuts (Ctrl+1-9)
     document.addEventListener('keydown', (e) => {
@@ -319,14 +334,14 @@ export class Sidebar {
           this.navigateTo(primaryItems[index].id);
         }
       }
-    });
+    }, { signal });
 
     // Listen for pinned plugins changes from PluginsLauncher
     window.addEventListener('pinned-plugins-changed', () => {
       this.pinnedPlugins = this.loadPinnedPlugins();
       this.render();
       this.attachEventListeners();
-    });
+    }, { signal });
   }
 
   /**
@@ -685,6 +700,8 @@ export class Sidebar {
    * Destroy the sidebar
    */
   public destroy(): void {
+    this.eventsController?.abort();
+    this.eventsController = null;
     this.container.innerHTML = '';
     this.listeners.clear();
     this.mobileToggleButton?.remove();

--- a/src/renderer/components/__tests__/Sidebar.test.ts
+++ b/src/renderer/components/__tests__/Sidebar.test.ts
@@ -83,3 +83,115 @@ describe('Sidebar mobile navigation toggle', () => {
     expect(document.querySelector('.mobile-menu-toggle')).toBeNull();
   });
 });
+
+/**
+ * Regression tests for issue #211: attachEventListeners() stacked a fresh
+ * copy of its delegated listeners on every call (constructor,
+ * pinned-plugins-changed, pinPlugin, unpinPlugin, updateBadge,
+ * setPluginNavItems) instead of replacing them. With an even number of
+ * listeners registered, every click toggle ran an even number of times and
+ * canceled itself out — the footer Collapse button and the Settings
+ * submenu both appeared dead. setPluginNavItems() (new in d7738b7) is now
+ * called at startup via renderer.ts's plugin-view sync, so this reliably
+ * reproduced on every boot with any plugin active.
+ */
+describe('Sidebar duplicate event listener regression (#211)', () => {
+  let container: HTMLElement;
+  let sidebar: Sidebar;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<aside id="sidebar"></aside>';
+    container = document.getElementById('sidebar')!;
+    sidebar = new Sidebar({ container, defaultView: 'dashboard' });
+    await sidebar.initialize();
+  });
+
+  afterEach(() => {
+    sidebar.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('toggles the sidebar collapsed state exactly once per click after setPluginNavItems() re-attaches listeners', () => {
+    // Mirrors renderer.ts's startup plugin-view sync, which calls
+    // setPluginNavItems() after construction/initialize().
+    sidebar.setPluginNavItems([]);
+
+    expect(container.classList.contains('collapsed')).toBe(false);
+
+    const collapseButton = container.querySelector('[data-action="toggle-collapse"]');
+    click(collapseButton);
+    expect(container.classList.contains('collapsed')).toBe(true);
+
+    click(collapseButton);
+    expect(container.classList.contains('collapsed')).toBe(false);
+  });
+
+  it('opens and closes the Settings submenu on repeated clicks after setPluginNavItems() re-attaches listeners', () => {
+    sidebar.setPluginNavItems([]);
+
+    const settingsItem = container.querySelector('[data-view-id="settings"]') as HTMLElement;
+    const collapsibleWrapper = settingsItem.parentElement as HTMLElement;
+
+    expect(collapsibleWrapper.classList.contains('expanded')).toBe(false);
+
+    click(settingsItem);
+    expect(collapsibleWrapper.classList.contains('expanded')).toBe(true);
+
+    click(settingsItem);
+    expect(collapsibleWrapper.classList.contains('expanded')).toBe(false);
+  });
+
+  it('still toggles exactly once per click after several plugin state-change cycles (no re-accumulation)', () => {
+    // Simulate repeated plugin-installed/uninstalled/state-change syncs,
+    // each of which calls setPluginNavItems() -> render() +
+    // attachEventListeners() in renderer.ts. Asserted via a spy on the
+    // private toggle handler rather than final class state, so the check
+    // is deterministic regardless of how many re-attach cycles ran
+    // (accumulated-listener counts can otherwise land on an odd number and
+    // coincidentally reproduce the correct end state).
+    sidebar.setPluginNavItems([{ id: 'kanban', label: 'Kanban', icon: '🗂️' }]);
+    sidebar.setPluginNavItems([]);
+    sidebar.setPluginNavItems([{ id: 'kanban', label: 'Kanban', icon: '🗂️' }]);
+    sidebar.pinPlugin('kanban');
+    sidebar.unpinPlugin('kanban');
+    sidebar.updateBadge('dashboard', 3);
+
+    const toggleCollapseSpy = jest.spyOn(sidebar as any, 'toggleCollapse');
+    const collapseButton = container.querySelector('[data-action="toggle-collapse"]');
+    click(collapseButton);
+
+    expect(toggleCollapseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits exactly one navigate event per nav item click', () => {
+    sidebar.setPluginNavItems([]);
+
+    const navigateSpy = jest.fn();
+    sidebar.on('navigate', navigateSpy);
+
+    const dashboardItem = container.querySelector('[data-view-id="dashboard"]');
+    click(dashboardItem);
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledWith('dashboard');
+  });
+
+  it('does not leak the document-level Ctrl+1-9 keydown listener past destroy()', () => {
+    sidebar.setPluginNavItems([]);
+
+    // Spy on the private navigateTo handler directly, rather than going
+    // through the public `on('navigate', ...)` listener map — destroy()
+    // clears that map unconditionally, which would make this assertion
+    // pass even if the underlying document keydown listener were still
+    // leaking (the actual bug being regression-tested here).
+    const navigateToSpy = jest.spyOn(sidebar as any, 'navigateTo');
+
+    sidebar.destroy();
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '1', ctrlKey: true, bubbles: true })
+    );
+
+    expect(navigateToSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Root cause

`Sidebar.attachEventListeners()` (`src/renderer/components/Sidebar.ts`) is called from 6 places — constructor, the `pinned-plugins-changed` handler, `pinPlugin`, `unpinPlugin`, `updateBadge`, and (new in d7738b7) `setPluginNavItems` — and never removed the listeners from the previous call. Every invocation added another copy of the container `click`/`keydown` delegated listeners, the document-level Ctrl+1-9 `keydown` listener, and the window `pinned-plugins-changed` listener.

With an even number of stacked listeners, every click toggle canceled itself out:
- **Collapse button:** each listener toggles the `collapsed` class, so N listeners toggle it N times per click.
- **Settings submenu:** listener 1 reads `isExpanded` and flips it; listener 2 re-reads the now-changed class and flips it right back — net freeze.

This bug was latent until `renderer.ts` started calling `sidebar.setPluginNavItems(...)` during the startup plugin-view sync (introduced in d7738b7 / #210), which guarantees at least 2 attach cycles on every boot with a plugin active.

## Fix

Hold an `AbortController` on the instance. Pass its `signal` to all four `addEventListener` calls (container click, container keydown, document keydown, window `pinned-plugins-changed`). At the top of `attachEventListeners()`, `abort()` the previous controller and create a new one before attaching — so every call *replaces* rather than *stacks* the listener set, regardless of which of the 6 call sites triggered it. `destroy()` now also aborts the controller, which incidentally fixes a pre-existing leak where the document-level Ctrl+1-9 handler survived teardown.

`render()` calls are untouched — only listener attachment behavior changed.

## Tests

Added 5 regression tests to `src/renderer/components/__tests__/Sidebar.test.ts`:
- Collapse button toggles exactly once per click after a `setPluginNavItems()` re-attach cycle.
- Settings submenu opens and closes on repeated clicks after a re-attach cycle.
- No re-accumulation across several plugin state-change calls (`setPluginNavItems` / `pinPlugin` / `unpinPlugin` / `updateBadge`) — verified via a spy on the private `toggleCollapse` handler rather than final DOM state, since accumulated-listener-count parity can otherwise coincidentally land on the "correct-looking" end state.
- Exactly one `navigate` event emitted per nav item click.
- No leaked Ctrl+1-9 document listener after `destroy()` — verified via a spy on the private `navigateTo` handler rather than the public `on()` listener map, since `destroy()` unconditionally clears that map regardless of whether the underlying document listener actually leaked.

Sanity-checked by reverting the `Sidebar.ts` fix (`git stash`) and confirming all 5 new tests fail deterministically against the unfixed code, then restoring the fix and confirming all 11 tests pass.

- `npm run build` — passes
- `npx jest Sidebar` — 11/11 passing
- Full `npx jest` — pre-existing failures only in unrelated suites (LLM adapters, provider-manager, repository-manager/git, ProviderSelector/VariableBrowser a11y), none touched by this change.

## Deviations from spec

None. Used the AbortController approach (spec's "more robust for destroy()" option) rather than the attach-once guard, since it also fixes the document-listener leak the spec flagged as pre-existing. `render()` calls and all 6 `attachEventListeners()` call sites were left in place per the spec — they're now idempotent by construction rather than needing removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)