### PR TITLE
feat(updates): check for FictionLab app updates via GitHub Releases

### DIFF
--- a/src/main/__tests__/app-updater.test.ts
+++ b/src/main/__tests__/app-updater.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for src/main/app-updater.ts (issue #213).
+ *
+ * Covers the two load-bearing pieces: the local semver-ish `compareVersions`
+ * helper (no dependency, per the issue), and the `no-releases` branch of
+ * `checkForAppUpdate` -- the 404-from-GitHub-Releases path that is NOT an
+ * error and is, as of 2026-07-10, the only path that will actually run in
+ * production (the repo has zero published releases). `fetch` is mocked so
+ * these run offline and deterministically.
+ */
+
+jest.mock('electron', () => ({
+  app: { getVersion: jest.fn(() => '0.1.0') },
+}));
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+  LogCategory: { SYSTEM: 'SYSTEM' },
+  logWithCategory: jest.fn(),
+}));
+
+import { checkForAppUpdate, compareVersions } from '../app-updater';
+
+describe('compareVersions', () => {
+  it.each([
+    ['1.2.3', '1.2.3', 0],
+    ['1.2.4', '1.2.3', 1],
+    ['1.2.3', '1.2.4', -1],
+    ['2.0.0', '1.9.9', 1],
+    ['1.9.9', '2.0.0', -1],
+    ['1.3.0', '1.2.9', 1],
+  ])('compareVersions(%s, %s) === %i', (a, b, expected) => {
+    expect(compareVersions(a, b)).toBe(expected);
+  });
+
+  it('strips a leading "v" from either argument', () => {
+    expect(compareVersions('v1.2.3', '1.2.3')).toBe(0);
+    expect(compareVersions('1.2.3', 'v1.2.3')).toBe(0);
+    expect(compareVersions('v2.0.0', 'v1.0.0')).toBe(1);
+  });
+
+  it('treats missing/non-numeric segments as 0 rather than throwing', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1', '1.0.0')).toBe(0);
+    expect(compareVersions('1.2.3-beta', '1.2.3')).toBe(0);
+  });
+});
+
+describe('checkForAppUpdate', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('returns status "no-releases" (not an error) on a 404 from the releases API', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    }) as any;
+
+    const result = await checkForAppUpdate(() => '0.1.0');
+
+    expect(result).toEqual({ status: 'no-releases', currentVersion: '0.1.0' });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('passes a User-Agent header (required by the GitHub API)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+    global.fetch = fetchMock as any;
+
+    await checkForAppUpdate(() => '0.1.0');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/MCP-Electron-App/releases/latest',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'MCP-Electron-App' }),
+      })
+    );
+  });
+
+  it('returns "update-available" when the latest tag is newer than the current version', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        tag_name: 'v0.2.0',
+        html_url: 'https://github.com/RLRyals/MCP-Electron-App/releases/tag/v0.2.0',
+        body: 'Release notes here',
+        published_at: '2026-07-01T00:00:00Z',
+        assets: [{ name: 'FictionLab-Setup.exe', browser_download_url: 'https://example.com/setup.exe', size: 12345 }],
+      }),
+    }) as any;
+
+    const result = await checkForAppUpdate(() => '0.1.0');
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('0.2.0');
+    expect(result.releaseUrl).toBe('https://github.com/RLRyals/MCP-Electron-App/releases/tag/v0.2.0');
+    expect(result.releaseNotes).toBe('Release notes here');
+    expect(result.assets).toEqual([
+      { name: 'FictionLab-Setup.exe', downloadUrl: 'https://example.com/setup.exe', size: 12345 },
+    ]);
+  });
+
+  it('returns "up-to-date" when the latest tag equals the current version', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tag_name: 'v0.1.0' }),
+    }) as any;
+
+    const result = await checkForAppUpdate(() => '0.1.0');
+
+    expect(result.status).toBe('up-to-date');
+    expect(result.latestVersion).toBe('0.1.0');
+  });
+
+  it('returns a graceful "error" status (never throws) on a network failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as any;
+
+    const result = await checkForAppUpdate(() => '0.1.0');
+
+    expect(result.status).toBe('error');
+    expect(result.currentVersion).toBe('0.1.0');
+    expect(result.error).toMatch(/network down/);
+  });
+
+  it('returns a rate-limit-specific error message on a 403', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden' }) as any;
+
+    const result = await checkForAppUpdate(() => '0.1.0');
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/rate limit/i);
+  });
+});

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -1,0 +1,169 @@
+/**
+ * App Updater Module (issue #213)
+ *
+ * Checks GitHub Releases for the MCP-Electron-App (FictionLab) repo itself,
+ * as opposed to `./updater.ts` which checks the MCP-Writing-Servers repo's
+ * git commits + Docker images. These are deliberately kept separate: this
+ * module answers "is there a newer installer build than the one I'm
+ * running", not "are my MCP servers stale".
+ *
+ * As of 2026-07-10 the repo has zero published releases/tags -- the GitHub
+ * Releases API returns 404 for `/releases/latest` in that case, which is
+ * NOT an error. It's the expected, first-class "no-releases" state that
+ * will actually be hit every time this runs until the repo owner publishes
+ * a `v*.*.*` tag. Callers must treat it as a normal status, not a failure.
+ *
+ * v1 scope: check + notify + link to the release page. No electron-updater,
+ * no silent auto-download/auto-install.
+ */
+import { app } from 'electron';
+import logger, { logWithCategory, LogCategory } from './logger';
+
+const APP_REPO = 'RLRyals/MCP-Electron-App';
+const RELEASES_LATEST_URL = `https://api.github.com/repos/${APP_REPO}/releases/latest`;
+
+export type AppUpdateStatus = 'up-to-date' | 'update-available' | 'no-releases' | 'error';
+
+export interface ReleaseAsset {
+  name: string;
+  downloadUrl: string;
+  size?: number;
+}
+
+export interface AppUpdateCheckResult {
+  status: AppUpdateStatus;
+  currentVersion: string;
+  latestVersion?: string;
+  releaseUrl?: string;
+  releaseNotes?: string;
+  publishedAt?: string;
+  assets?: ReleaseAsset[];
+  error?: string;
+}
+
+/**
+ * Strip a leading "v" (e.g. "v1.2.3" -> "1.2.3"). Also trims whitespace.
+ */
+function stripLeadingV(version: string): string {
+  const trimmed = version.trim();
+  return trimmed.startsWith('v') || trimmed.startsWith('V') ? trimmed.slice(1) : trimmed;
+}
+
+/**
+ * Parse a semver-ish "x.y.z" string into its numeric parts. Non-numeric or
+ * missing segments are treated as 0 so partial versions ("1.2") still
+ * compare sanely instead of throwing. Pre-release/build metadata
+ * (anything after '-' or '+') is dropped for comparison purposes -- this
+ * repo only ever tags plain `v*.*.*` releases (see release.yml), so a
+ * fuller semver-precedence implementation isn't needed.
+ */
+function parseVersionParts(version: string): [number, number, number] {
+  const core = stripLeadingV(version).split(/[-+]/)[0];
+  const parts = core.split('.').map((part) => {
+    const n = parseInt(part, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * Compare two version strings, ignoring a leading "v".
+ * Returns 1 if `a` > `b`, -1 if `a` < `b`, 0 if equal.
+ * Intentionally small and local -- no new dependency, per issue #213.
+ */
+export function compareVersions(a: string, b: string): number {
+  const [aMajor, aMinor, aPatch] = parseVersionParts(a);
+  const [bMajor, bMinor, bPatch] = parseVersionParts(b);
+
+  if (aMajor !== bMajor) return aMajor > bMajor ? 1 : -1;
+  if (aMinor !== bMinor) return aMinor > bMinor ? 1 : -1;
+  if (aPatch !== bPatch) return aPatch > bPatch ? 1 : -1;
+  return 0;
+}
+
+/**
+ * Check GitHub Releases for a newer published build of this app than the
+ * one currently running. Never throws -- all failure paths (network error,
+ * malformed response, rate limiting) resolve to `{ status: 'error' }` so
+ * callers can render a graceful message instead of an unhandled rejection.
+ */
+export async function checkForAppUpdate(
+  getCurrentVersion: () => string = () => app.getVersion()
+): Promise<AppUpdateCheckResult> {
+  const currentVersion = getCurrentVersion();
+
+  try {
+    logWithCategory('info', LogCategory.SYSTEM, `Checking for FictionLab app updates (current: ${currentVersion})...`);
+
+    const response = await fetch(RELEASES_LATEST_URL, {
+      headers: {
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'MCP-Electron-App',
+      },
+    });
+
+    if (response.status === 404) {
+      // Expected steady-state until the first release is tagged -- not an error.
+      logWithCategory('info', LogCategory.SYSTEM, 'No published releases found for the app repo yet.');
+      return { status: 'no-releases', currentVersion };
+    }
+
+    if (!response.ok) {
+      if (response.status === 403) {
+        return {
+          status: 'error',
+          currentVersion,
+          error: 'GitHub API rate limit exceeded. Please try again later.',
+        };
+      }
+      return {
+        status: 'error',
+        currentVersion,
+        error: `GitHub API error: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const release = await response.json();
+    const tagName: string | undefined = release?.tag_name;
+
+    if (!tagName) {
+      return {
+        status: 'error',
+        currentVersion,
+        error: 'Latest release response did not include a tag_name.',
+      };
+    }
+
+    const latestVersion = stripLeadingV(tagName);
+    const releaseUrl: string | undefined = release?.html_url;
+    const releaseNotes: string | undefined = release?.body || undefined;
+    const publishedAt: string | undefined = release?.published_at || undefined;
+    const assets: ReleaseAsset[] | undefined = Array.isArray(release?.assets)
+      ? release.assets.map((asset: any) => ({
+          name: asset?.name,
+          downloadUrl: asset?.browser_download_url,
+          size: asset?.size,
+        }))
+      : undefined;
+
+    const status: AppUpdateStatus =
+      compareVersions(latestVersion, currentVersion) > 0 ? 'update-available' : 'up-to-date';
+
+    return {
+      status,
+      currentVersion,
+      latestVersion,
+      releaseUrl,
+      releaseNotes,
+      publishedAt,
+      assets,
+    };
+  } catch (error: any) {
+    logger.error('Error checking for FictionLab app updates:', error);
+    return {
+      status: 'error',
+      currentVersion,
+      error: error?.message || String(error),
+    };
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ import * as mcpSystem from './mcp-system';
 import * as databaseBackup from './database-backup';
 import * as databaseAdmin from './database-admin';
 import * as updater from './updater';
+import * as appUpdater from './app-updater';
 import * as setupWizard from './setup-wizard';
 import * as appSettings from './app-settings';
 import type { CurrentUserSetting } from '../types/identity';
@@ -1338,6 +1339,12 @@ function setupIPC(): void {
   registerHandler('updater:set-preferences', "", async (_, prefs: updater.UpdatePreferences) => {
     logWithCategory('info', LogCategory.SYSTEM, 'IPC: Setting update preferences...');
     return await updater.setUpdatePreferences(prefs);
+  });
+
+  // App Update IPC handler (issue #213 -- FictionLab app self-update check via GitHub Releases)
+  registerHandler('updates:check-for-updates', "", async () => {
+    logWithCategory('info', LogCategory.SYSTEM, 'IPC: Checking for FictionLab app updates...');
+    return await appUpdater.checkForAppUpdate();
   });
 
   // App Settings IPC handlers (issue #181 -- configured current-user identity)

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -488,6 +488,21 @@ interface UpdateProgress {
 }
 
 /**
+ * FictionLab app self-update check result (issue #213 -- GitHub Releases,
+ * distinct from the MCP-Writing-Servers `UpdateCheckResult` above).
+ */
+interface AppUpdateCheckResult {
+  status: 'up-to-date' | 'update-available' | 'no-releases' | 'error';
+  currentVersion: string;
+  latestVersion?: string;
+  releaseUrl?: string;
+  releaseNotes?: string;
+  publishedAt?: string;
+  assets?: Array<{ name: string; downloadUrl: string; size?: number }>;
+  error?: string;
+}
+
+/**
  * Wizard step enum
  */
 enum WizardStep {
@@ -1842,6 +1857,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     removeCheckListeners: (): void => {
       ipcRenderer.removeAllListeners('updater:check-complete');
       ipcRenderer.removeAllListeners('updater:auto-check-complete');
+    },
+  },
+
+  /**
+   * App Update API (issue #213 -- FictionLab app self-update check via
+   * GitHub Releases on this repo, separate from the `updater` namespace
+   * above which checks MCP-Writing-Servers)
+   */
+  updates: {
+    /**
+     * Check GitHub Releases for a newer published build of this app
+     */
+    checkForUpdates: (): Promise<AppUpdateCheckResult> => {
+      return ipcRenderer.invoke('updates:check-for-updates');
     },
   },
 

--- a/src/renderer/components/SetupTab.ts
+++ b/src/renderer/components/SetupTab.ts
@@ -23,11 +23,19 @@ interface AllPrerequisitesResult {
   platform: string;
 }
 
-interface UpdateCheckResult {
-  hasUpdate: boolean;
+/**
+ * FictionLab app self-update check result (issue #213). Mirrors
+ * `AppUpdateCheckResult` from src/main/app-updater.ts / the preload bridge.
+ */
+interface AppUpdateCheckResult {
+  status: 'up-to-date' | 'update-available' | 'no-releases' | 'error';
   currentVersion: string;
   latestVersion?: string;
-  message: string;
+  releaseUrl?: string;
+  releaseNotes?: string;
+  publishedAt?: string;
+  assets?: Array<{ name: string; downloadUrl: string; size?: number }>;
+  error?: string;
 }
 
 interface GitPullResult {
@@ -350,10 +358,10 @@ async function handleCheckFictionLabUpdates(): Promise<void> {
       statusDiv.style.color = '#FFB84D';
     }
 
-    // Check if update API is available
-    if (!(window.electronAPI as any).updates?.checkForUpdates) {
+    // Guard for renderer builds/tests running against an older preload that
+    // hasn't picked up the `updates` bridge yet.
+    if (!window.electronAPI.updates?.checkForUpdates) {
       const version = await window.electronAPI.getAppVersion();
-      showNotification('Automatic update checking not yet implemented', 'info');
       if (statusDiv) {
         statusDiv.textContent = `Current version: ${version} - Check GitHub for latest releases`;
         statusDiv.style.color = '#FFB84D';
@@ -363,23 +371,40 @@ async function handleCheckFictionLabUpdates(): Promise<void> {
 
     showNotification('Checking for FictionLab updates...', 'info');
 
-    // Check for FictionLab updates
-    const result = await (window.electronAPI as any).updates.checkForUpdates();
+    const result = (await window.electronAPI.updates.checkForUpdates()) as AppUpdateCheckResult;
 
-    if (result.hasUpdate) {
-      if (statusDiv) {
-        statusDiv.textContent = `Update available: ${result.latestVersion}`;
-        statusDiv.style.color = '#FFB84D';
-      }
+    switch (result.status) {
+      case 'no-releases':
+        if (statusDiv) {
+          statusDiv.textContent = `No published releases yet — current version ${result.currentVersion}`;
+          statusDiv.style.color = '#FFB84D';
+        }
+        break;
 
-      // Show update dialog
-      showUpdateDialog(result);
-    } else {
-      showNotification('FictionLab is up to date!', 'success');
-      if (statusDiv) {
-        statusDiv.textContent = `Up to date (${result.currentVersion})`;
-        statusDiv.style.color = '#00D4AA';
-      }
+      case 'update-available':
+        if (statusDiv) {
+          statusDiv.textContent = `Update available: ${result.latestVersion}`;
+          statusDiv.style.color = '#FFB84D';
+        }
+        showUpdateDialog(result);
+        break;
+
+      case 'up-to-date':
+        showNotification('FictionLab is up to date!', 'success');
+        if (statusDiv) {
+          statusDiv.textContent = `You're up to date (${result.currentVersion})`;
+          statusDiv.style.color = '#00D4AA';
+        }
+        break;
+
+      case 'error':
+      default:
+        showNotification(`Failed to check for updates: ${result.error || 'Unknown error'}`, 'error');
+        if (statusDiv) {
+          statusDiv.textContent = `Failed to check for updates: ${result.error || 'Unknown error'}`;
+          statusDiv.style.color = '#f44336';
+        }
+        break;
     }
 
   } catch (error) {
@@ -398,9 +423,12 @@ async function handleCheckFictionLabUpdates(): Promise<void> {
 /**
  * Show update dialog for FictionLab
  */
-function showUpdateDialog(updateInfo: UpdateCheckResult): void {
+function showUpdateDialog(updateInfo: AppUpdateCheckResult): void {
   const dialog = document.createElement('div');
   dialog.className = 'error-dialog'; // Reuse error dialog styles
+  const notesHtml = updateInfo.releaseNotes
+    ? `<p><strong>Release Notes:</strong></p><pre class="error-stack">${escapeHtml(updateInfo.releaseNotes)}</pre>`
+    : '';
   dialog.innerHTML = `
     <div class="error-dialog-backdrop"></div>
     <div class="error-dialog-content">
@@ -408,9 +436,9 @@ function showUpdateDialog(updateInfo: UpdateCheckResult): void {
       <p>A new version of FictionLab is available!</p>
       <p><strong>Current Version:</strong> ${updateInfo.currentVersion}</p>
       <p><strong>Latest Version:</strong> ${updateInfo.latestVersion}</p>
-      <p>${updateInfo.message}</p>
+      ${notesHtml}
       <div class="error-dialog-buttons">
-        <button id="download-update" class="button primary">Download Update</button>
+        <button id="download-update" class="button primary">View Release</button>
         <button id="close-update-dialog" class="button">Later</button>
       </div>
     </div>
@@ -424,9 +452,14 @@ function showUpdateDialog(updateInfo: UpdateCheckResult): void {
 
   if (downloadButton) {
     downloadButton.addEventListener('click', () => {
-      // Note: Electron app self-updates are not yet implemented
-      // Users should download updates manually from the releases page
-      showNotification('Please download the latest version from the releases page', 'info');
+      // v1 scope: no in-app installer download, just open the release page
+      // in the default browser via the existing app:open-external channel
+      // (the same http(s)-only gate used by Kanban card links, issue #198).
+      if (updateInfo.releaseUrl) {
+        void (window.electronAPI as any).invoke('app:open-external', updateInfo.releaseUrl);
+      } else {
+        showNotification('No release URL available', 'error');
+      }
       document.body.removeChild(dialog);
     });
   }
@@ -436,6 +469,16 @@ function showUpdateDialog(updateInfo: UpdateCheckResult): void {
       document.body.removeChild(dialog);
     });
   }
+}
+
+/**
+ * Minimal HTML-escape for interpolating untrusted release-notes text into
+ * the dialog's innerHTML.
+ */
+function escapeHtml(value: string): string {
+  const div = document.createElement('div');
+  div.textContent = value;
+  return div.innerHTML;
 }
 
 /**

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -449,6 +449,18 @@ interface ElectronAPI {
     onAutoCheckComplete: (callback: (result: any) => void) => void;
     removeCheckListeners: () => void;
   };
+  updates?: {
+    checkForUpdates: () => Promise<{
+      status: 'up-to-date' | 'update-available' | 'no-releases' | 'error';
+      currentVersion: string;
+      latestVersion?: string;
+      releaseUrl?: string;
+      releaseNotes?: string;
+      publishedAt?: string;
+      assets?: Array<{ name: string; downloadUrl: string; size?: number }>;
+      error?: string;
+    }>;
+  };
 }
 
 // Access the API exposed through preload script


### PR DESCRIPTION
## Summary
- Adds `src/main/app-updater.ts`: `checkForAppUpdate()` hits `GET /repos/RLRyals/MCP-Electron-App/releases/latest` (with the required `User-Agent` header) and returns `{ status, currentVersion, latestVersion?, releaseUrl?, releaseNotes?, publishedAt?, assets?, error? }`. A 404 (no releases published yet) resolves to `status: 'no-releases'` as a first-class, non-error result — this is the path that will actually run in production today, since the repo has zero tagged releases. Semver comparison (`compareVersions`) is a small local helper, strips a leading `v`, and treats missing/non-numeric segments as `0`; no new dependency was added.
- Registers `ipcMain.handle('updates:check-for-updates', ...)` in `src/main/index.ts`, right next to the existing `updater:*` handlers. Left `src/main/updater.ts` (MCP-Writing-Servers checker) untouched.
- Exposes the `updates: { checkForUpdates }` namespace in `src/preload/preload.ts`, next to the `updater` bridge — this is exactly what `SetupTab.ts:353` was already guarding on, so the renderer's existing call path lights up without further plumbing.
- Updates `handleCheckFictionLabUpdates` / `showUpdateDialog` in `src/renderer/components/SetupTab.ts` to render the three real statuses instead of the old "not yet implemented" toast:
  - `no-releases` → amber "No published releases yet — current version X.Y.Z"
  - `update-available` → the existing update dialog, now showing release notes, with its action button opening `releaseUrl` via the existing `app:open-external` IPC channel (same http(s)-only gate used by Kanban card links, issue #198)
  - `up-to-date` → "You're up to date (X.Y.Z)"
  - `error` → status text + toast with the underlying message, no unhandled rejection
- Skipped the optional Help-menu wiring (index.ts:211-225) per the issue's "skip if it complicates the change" guidance — the two entry points can be unified in a follow-up if desired.
- No `electron-updater`, no silent auto-download/auto-install — v1 is check + notify + link, per the issue's stated scope.

## Test plan
- [x] `npm run build` passes (tsc renderer + main + asset copy)
- [x] New unit tests in `src/main/__tests__/app-updater.test.ts` (14 tests): `compareVersions` semver-ish comparisons (equal/newer/older, leading `v`, missing/non-numeric segments) and `checkForAppUpdate` branches (no-releases on 404, User-Agent header present, update-available, up-to-date, network-error → graceful `error` status never throws, 403 rate-limit message)
- [x] `src/renderer/views/__tests__/SetupView.test.ts` (Setup tab UI) still passes
- [x] Full suite run: 651 passing / 25 failing, all 25 failures pre-existing and unrelated (LLM provider/adapter tests, a11y snapshot tests, and git/build-orchestrator tests that time out on network/filesystem — none touch app-updater, the new IPC handler, preload, or SetupTab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)