### PR TITLE
chore: bump version to 0.2.0 for first tagged release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fictionlab",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fictionlab",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fictionlab",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI-powered writing workspace for authors - your creative laboratory",
   "main": "dist/main/index.js",
   "author": "FictionLab",


### PR DESCRIPTION
Bumps package.json/package-lock.json to 0.2.0.

Why: the new update checker (#213, merged in #218) compares GitHub release tags against `app.getVersion()`. The repo has never published a release; to make the checker meaningful, the first tagged release must ship a build whose embedded version matches its tag. Merging this and then pushing tag `v0.2.0` (which triggers release.yml) produces that first release.

After merge: push tag `v0.2.0` on the merge commit (or run release.yml via workflow_dispatch with v0.2.0). Casey can do the tag push on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)