### PR TITLE
fix(ci): release workflow needs contents:write + Windows installer glob fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
 
+# The default GITHUB_TOKEN is read-only in this repo; creating the release
+# (softprops/action-gh-release) needs contents: write.
+permissions:
+  contents: write
+
 jobs:
   build-windows:
     name: Build Windows
@@ -305,7 +310,7 @@ jobs:
           draft: false
           prerelease: ${{ contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'rc') }}
           files: |
-            release-assets/windows/*.exe
+            release-assets/windows/**/*.exe
             release-assets/windows/checksums-windows.txt
             release-assets/macos/*.dmg
             release-assets/macos/*.zip


### PR DESCRIPTION
The `v0.2.0` tag run ([29124571122](https://github.com/RLRyals/MCP-Electron-App/actions/runs/29124571122)) built Windows/macOS/Linux successfully but **Create Release failed with 403 ×3**.

Two fixes:
1. **`permissions: contents: write`** added at workflow level — the repo's default `GITHUB_TOKEN` is read-only, and `softprops/action-gh-release` needs write to create the release.
2. **`release-assets/windows/*.exe` → `release-assets/windows/**/*.exe`** — the windows-installer artifact unpacks with a nested `release/` subdirectory (verified in the run's 'List downloaded artifacts' log), so the old glob matched nothing and the Windows installer (the one that matters most here) would have been silently absent from the release.

The `macos/*.zip` warning is left as-is — the build produces DMGs only; softprops treats unmatched patterns as warnings.

**After merge:** the v0.2.0 tag must be moved to the merge commit (the workflow's permissions are read from the file at the tag's ref). Casey will delete and re-push the tag — safe, since no release was ever published from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)