### PR TITLE
fix: publish outline (3013) and kanban (3015) HTTP ports to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
       - "${DB_ADMIN_PORT}:3010"
       - "${NPE_PORT}:3011"  # NPE Server (host side remappable, container fixed at 3011)
       - "${WORKFLOW_MANAGER_PORT}:3012"  # Workflow Manager (host side remappable, container fixed at 3012)
+      - "${OUTLINE_PORT}:3013"  # Outline Server (host side remappable, container fixed at 3013)
+      - "${KANBAN_PORT}:3015"  # Kanban Server (host side remappable, container fixed at 3015)
     environment:
       # PRIMARY: Use PgBouncer for connection pooling (internal Docker network port)
       # CRITICAL: Use container name and INTERNAL port (6432), NOT the external ${PGBOUNCER_PORT} variable

--- a/src/main/env-config.ts
+++ b/src/main/env-config.ts
@@ -31,6 +31,8 @@ export interface EnvConfig {
   PGBOUNCER_PORT: number;
   NPE_PORT: number;
   WORKFLOW_MANAGER_PORT: number;
+  OUTLINE_PORT: number;
+  KANBAN_PORT: number;
   GITHUB_TOKEN?: string;
 }
 
@@ -49,6 +51,8 @@ export const DEFAULT_CONFIG: EnvConfig = {
   PGBOUNCER_PORT: 6432,
   NPE_PORT: 3011,
   WORKFLOW_MANAGER_PORT: 3012,
+  OUTLINE_PORT: 3013,
+  KANBAN_PORT: 3015,
   GITHUB_TOKEN: '',
 };
 
@@ -457,6 +461,8 @@ export async function checkAllPortsAndSuggestAlternatives(
     { port: config.PGBOUNCER_PORT, name: 'PgBouncer', key: 'PGBOUNCER_PORT' as const },
     { port: config.NPE_PORT, name: 'NPE Server', key: 'NPE_PORT' as const },
     { port: config.WORKFLOW_MANAGER_PORT, name: 'Workflow Manager', key: 'WORKFLOW_MANAGER_PORT' as const },
+    { port: config.OUTLINE_PORT, name: 'Outline Server', key: 'OUTLINE_PORT' as const },
+    { port: config.KANBAN_PORT, name: 'Kanban Server', key: 'KANBAN_PORT' as const },
   ];
 
   // Check configurable ports
@@ -630,6 +636,12 @@ export function parseEnvFile(content: string): Partial<EnvConfig> {
         case 'WORKFLOW_MANAGER_PORT':
           config.WORKFLOW_MANAGER_PORT = parseInt(unquotedValue, 10);
           break;
+        case 'OUTLINE_PORT':
+          config.OUTLINE_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'KANBAN_PORT':
+          config.KANBAN_PORT = parseInt(unquotedValue, 10);
+          break;
         case 'GITHUB_TOKEN':
           config.GITHUB_TOKEN = unquotedValue;
           break;
@@ -732,6 +744,8 @@ export function formatEnvFile(config: EnvConfig): string {
     `PGBOUNCER_PORT=${config.PGBOUNCER_PORT}`,
     `NPE_PORT=${config.NPE_PORT}`,
     `WORKFLOW_MANAGER_PORT=${config.WORKFLOW_MANAGER_PORT}`,
+    `OUTLINE_PORT=${config.OUTLINE_PORT}`,
+    `KANBAN_PORT=${config.KANBAN_PORT}`,
   ];
 
   // Only include GITHUB_TOKEN if it's set
@@ -831,6 +845,16 @@ export function validateConfig(config: EnvConfig): { valid: boolean; errors: str
   const workflowManagerPortValidation = validatePort(config.WORKFLOW_MANAGER_PORT);
   if (!workflowManagerPortValidation.valid) {
     errors.push(`Workflow Manager port: ${workflowManagerPortValidation.error}`);
+  }
+
+  const outlinePortValidation = validatePort(config.OUTLINE_PORT);
+  if (!outlinePortValidation.valid) {
+    errors.push(`Outline port: ${outlinePortValidation.error}`);
+  }
+
+  const kanbanPortValidation = validatePort(config.KANBAN_PORT);
+  if (!kanbanPortValidation.valid) {
+    errors.push(`Kanban port: ${kanbanPortValidation.error}`);
   }
 
   // Validate auth token

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -676,6 +676,8 @@ async function execDockerCompose(
         DB_ADMIN_PORT: String(config.DB_ADMIN_PORT),
         NPE_PORT: String(config.NPE_PORT),
         WORKFLOW_MANAGER_PORT: String(config.WORKFLOW_MANAGER_PORT),
+        OUTLINE_PORT: String(config.OUTLINE_PORT),
+        KANBAN_PORT: String(config.KANBAN_PORT),
         MCP_AUTH_TOKEN: config.MCP_AUTH_TOKEN,
         // Path to MCP config file for Docker volume mounting
         MCP_CONFIG_FILE_PATH: mcpConfigPath,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -78,6 +78,8 @@ interface EnvConfig {
   PGBOUNCER_PORT: number;
   NPE_PORT: number;
   WORKFLOW_MANAGER_PORT: number;
+  OUTLINE_PORT: number;
+  KANBAN_PORT: number;
 }
 
 /**

--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -38,6 +38,8 @@ interface EnvConfig {
   PGBOUNCER_PORT: number;
   NPE_PORT: number;
   WORKFLOW_MANAGER_PORT: number;
+  OUTLINE_PORT: number;
+  KANBAN_PORT: number;
 }
 
 /**
@@ -107,7 +109,7 @@ const MCP_SERVERS: Array<{
  * A single row in the Ports settings table
  */
 interface PortRowDefinition {
-  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT';
+  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT' | 'OUTLINE_PORT' | 'KANBAN_PORT';
   name: string;
 }
 
@@ -122,6 +124,8 @@ const PORT_ROWS: PortRowDefinition[] = [
   { key: 'DB_ADMIN_PORT', name: 'DB Admin' },
   { key: 'NPE_PORT', name: 'NPE Server' },
   { key: 'WORKFLOW_MANAGER_PORT', name: 'Workflow Manager' },
+  { key: 'OUTLINE_PORT', name: 'Outline Server' },
+  { key: 'KANBAN_PORT', name: 'Kanban Server' },
 ];
 
 export class ServicesTab {

--- a/src/renderer/components/__tests__/ServicesTab.test.ts
+++ b/src/renderer/components/__tests__/ServicesTab.test.ts
@@ -58,6 +58,8 @@ const CONFIG_FIXTURE = {
   PGBOUNCER_PORT: 6432,
   NPE_PORT: 8765,
   WORKFLOW_MANAGER_PORT: 8766,
+  OUTLINE_PORT: 8767,
+  KANBAN_PORT: 8768,
 };
 
 /**
@@ -193,7 +195,7 @@ describe('Services tab (issue #124)', () => {
     expect(container.textContent).toContain('Docker Desktop');
 
     const portRows = document.querySelectorAll('#ports-table-body tr');
-    expect(portRows.length).toBe(7);
+    expect(portRows.length).toBe(9);
   });
 
   it('shows PostgreSQL connection info (host, port, database) from the env config', async () => {

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -16,6 +16,8 @@ interface EnvConfig {
   PGBOUNCER_PORT: number;
   NPE_PORT: number;
   WORKFLOW_MANAGER_PORT: number;
+  OUTLINE_PORT: number;
+  KANBAN_PORT: number;
   GITHUB_TOKEN?: string;
 }
 
@@ -232,6 +234,8 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       PGBOUNCER_PORT: currentEnvConfig?.PGBOUNCER_PORT || 6432,
       NPE_PORT: currentEnvConfig?.NPE_PORT || 3011,
       WORKFLOW_MANAGER_PORT: currentEnvConfig?.WORKFLOW_MANAGER_PORT || 3012,
+      OUTLINE_PORT: currentEnvConfig?.OUTLINE_PORT || 3013,
+      KANBAN_PORT: currentEnvConfig?.KANBAN_PORT || 3015,
       // Not exposed as a form field on this form - preserve existing value so a
       // re-save doesn't silently erase a stored GitHub token
       GITHUB_TOKEN: currentEnvConfig?.GITHUB_TOKEN,

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -72,6 +72,8 @@ interface EnvConfig {
   PGBOUNCER_PORT: number;
   NPE_PORT: number;
   WORKFLOW_MANAGER_PORT: number;
+  OUTLINE_PORT: number;
+  KANBAN_PORT: number;
 }
 
 interface PortConflictDetail {

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -729,6 +729,8 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             // Not exposed in this wizard step - preserve existing value, default otherwise
             NPE_PORT: currentConfig?.NPE_PORT || 3011,
             WORKFLOW_MANAGER_PORT: currentConfig?.WORKFLOW_MANAGER_PORT || 3012,
+            OUTLINE_PORT: currentConfig?.OUTLINE_PORT || 3013,
+            KANBAN_PORT: currentConfig?.KANBAN_PORT || 3015,
             // Not exposed in this wizard step - preserve existing value so a re-save
             // doesn't silently erase a stored GitHub token
             GITHUB_TOKEN: currentConfig?.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary

The kanban MCP server serves HTTP/SSE on port 3015 and the outline server on 3013, both inside the `mcp-writing-servers` container, but neither port was ever published to the host — so `http://localhost:3015/info` and `http://localhost:3013/info` failed even though the servers are listening in-container (`:3001`, `:3010`-`:3012` work fine). The MCP Connector's internal Docker-network path to the kanban server is unaffected by this.

- Added `"${OUTLINE_PORT}:3013"` and `"${KANBAN_PORT}:3015"` to the `mcp-writing-servers` service's `ports` block in `docker-compose.yml`, matching the existing `NPE_PORT`/`WORKFLOW_MANAGER_PORT` style (host side remappable, container side fixed).
- Wired `OUTLINE_PORT=3013` / `KANBAN_PORT=3015` everywhere the existing port vars are wired (found by grepping for `WORKFLOW_MANAGER_PORT`): `env-config.ts` (interface, defaults, port-conflict probe list, `.env` parse/format, validation), the docker-compose env injection in `mcp-system.ts`, and the Electron Ports settings UI (`ServicesTab.ts` port rows + its test fixture/row-count assertion, plus the `EnvConfig` type mirrored in `preload.ts`, `renderer.ts`, `env-config-handlers.ts`, and the preserved-value defaults in `setup-wizard-handlers.ts`).

## Ports 3002-3009 (config-mcp phase wrappers)

Left unpublished on purpose, per the plan: nothing on the host consumes them today, and the convention here is to publish only ports that have a consumer. If a host-side consumer for those ever shows up, they can be added the same way this PR added 3013/3015.

## Test plan

- [x] `npm run build` (tsc renderer + main) — compiles clean
- [x] `npx jest --config jest.config.ci.cjs` (the CI-required gate) — 36/36 suites, 368/368 tests pass
- [x] `npx jest --testPathPattern="ServicesTab.test.ts"` — updated the Ports table row-count assertion (7 → 9 rows) and added `OUTLINE_PORT`/`KANBAN_PORT` to the test fixture; 10/10 pass
- [x] `docker compose --env-file <full-env> config` against the modified `docker-compose.yml` — confirmed it resolves cleanly and both new mappings (`3013:3013`, `3015:3015`) appear alongside the untouched existing ones (`3001`, `3010`, `3011`, `3012`)
- Not run: no restart of the live stack — this only takes effect after a released build is installed and the stack is restarted, which is out of scope for this PR

Closes bead: mea-0zq

🤖 Generated with [Claude Code](https://claude.com/claude-code)