### PR TITLE
fix(dashboard): pass the clicked card id through to the kanban view

### DIFF
--- a/src/renderer/views/DashboardViewReact.tsx
+++ b/src/renderer/views/DashboardViewReact.tsx
@@ -247,12 +247,14 @@ export const DashboardApp: React.FC = () => {
   const handleResume = useCallback((id: string) => invokeWorkflowAction('workflow:resume', id), [invokeWorkflowAction]);
   const handleCancel = useCallback((id: string) => invokeWorkflowAction('workflow:cancel', id), [invokeWorkflowAction]);
 
-  // v1 deep-link scope (design supplement decision 1): every kanban-backed
-  // item just navigates to the Board view. Opening a specific card's
-  // drawer would need plugin-side support.
-  // v2: card deep-link needs plugin API
-  const handleCardClick = useCallback((_card: KanbanCard) => {
-    (window as any).__viewRouter__?.navigateTo?.('kanban');
+  // Card deep-link (bead mea-5bq): navigate to the Board view AND tell it
+  // which card to open. The card id crosses the app->plugin boundary via
+  // ViewRouter's existing `navigateTo(viewId, params)` -> `view.mount(container,
+  // params)` contract; the fictionlab-kanban plugin (>= 1.1.2) reads
+  // `params.cardId` in its mount() and opens that card's drawer. Older plugin
+  // versions ignore the extra param and just show the board (previous behavior).
+  const handleCardClick = useCallback((card: KanbanCard) => {
+    (window as any).__viewRouter__?.navigateTo?.('kanban', { cardId: card.id });
   }, []);
 
   const handleWorkflowClick = useCallback((_workflow: ActiveWorkflowInstance) => {

--- a/src/renderer/views/__tests__/DashboardViewReact.test.tsx
+++ b/src/renderer/views/__tests__/DashboardViewReact.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * DashboardApp card deep-link regression test (bead mea-5bq).
+ *
+ * The bug: clicking a cockpit card navigated to the kanban view but dropped
+ * the card id (`navigateTo('kanban')` with no params), so the board opened
+ * without the clicked card's drawer. The fix threads the id across the
+ * app->plugin boundary via ViewRouter's existing `navigateTo(viewId, params)`
+ * -> `view.mount(container, params)` contract; the fictionlab-kanban plugin
+ * (>= 1.1.2) reads `params.cardId` on mount and opens that drawer (covered
+ * on its side by deep-link-utils tests in the fictionlab-workflow repo).
+ *
+ * This test locks the app side of that contract: a card click in each
+ * cockpit panel must call `navigateTo('kanban', { cardId: <clicked id> })`.
+ * Panel render behavior itself is covered by the per-panel tests in
+ * src/renderer/components/dashboard/__tests__/.
+ */
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DashboardApp } from '../DashboardViewReact';
+import type { KanbanCard } from '../../components/dashboard/types';
+
+const KANBAN_LIST_CHANNEL = 'plugin:fictionlab-kanban:board:list-cards';
+
+function installMocks(cards: KanbanCard[]) {
+  const invoke = jest.fn(async (channel: string) => {
+    if (channel === KANBAN_LIST_CHANNEL) return cards;
+    return undefined;
+  });
+
+  (window as any).electronAPI = {
+    invoke,
+    on: jest.fn(),
+    off: jest.fn(),
+    removeAllListeners: jest.fn(),
+    // isPluginActive() gate: kanban active, workflow inactive (workflow data
+    // isn't needed to exercise the card-click path).
+    plugins: {
+      list: jest.fn().mockResolvedValue([{ id: 'fictionlab-kanban', status: 'active' }]),
+    },
+    // SystemStrip renders unconditionally inside DashboardApp.
+    mcpSystem: {
+      getDetailedStatus: jest.fn().mockResolvedValue({
+        overall: { running: true, healthy: true, ready: true, message: 'ok' },
+        services: [],
+        timestamp: new Date(),
+      }),
+      start: jest.fn(),
+      stop: jest.fn(),
+      restart: jest.fn(),
+      onProgress: jest.fn(),
+      removeProgressListener: jest.fn(),
+    },
+    clientSelection: {
+      getSelection: jest.fn().mockResolvedValue({ clients: [], selectedAt: new Date().toISOString() }),
+    },
+  };
+
+  const navigateTo = jest.fn();
+  (window as any).__viewRouter__ = { navigateTo };
+  return { navigateTo };
+}
+
+afterEach(() => {
+  delete (window as any).__viewRouter__;
+});
+
+describe('DashboardApp card deep-link (bead mea-5bq)', () => {
+  it('clicking a Next-panel card navigates to kanban WITH that card id in the params', async () => {
+    const { navigateTo } = installMocks([
+      { id: 'card-42', title: 'Ship the deep link', status: 'ready', priority: 'high' },
+    ]);
+
+    render(<DashboardApp />);
+
+    const row = await screen.findByTitle('Ship the deep link');
+    await userEvent.click(row);
+
+    expect(navigateTo).toHaveBeenCalledTimes(1);
+    expect(navigateTo).toHaveBeenCalledWith('kanban', { cardId: 'card-42' });
+  });
+
+  it('passes each clicked card its OWN id (Running and Blocked panels share the same handler)', async () => {
+    const { navigateTo } = installMocks([
+      { id: 'card-run', title: 'In progress card', status: 'in_progress' },
+      { id: 'card-blocked', title: 'Blocked card', status: 'blocked' },
+    ]);
+
+    render(<DashboardApp />);
+
+    await userEvent.click(await screen.findByTitle('In progress card'));
+    await userEvent.click(await screen.findByTitle('Blocked card'));
+
+    expect(navigateTo).toHaveBeenNthCalledWith(1, 'kanban', { cardId: 'card-run' });
+    expect(navigateTo).toHaveBeenNthCalledWith(2, 'kanban', { cardId: 'card-blocked' });
+  });
+
+  it('regression shape-lock: numeric ids pass through unchanged (plugin side normalizes to string)', async () => {
+    const { navigateTo } = installMocks([
+      { id: 7, title: 'Numeric id card', status: 'ready' },
+    ]);
+
+    render(<DashboardApp />);
+
+    await userEvent.click(await screen.findByTitle('Numeric id card'));
+
+    expect(navigateTo).toHaveBeenCalledWith('kanban', { cardId: 7 });
+  });
+});


### PR DESCRIPTION
## Problem

On the dashboard cockpit (PR #222 panels), clicking a card opened the kanban view but NOT the clicked card. Root cause: `handleCardClick` in `DashboardViewReact.tsx` called `navigateTo('kanban')` and threw the card away — the parameter was even named `_card`, with a comment deferring the deep-link to "v2".

## Fix

ViewRouter already threads a params object from `navigateTo(viewId, params)` into `view.mount(container, params)` — on every navigation, including cached view instances — so the card id now rides that existing, defined interface as `{ cardId: card.id }`. No new channel, no global.

The receiving side of the boundary is the kanban plugin (it owns the board view since the containment migration, fictionlab-workflow#9): **companion PR RLRyals/fictionlab-workflow#21** ships fictionlab-kanban `1.1.2`, whose `KanbanViewReact.mount()` parses `params.cardId` and opens that card's drawer once the board list resolves. The two PRs should be reviewed together. Version skew is safe in both directions: an older plugin ignores the extra param (previous open-the-board behavior); an updated plugin with an older app sees no params and opens the board normally.

## Acceptance criteria (bead)

- [x] Clicking a dashboard card opens the kanban view WITH that card's drawer open (app sends the id; plugin 1.1.2 opens the drawer — companion PR).
- [x] Card id survives the app→plugin boundary via a defined interface, not a global (`navigateTo(viewId, params)` → `View.mount(container, params)`).
- [x] Regression test exists — unit tests on both sides of the boundary, with the e2e limitation documented below.

## Tests

- **This repo:** new `src/renderer/views/__tests__/DashboardViewReact.test.tsx` locks the navigation payload — a click in each cockpit panel (Next / Running / Blocked) must call `navigateTo('kanban', { cardId: <clicked id> })`, plus a numeric-id shape-lock.
- **Plugin repo:** `deep-link-utils.node-test.mjs` (10 cases) covers param parsing/board resolution on the receiving side.
- **Why no e2e:** the merged Playwright suite (PR #209) runs pluginless launch-only smoke; the kanban view (a plugin renderer bundle) never mounts in that CI harness, so a dashboard→drawer interaction test can't run there yet. Boundary-side unit tests on both repos are the documented fallback per the bead's acceptance criteria.

## CI gate (run locally)

- `npm run build`: clean.
- `npx jest --config jest.config.ci.cjs`: 39 suites / 387 tests, all pass (was 38/384 before this PR).

Closes bead: mea-5bq

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFB6929vCJMhsSFn4LMADe