### PR TITLE
feat(release): cross-platform release matrix — win-arm64, per-platform e2e smoke, tester intake (mea-0um)

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-test-report.yml
+++ b/.github/ISSUE_TEMPLATE/platform-test-report.yml
@@ -1,0 +1,183 @@
+name: Platform Test Report
+description: >-
+  Report the results of running through TESTING.md on a real machine
+  (Linux, macOS, or Windows ARM64/x64). This is community test-result
+  intake, not a work-tracking issue -- it gets triaged into the project's
+  own tracker, so please don't expect a direct code-review thread here.
+title: '[TEST] '
+labels:
+  - platform-test-report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing a FictionLab release! Please work through
+        [TESTING.md](../../blob/develop/TESTING.md) first, then fill this
+        in. Every checkbox below mirrors a section of that checklist --
+        check it only if that step actually passed on your machine.
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux Mint
+        - Other Debian/Ubuntu-family Linux
+        - Other Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: e.g. "21.3", "14.5 Sonoma", "11 24H2"
+      placeholder: OS version number
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: CPU architecture
+      options:
+        - x64 / amd64
+        - arm64 / Apple Silicon
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: FictionLab version tested
+      description: The version in the installer filename, or Help → About once installed.
+      placeholder: e.g. 0.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: installer-file
+    attributes:
+      label: Installer file downloaded
+      description: Exact filename from the release page.
+      placeholder: e.g. "FictionLab Setup 0.3.0 arm64.exe"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: download-verify
+    attributes:
+      label: '1. Download and verify (TESTING.md #1)'
+      options:
+        - label: SHA256 checksum matched the published checksums file
+          required: false
+
+  - type: checkboxes
+    id: install
+    attributes:
+      label: '2. Install (TESTING.md #2)'
+      options:
+        - label: Installer ran / package installed without unexpected errors
+          required: false
+        - label: >-
+            OS security warning appeared (SmartScreen / Gatekeeper / distro
+            equivalent) -- describe exactly what you saw and what you clicked
+            through in the notes field below
+          required: false
+        - label: App launched successfully after install
+          required: false
+
+  - type: checkboxes
+    id: first-run
+    attributes:
+      label: '3. First-run wizard (TESTING.md #3)'
+      options:
+        - label: App opened to the setup wizard, not a blank window or crash
+          required: false
+        - label: Docker Desktop detection worked (install guidance shown, or "not running" prompt if applicable)
+          required: false
+        - label: Setup wizard completed (client selection etc.)
+          required: false
+
+  - type: checkboxes
+    id: database
+    attributes:
+      label: '4. Database initialization (TESTING.md #4)'
+      options:
+        - label: PostgreSQL initialized via Docker without manual steps
+          required: false
+        - label: Settings > Database shows connected/healthy
+          required: false
+
+  - type: checkboxes
+    id: connector
+    attributes:
+      label: '5. Connector health :50880 (TESTING.md #5)'
+      options:
+        - label: Settings > Services shows all three containers running (PostgreSQL, MCP Writing Servers, MCP Connector)
+          required: false
+        - label: MCP Connector reachable at localhost:50880
+          required: false
+
+  - type: checkboxes
+    id: pluginless
+    attributes:
+      label: '6. Pluginless core check (TESTING.md #6)'
+      options:
+        - label: Sidebar shows only core items with zero plugins installed (no Workflows, no plugin-named entries)
+          required: false
+        - label: Settings > Services and Settings > Setup both reachable, no "plugin not found" / "plugin required" text
+          required: false
+        - label: Plugins screen itself is reachable
+          required: false
+
+  - type: checkboxes
+    id: update-uninstall
+    attributes:
+      label: '7-8. Update check and uninstall (TESTING.md #7-8, optional)'
+      options:
+        - label: 'Check for Updates completed without error (up-to-date is a pass)'
+          required: false
+        - label: Uninstall completed cleanly via the normal OS mechanism
+          required: false
+
+  - type: dropdown
+    id: overall
+    attributes:
+      label: Overall result
+      options:
+        - Everything passed
+        - Passed with minor issues (see notes)
+        - Blocked / could not complete testing (see notes)
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / anything that failed
+      description: >-
+        Describe any failed step, unexpected dialog/warning text, or
+        anything not covered above. Exact error text is much more useful
+        than a paraphrase.
+      placeholder: What happened, at which step, and what you expected instead
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (if anything failed)
+      description: >-
+        Attach the app logs by dragging the file(s) into this box, or paste
+        relevant excerpts. Log locations: Windows
+        `%USERPROFILE%\AppData\Roaming\fictionlab\logs`, macOS
+        `~/Library/Logs/fictionlab`, Linux `~/.config/fictionlab/logs`.
+        Please redact anything that looks like a token, password, or API
+        key before attaching -- see SECURITY-NOTES.md.
+      placeholder: Drag and drop log files here, or paste excerpts
+    validations:
+      required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,96 @@ jobs:
             out/checksums-windows.txt
           retention-days: 1
 
+  build-windows-arm64:
+    name: Build Windows ARM64
+    # Hosted arm64 Windows runner (bead mea-0um). Native arm64 host, not a
+    # cross-build from windows-latest -- electron-builder + the NSIS tooling
+    # it shells out to run fine under this runner the same way they do on
+    # windows-latest (Windows-on-ARM handles the x64 helper binaries via
+    # built-in emulation).
+    runs-on: windows-11-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Run full test suite (informational)
+        id: full_tests
+        continue-on-error: true
+        run: npm test
+
+      - name: Note pre-existing test failures
+        if: steps.full_tests.outcome == 'failure'
+        run: |
+          echo "::warning::Full suite (npm test) has pre-existing failures tracked in issue #176; not blocking this release build. The required gate above (npm run test:ci) covers the currently-green suites and does block on regressions there. See the 'Run full test suite' step log for detail."
+
+      - name: Install Playwright browsers
+        run: |
+          npx playwright install chromium --with-deps
+
+      - name: Run Electron E2E smoke tests (bead mea-0um)
+        # Same suite as the win-x64 job (smoke.spec.ts + pluginless.spec.ts).
+        # windows-11-arm is a GUI-capable hosted runner like windows-latest,
+        # so no xvfb wrapper is needed here (unlike ubuntu-latest below).
+        # NOTE: this is the first time this suite runs on windows-11-arm --
+        # if Playwright's chromium download has no win32-arm64 binary this
+        # step will fail loudly on the first real CI run rather than silently
+        # skip; that is the intended "documented, not silent" failure mode
+        # per bead mea-0um until verified.
+        run: |
+          npm run test:e2e
+
+      - name: Build Windows ARM64 app
+        run: npm run package:win-arm64
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Generate checksums
+        shell: powershell
+        run: |
+          $releaseDir = Join-Path $PWD 'out\release'
+          New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+
+          # Same *Setup*.exe scoping as the win-x64 job (issue #223 lesson).
+          # nsis.artifactName now includes ${arch} (package.json) so the x64
+          # and arm64 installers never collide when both are attached to the
+          # same GitHub release.
+          Get-ChildItem -Path (Join-Path $PWD 'out') -Filter '*Setup*.exe' -File |
+            ForEach-Object {
+              $hash = Get-FileHash -Path $_.FullName -Algorithm SHA256
+              $filename = $_.Name
+              "$($hash.Hash.ToLower())  $filename" | Out-File -Append -FilePath (Join-Path $PWD 'out\checksums-windows-arm64.txt') -Encoding utf8
+
+              $dest = Join-Path $releaseDir $filename
+              Copy-Item -Path $_.FullName -Destination $dest -Force
+            }
+
+          Get-Content out/checksums-windows-arm64.txt
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-installer
+          path: |
+            out/release/*.exe
+            out/checksums-windows-arm64.txt
+          retention-days: 1
+
   build-macos:
     name: Build macOS
     runs-on: macos-latest
@@ -136,6 +226,17 @@ jobs:
         if: steps.full_tests.outcome == 'failure'
         run: |
           echo "::warning::Full suite (npm test) has pre-existing failures tracked in issue #176; not blocking this release build. The required gate above (npm run test:ci) covers the currently-green suites and does block on regressions there. See the 'Run full test suite' step log for detail."
+
+      - name: Install Playwright browsers
+        run: |
+          npx playwright install chromium --with-deps
+
+      - name: Run Electron E2E smoke tests (bead mea-0um)
+        # macos-latest is GUI-capable out of the box (macOS CI runners always
+        # have a windowserver, unlike Linux) -- no xvfb wrapper needed, same
+        # as the win-x64 job.
+        run: |
+          npm run test:e2e
 
       - name: Build macOS app
         run: npm run package:mac
@@ -196,6 +297,19 @@ jobs:
         run: |
           echo "::warning::Full suite (npm test) has pre-existing failures tracked in issue #176; not blocking this release build. The required gate above (npm run test:ci) covers the currently-green suites and does block on regressions there. See the 'Run full test suite' step log for detail."
 
+      - name: Install Playwright browsers
+        run: |
+          npx playwright install chromium --with-deps
+
+      - name: Run Electron E2E smoke tests (bead mea-0um)
+        # ubuntu-latest is headless -- Electron (and Playwright's underlying
+        # CDP connection to it) needs a display server, so this runs under
+        # xvfb-run the same way an Electron app would in any headless Linux
+        # CI environment. xvfb itself comes from the --with-deps install
+        # above.
+        run: |
+          xvfb-run --auto-servernum npm run test:e2e
+
       - name: Build Linux app
         run: npm run package:linux
 
@@ -222,7 +336,15 @@ jobs:
 
   create-release:
     name: Create Release
-    needs: [build-windows, build-macos, build-linux]
+    # build-windows-arm64 is listed as a dependency (so it's scheduled and
+    # awaited alongside the others) but deliberately NOT required to succeed
+    # in the `if:` gate below (bead mea-0um). windows-11-arm is a brand new
+    # hosted runner class this workflow has never exercised; the existing
+    # win-x64/mac/linux release path should not go dark because of a problem
+    # on the newest, least-proven leg. If it fails, the release still ships
+    # for the other three platforms and simply omits the win-arm64 asset --
+    # a documented skip, not a silent one (see the job's own comments).
+    needs: [build-windows, build-windows-arm64, build-macos, build-linux]
     runs-on: ubuntu-latest
     if: always() && needs.build-windows.result == 'success' && needs.build-macos.result == 'success' && needs.build-linux.result == 'success'
 
@@ -248,6 +370,16 @@ jobs:
         with:
           name: windows-installer
           path: release-assets/windows
+
+      - name: Download Windows ARM64 artifacts
+        # Best-effort: only download if that job actually succeeded, so a
+        # win-arm64 failure doesn't take down asset collection for the other
+        # three platforms (see the create-release job comment above).
+        if: needs.build-windows-arm64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-arm64-installer
+          path: release-assets/windows-arm64
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
@@ -278,9 +410,9 @@ jobs:
           cat << EOF > release_notes.md
           ## Installation
 
-          **Windows**: Download and run the installer executable.
+          **Windows (x64 and ARM64)**: Download and run the installer executable for your architecture (the filename includes \`x64\` or \`arm64\`). Not sure which you have? Settings > System > About > "System type".
 
-          **macOS**: Download the DMG file, mount it, and drag the app to Applications.
+          **macOS (Apple Silicon)**: Download the DMG file, mount it, and drag the app to Applications. Unsigned build -- see the Notes section below for the Gatekeeper steps.
 
           **Linux AppImage**: Download the AppImage file, make it executable, and run:
           \`\`\`bash
@@ -299,7 +431,8 @@ jobs:
 
           ## Notes
 
-          - Code signing certificates are not yet configured (Windows and macOS may show security warnings)
+          - Code signing certificates are not yet configured for any platform (Windows and macOS builds are unsigned and will show OS security warnings -- SmartScreen on Windows, Gatekeeper on macOS). See TESTING.md for the exact click-through steps on each OS.
+          - Windows ARM64 and the win-arm64 CI smoke test are new in this release; if the ARM64 asset is missing from this release, its build did not complete in time and shipped without blocking the other platforms -- check the release workflow run for the \`Build Windows ARM64\` job status.
           - Please verify checksums before installation
           EOF
 
@@ -320,6 +453,8 @@ jobs:
           files: |
             release-assets/windows/**/*Setup*.exe
             release-assets/windows/checksums-windows.txt
+            release-assets/windows-arm64/**/*Setup*.exe
+            release-assets/windows-arm64/checksums-windows-arm64.txt
             release-assets/macos/*.dmg
             release-assets/macos/*.zip
             release-assets/macos/checksums-macos.txt

--- a/README.md
+++ b/README.md
@@ -20,24 +20,28 @@ FictionLab is an installer and management tool that sets up everything you need 
 
 Download the latest installer for your operating system from the [GitHub Releases](../../releases) page:
 
-- **Windows:** `FictionLab-Setup.exe` (Windows 10/11, 64-bit)
-- **macOS:** `FictionLab.dmg` (macOS 10.15+, Intel and Apple Silicon)
-- **Linux:** `FictionLab.AppImage` or `fictionlab.deb` (Ubuntu 20.04+, Debian, other distros)
+- **Windows:** `FictionLab Setup <version> x64.exe` or `... arm64.exe` (Windows 10/11, 64-bit or ARM64)
+- **macOS:** `FictionLab-<version>-arm64.dmg` (macOS 11+, Apple Silicon only -- no Intel/x64 build)
+- **Linux:** `FictionLab.AppImage` or `fictionlab.deb` (Ubuntu 20.04+, Debian, Linux Mint, other distros; x64)
+
+**None of these builds are code-signed** (no Windows Authenticode cert, no Apple Developer cert). Expect an OS security warning on first launch -- see the click-through steps below and [TESTING.md](TESTING.md) for the full checklist.
 
 #### Installation Steps
 
-**Windows:**
-1. Download `FictionLab-Setup.exe`
+**Windows (x64 or ARM64):**
+1. Download the installer matching your architecture (check Settings > System > About > "System type" if unsure)
 2. Double-click the installer
-3. Follow the installation wizard (choose installation folder if desired)
-4. Click "Install" and wait for completion
-5. Launch the app from your Start Menu or Desktop shortcut
+3. Windows SmartScreen will likely warn "Windows protected your PC" -- click **More info** → **Run anyway**
+4. Follow the installation wizard (choose installation folder if desired)
+5. Click "Install" and wait for completion
+6. Launch the app from your Start Menu or Desktop shortcut
 
-**macOS:**
-1. Download `FictionLab.dmg`
+**macOS (Apple Silicon):**
+1. Download `FictionLab-<version>-arm64.dmg`
 2. Open the downloaded DMG file
 3. Drag the FictionLab icon to your Applications folder
-4. Open from Applications (you may need to allow the app in Security & Privacy settings)
+4. Because the app is unsigned and not notarized, a plain double-click will likely be **blocked outright** ("FictionLab is damaged and can't be opened"), not just warned. Instead: **right-click (Control-click) FictionLab in Applications → Open → Open** in the confirmation dialog. This is only needed once.
+   - If macOS still refuses: System Settings → Privacy & Security → "FictionLab was blocked" → **Open Anyway**.
 
 **Linux:**
 1. Download `FictionLab.AppImage` or `fictionlab.deb`
@@ -99,7 +103,7 @@ All of this happens through the app's graphical interface - no configuration fil
 ### System Requirements
 
 **Minimum Requirements:**
-- **OS:** Windows 10/11 (64-bit), macOS 10.15+, or Linux (Ubuntu 20.04+)
+- **OS:** Windows 10/11 (x64 or ARM64), macOS 11+ (Apple Silicon only), or Linux (Ubuntu 20.04+, Debian, Linux Mint)
 - **RAM:** 4GB minimum (8GB recommended)
 - **Disk Space:** 10GB free space (for Docker images and databases)
 - **Internet:** Required for initial setup and downloading components
@@ -180,6 +184,7 @@ If Docker Desktop isn't installed, the app provides a comprehensive step-by-step
 - **[Quick Start](docs/QUICK-START.md)** - Fast setup for experienced users
 - **[Troubleshooting](docs/TROUBLESHOOTING.md)** - Solutions to common problems
 - **[FAQ](docs/FAQ.md)** - Frequently asked questions
+- **[Testing Checklist](TESTING.md)** - Manual per-platform tester script (Linux, macOS, Windows x64/ARM64); also where to report results
 
 **For Developers:**
 - **[Architecture](docs/ARCHITECTURE.md)** - Technical architecture overview

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -99,11 +99,14 @@ If you maintain a CHANGELOG.md, update it with:
 
 ### 5. Testing
 
-Test the application on multiple platforms:
+Test the application on multiple platforms (see [TESTING.md](TESTING.md) for
+the full tester checklist -- Docker detection, DB init, connector health,
+pluginless core check):
 
-- [ ] Windows 10/11
-- [ ] macOS (Intel and Apple Silicon if possible)
-- [ ] Linux (at least one major distribution)
+- [ ] Windows x64
+- [ ] Windows ARM64
+- [ ] macOS (Apple Silicon)
+- [ ] Linux (Ubuntu/Debian/Mint or another major distribution)
 
 ### 6. Clean State
 
@@ -184,23 +187,61 @@ When a version tag is pushed, the following happens:
 
 ### 2. Build Jobs (Parallel)
 
-Three jobs run simultaneously on different runners:
+Four jobs run simultaneously on different runners (bead mea-0um added the
+Windows ARM64 leg):
 
-#### Windows Build (`windows-latest`)
-- Builds NSIS installer (.exe)
+#### Windows x64 Build (`windows-latest`)
+- Runs `npm run test:ci` (required gate) + the Playwright Electron E2E smoke
+  suite (`e2e/smoke.spec.ts` + `e2e/pluginless.spec.ts`)
+- Builds NSIS installer (.exe), x64
 - Generates SHA256 checksums
 - Uploads to release
 
+#### Windows ARM64 Build (`windows-11-arm`)
+- Same test/smoke gate as the x64 job
+- Builds NSIS installer (.exe), arm64, via `npm run package:win-arm64`
+- Generates SHA256 checksums
+- Uploads to release
+- **Not required for the release to publish.** This is the newest, least-proven
+  leg of the matrix (a brand-new hosted runner class this workflow has never
+  exercised) -- `create-release` waits for it but does not block on its
+  success, so a win-arm64 failure ships the other three platforms without the
+  ARM64 asset rather than blocking everyone. Check the workflow run if the
+  ARM64 installer is missing from a release.
+
 #### macOS Build (`macos-latest`)
-- Builds DMG for Intel (x64) and Apple Silicon (arm64)
+- Same test/smoke gate as the Windows jobs (macOS CI runners are GUI-capable
+  without xvfb)
+- Builds DMG for Apple Silicon (arm64) -- **no Intel/x64 build**
 - Generates SHA256 checksums
 - Uploads to release
 
 #### Linux Build (`ubuntu-latest`)
-- Builds AppImage
-- Builds Debian package (.deb)
+- Same test gate; the E2E smoke suite runs under `xvfb-run` since
+  `ubuntu-latest` is headless
+- Builds AppImage (x64)
+- Builds Debian package (.deb, x64)
 - Generates SHA256 checksums
 - Uploads to release
+
+### Code signing status (honest, as of this release)
+
+**No platform is code-signed.** `CSC_IDENTITY_AUTO_DISCOVERY: false` is set
+on every build job, and no signing secrets are configured. Concretely:
+
+- **Windows** (both x64 and ARM64): unsigned. Users hit a SmartScreen
+  "Windows protected your PC" warning and must click through "More info" →
+  "Run anyway".
+- **macOS**: unsigned and not notarized. Users hit Gatekeeper's harder block
+  ("...is damaged and can't be opened") and must right-click → Open, or use
+  System Settings → Privacy & Security → "Open Anyway".
+- **Linux**: no GPG-signed apt repository; the `.deb` is a standalone package
+  installed directly with `dpkg`, and the AppImage is unsigned (AppImage has
+  no standard code-signing mechanism in wide use).
+
+See [TESTING.md](TESTING.md) for the exact tester-facing click-through steps,
+and the "Code Signing Issues" section below for how to actually turn signing
+on when certificates are available.
 
 ### 3. Release Complete Job
 
@@ -216,18 +257,23 @@ After a successful release:
 
 1. Go to the [Releases page](https://github.com/<username>/MCP-Electron-App/releases)
 2. Check that all artifacts are present:
-   - Windows: `MCP-Electron-App-Setup-vX.X.X.exe`
-   - macOS: `MCP-Electron-App-vX.X.X.dmg`
-   - Linux: `MCP-Electron-App-vX.X.X.AppImage` and `mcp-electron-app_vX.X.X_amd64.deb`
-   - Checksum files for each platform
+   - Windows x64: `FictionLab Setup X.X.X x64.exe`
+   - Windows ARM64: `FictionLab Setup X.X.X arm64.exe` (best-effort -- see the
+     "Windows ARM64 Build" note above; may be absent on a given release)
+   - macOS: `FictionLab-X.X.X-arm64.dmg`
+   - Linux: `FictionLab-X.X.X.AppImage` and `fictionlab_X.X.X_amd64.deb`
+   - Checksum files for each platform (`checksums-windows.txt`,
+     `checksums-windows-arm64.txt`, `checksums-macos.txt`,
+     `checksums-linux.txt`)
 
 ### 2. Test Downloads
 
-Download and test the installer on each platform:
+Download and test the installer on each platform (see
+[TESTING.md](TESTING.md) for the full checklist):
 
 ```bash
 # Verify checksums
-sha256sum MCP-Electron-App-vX.X.X.AppImage
+sha256sum FictionLab-X.X.X.AppImage
 # Compare with checksums-linux.txt
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,161 @@
+# Tester Checklist (bead mea-0um)
+
+This is the manual test script for anyone doing real-machine testing of a
+FictionLab installer -- Linux Mint (or any Debian/Ubuntu-family distro),
+macOS (Apple Silicon), or Windows (x64 or ARM64). CI (`.github/workflows/release.yml`)
+covers install/launch-level checks on hosted runners; it cannot cover Docker
+Desktop setup, database initialization, or real hardware quirks. That's what
+this checklist is for.
+
+If you're reporting results, please use the
+[Platform Test Report](../../issues/new?template=platform-test-report.yml)
+issue form instead of (or alongside) this file -- it mirrors these steps as
+structured checkboxes plus a log-attachment field.
+
+## Before you start
+
+- Note your exact OS version and CPU architecture (e.g. "Windows 11 24H2,
+  ARM64" or "Linux Mint 21.3, x64" or "macOS 14.5, Apple Silicon"). You'll
+  need this for the report.
+- Have Docker Desktop **not** installed yet if you can manage it -- the
+  first-run wizard's Docker-detection path is one of the things being tested.
+  If Docker Desktop is already installed, that's fine too; just note it in
+  your report.
+
+## 1. Download and verify
+
+- [ ] Download the installer for your platform from the release page.
+  - Windows: `FictionLab Setup <version> x64.exe` or `... arm64.exe`
+  - macOS: `FictionLab-<version>-arm64.dmg` (Apple Silicon)
+  - Linux: `FictionLab-<version>.AppImage` or `fictionlab_<version>_amd64.deb`
+- [ ] Verify the SHA256 checksum against the matching `checksums-*.txt` file
+      in the release.
+  - Windows (PowerShell): `Get-FileHash .\FictionLab*.exe -Algorithm SHA256`
+  - macOS: `shasum -a 256 FictionLab*.dmg`
+  - Linux: `sha256sum FictionLab*.AppImage` or `fictionlab*.deb`
+
+## 2. Install
+
+**Windows (x64 or ARM64):**
+- [ ] Double-click the installer.
+- [ ] SmartScreen will likely warn "Windows protected your PC" -- this build
+      is unsigned (see "Known limitations" below). Click **More info** ->
+      **Run anyway** to proceed. Note whether this warning appeared.
+- [ ] Follow the install wizard (you may change the install directory).
+- [ ] Launch from the Start Menu or the desktop shortcut.
+
+**macOS (Apple Silicon):**
+- [ ] Open the DMG, drag FictionLab to Applications.
+- [ ] This build is unsigned and not notarized -- the first launch attempt
+      via double-click will likely be **blocked outright** ("FictionLab is
+      damaged and can't be opened" or similar), not just warned. Instead:
+      **right-click (or Control-click) the app in Applications -> Open ->
+      Open** in the confirmation dialog. This only needs to be done once.
+  - If macOS still refuses: System Settings -> Privacy & Security -> scroll
+    to the "FictionLab was blocked" notice -> **Open Anyway**.
+- [ ] Note in your report exactly which of the above was required -- this is
+      one of the things we don't yet know without real-machine testing on
+      Apple Silicon.
+
+**Linux (AppImage):**
+- [ ] `chmod +x FictionLab-*.AppImage`
+- [ ] Run it: `./FictionLab-*.AppImage`
+- [ ] Note whether a sandboxing error occurs (some distros need
+      `--no-sandbox` for unprivileged AppImage execution, or
+      `sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0` on newer
+      Ubuntu/Mint releases with AppArmor userns restrictions) -- report the
+      exact error text if so.
+
+**Linux (.deb, Debian/Ubuntu/Mint):**
+- [ ] `sudo dpkg -i fictionlab_*.deb` (or `sudo apt install ./fictionlab_*.deb`
+      to auto-resolve dependencies)
+- [ ] Launch from the applications menu, or `fictionlab` from a terminal.
+
+## 3. First-run wizard
+
+- [ ] The app opens to a first-run / setup flow (not a blank window, not a
+      crash).
+- [ ] **Docker detection**: if Docker Desktop is not installed, the app
+      offers guided installation instructions rather than failing silently.
+      If Docker Desktop **is** installed but not running, the app prompts
+      you to start it.
+- [ ] Once Docker Desktop is running, complete the setup wizard (client
+      selection, etc.).
+
+## 4. Database initialization
+
+- [ ] The app initializes PostgreSQL (via Docker) without manual `psql`/SQL
+      steps on your part.
+- [ ] Settings > Database shows the database as connected/healthy once
+      initialization completes.
+
+## 5. Connector health (:50880)
+
+- [ ] Settings > Services shows three containers: PostgreSQL, MCP Writing
+      Servers, and the MCP Connector -- all reporting "running" once setup
+      completes.
+- [ ] The local TypingMind MCP Connector is reachable at
+      `http://localhost:50880` (the app's own health/status indicator on the
+      Services tab is sufficient; you do not need to curl it manually unless
+      the in-app status looks wrong, in which case: `curl -i
+      http://localhost:50880/health` or open it in a browser and report what
+      you see).
+
+## 6. Pluginless core check
+
+FictionLab's core promise is that it is fully usable with **zero plugins
+installed** -- Docker, the database, and the MCP Connector, nothing else
+required (see `docs/CORE-VS-OPTIONAL-COMPONENTS.md`). On a fresh install,
+before installing any plugin:
+
+- [ ] The sidebar shows only core items: Dashboard, Settings (Setup,
+      Database, Services, Logs), Plugins, Help/About. No "Workflows" entry,
+      no plugin-named entries.
+- [ ] Settings > Services and Settings > Setup are both reachable and show
+      no "plugin not found" / "plugin required" errors anywhere on screen.
+- [ ] The Plugins screen itself is reachable and lists what's available to
+      install (this is how you'd add Workflows/Kanban capability later --
+      not required for this checklist).
+
+## 7. Update check (optional but useful)
+
+- [ ] Settings > Setup > "Check for Updates" completes without error (it may
+      correctly report "up to date" if you're on the newest release -- that's
+      a pass, not a failure).
+
+## 8. Uninstall
+
+- [ ] Uninstall via the OS's normal mechanism (Windows: Add/Remove Programs;
+      macOS: drag to Trash; Linux: `sudo dpkg -r fictionlab` or delete the
+      AppImage) and confirm it does not error or leave the app unusable
+      without a manual cleanup step.
+
+## Known limitations (honest, as of this release)
+
+- **No code signing on any platform.** Windows and macOS builds are
+  unsigned; Linux packages are unsigned in the .deb sense too (no GPG-signed
+  apt repo -- this is a standalone .deb, not a repository package). Expect
+  SmartScreen (Windows) and Gatekeeper (macOS) warnings; see the install
+  steps above for exactly how to get past them.
+- **macOS is Apple Silicon (arm64) only** in this release's build matrix.
+  There is no Intel (x64) macOS build.
+- **Windows ARM64 is new** and has not yet been verified on real ARM64
+  hardware -- only the CI runner's ARM64 build+launch. If you're testing on
+  a Windows ARM64 device (e.g. Surface Pro X or similar), your report is
+  the first real-hardware signal we'll have.
+- **CI cannot test the full Docker/database/connector flow.** Hosted CI
+  runners don't run Docker Desktop the way a real user's machine does, so
+  the smoke tests in `.github/workflows/release.yml` only prove the app
+  installs and its renderer boots -- not that setup-through-connector-health
+  works end to end. That gap is exactly what sections 3-6 above are for.
+
+## Reporting results
+
+Please file a
+[Platform Test Report](../../issues/new?template=platform-test-report.yml)
+with your OS/arch, which steps passed or failed, and (if anything failed)
+the app logs:
+
+- Windows: `%USERPROFILE%\AppData\Roaming\fictionlab\logs`
+- macOS: `~/Library/Logs/fictionlab`
+- Linux: `~/.config/fictionlab/logs`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "copy-assets": "node scripts/copy-assets.js",
     "package": "npm run build && electron-builder build --publish never",
     "package:win": "npm run build && electron-builder build --win --publish never",
+    "package:win-arm64": "npm run build && electron-builder build --win --arm64 --publish never",
     "package:mac": "npm run build && electron-builder build --mac --publish never",
     "package:linux": "npm run build && electron-builder build --linux --publish never",
     "package:all": "npm run build && electron-builder build -mwl --publish never",
@@ -123,7 +124,8 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
-      "createStartMenuShortcut": true
+      "createStartMenuShortcut": true,
+      "artifactName": "${productName} Setup ${version} ${arch}.${ext}"
     },
     "mac": {
       "target": [


### PR DESCRIPTION
## Summary

Adds the missing cross-platform coverage for release builds (bead mea-0um):

- **New: Windows ARM64 NSIS build**, alongside the existing win-x64. Runs on the hosted `windows-11-arm` runner via a new `package:win-arm64` script (`electron-builder build --win --arm64`). `nsis.artifactName` now includes `${arch}` so the x64 and arm64 installers never collide when both are attached to the same GitHub release (nsis is the only electron-builder target here whose default artifactName omits arch — dmg/AppImage/deb already include it).
- **Already present, now documented**: linux x64 AppImage + deb, macOS Apple-Silicon (arm64) dmg. No code changes needed there — the existing matrix already covers what the bead asked for on those two platforms.
- **Per-platform CI smoke**: wires the Playwright Electron E2E suite (`smoke.spec.ts` + `pluginless.spec.ts`, merged via #228) into the macOS and Linux build jobs to match the Windows job that already had it. Linux runs it under `xvfb-run` since `ubuntu-latest` is headless; macOS runs it directly (macOS CI runners are GUI-capable without a virtual display, same as Windows).
- **TESTING.md**: the manual tester checklist — download/verify, install (with the exact SmartScreen/Gatekeeper click-through steps per OS), first-run wizard, DB init, connector health at `:50880`, and the pluginless-core check (per `docs/CORE-VS-OPTIONAL-COMPONENTS.md`), uninstall, and an honest "known limitations" section.
- **`.github/ISSUE_TEMPLATE/platform-test-report.yml`**: structured GitHub Issue Form for community test-report intake — OS/arch dropdowns, checkboxes mirroring each TESTING.md section, and a log-attachment field. This is a sanctioned exception to the "no new GH issues" policy (external testers can't see the project's own tracker; these are intake to be triaged, not work items).
- **Honest signing docs**: README.md and RELEASE.md now state plainly that no platform is code-signed (Windows/macOS both unsigned, Linux .deb is a standalone package with no signed-repo mechanism), with the exact click-through steps for each OS's warning dialog. Also corrected several stale artifact-filename examples in RELEASE.md (`MCP-Electron-App-*` → `FictionLab-*`, matching `productName` in package.json) while in the area.

## release.yml collision context

PRs #229 (narrowed the Windows checksum/asset glob to `*Setup*.exe`) and #231 (added `generate_release_notes: true`, removed the manual changelog step) both touched `release.yml` and were **already merged into `develop` before this branch was created** — this branch is based on current `origin/develop`, which already has both changes composed, so no manual union-merge was needed. The new `build-windows-arm64` job and `create-release` changes here compose with both: the `*Setup*.exe` glob convention is reused verbatim for the arm64 asset (`release-assets/windows-arm64/**/*Setup*.exe`), and `generate_release_notes: true` / the trimmed "Generate release notes" step are untouched — I only edited the static Installation/Notes text inside `release_notes.md` to mention arm64 and the signing status.

## Design choice: win-arm64 is best-effort, not blocking

`windows-11-arm` is a brand-new hosted runner class this workflow has never exercised. `create-release` lists `build-windows-arm64` as a dependency (so it's scheduled and waited for) but its `if:` gate does **not** require that job to succeed — only win-x64, macOS, and Linux must succeed for a release to publish. If the ARM64 leg fails, the release still ships for the other three platforms and simply omits the win-arm64 asset (the download step and the file globs are structured to degrade gracefully — see the comments in the job and in `create-release`). This is a deliberate reading of "CI smoke passes on linux/mac/win-arm runners (or documented skip with reason)" extended to the whole new leg, given I have no way to pre-verify `windows-11-arm` behavior from this environment.

## What was verified locally (Windows dev machine)

- ✅ `.github/workflows/release.yml` and the new issue-form YAML both parse cleanly (`js-yaml`).
- ✅ `npm run build` (TypeScript + asset copy) succeeds.
- ✅ `npm run test:ci` (the required jest gate every build job runs) — 41 suites / 414 tests passed.
- ✅ `package.json` is valid JSON.
- ✅ `electron-builder build --win --arm64 --dir` dry-run: correctly resolved the target (`platform=win32 arch=arm64`) and successfully downloaded the matching prebuilt `electron-v28.3.3-win32-arm64.zip` — confirms the arm64 Electron target is real and electron-builder can address it. The dry-run stalled only on `winCodeSign` archive extraction needing a symlink privilege this local (non-admin, non-Developer-Mode) Windows machine doesn't have — an environment limitation unrelated to `CSC_IDENTITY_AUTO_DISCOVERY: false` or to CI (hosted runners don't have this restriction).

## What could NOT be verified pre-release (first-release verification needed)

- Whether `npx playwright install chromium --with-deps` and the Electron smoke suite actually succeed on a live `windows-11-arm` runner (Playwright's bundled Chromium may or may not ship a native win32-arm64 build; Electron's own win32-arm64 Chromium engine is separate and confirmed to exist).
- Whether `xvfb-run` + the smoke suite pass on `ubuntu-latest` as wired (no linux GUI environment available locally to exercise this).
- The actual NSIS packaging + checksum step end-to-end on `windows-11-arm` (blocked locally on the symlink issue above).
- Real Windows-ARM64 hardware behavior (SmartScreen wording, install/launch) — flagged in TESTING.md as the first real-hardware signal this project will have.
- macOS Gatekeeper's exact block text on a genuinely unsigned/non-notarized build (documented from platform knowledge, not a live macOS test).

None of this blocks the PR from being reviewable — the workflow YAML is syntactically valid and the job/dependency graph is sound; the runner-capability unknowns will surface as CI failures on the next real release run rather than silently.

## Test plan

- [x] `npm run build`
- [x] `npm run test:ci` (41/41 suites, 414/414 tests)
- [x] YAML validity: `release.yml`, `platform-test-report.yml`
- [x] `package.json` JSON validity
- [x] electron-builder win-arm64 target resolution (dry-run, partial — see above)
- [ ] Live CI run across all four platform build jobs (first real trigger after merge/tag)
- [ ] Real-hardware Windows ARM64 test (community, via the new issue form)

Closes bead: mea-0um

🤖 Generated with [Claude Code](https://claude.com/claude-code)