### PR TITLE
feat: BRAT-style plugin auto-update from private GitHub repo

### DIFF
--- a/src/main/__tests__/plugin-github-updater.test.ts
+++ b/src/main/__tests__/plugin-github-updater.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Unit tests for src/main/plugin-github-updater.ts (bead mea-6tt).
+ *
+ * Follows the same mock-fetch pattern as release-notes.test.ts /
+ * app-updater.test.ts for the network layer, and the same real-temp-dir
+ * pattern as plugin-update-swap.test.ts for the filesystem layer (this
+ * module's whole job is to hand a downloaded bundle to that proven swap
+ * path, so exercising real directories catches integration mistakes a
+ * mocked fs wouldn't).
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  checkPluginUpdate,
+  checkPluginDependencies,
+  downloadAndInstallPluginUpdate,
+  findMatchingAsset,
+  maskToken,
+  redactSecret,
+  normalizeVersion,
+  resolveUpdateSource,
+  KNOWN_PLUGIN_UPDATE_SOURCES,
+} from '../plugin-github-updater';
+import { readPluginManifestSafe } from '../plugin-update-swap';
+
+function okJsonResponse(body: any) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body };
+}
+
+let workDir: string;
+let pluginsDir: string;
+
+beforeEach(async () => {
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-github-updater-'));
+  pluginsDir = path.join(workDir, 'plugins');
+  await fs.ensureDir(pluginsDir);
+});
+
+afterEach(async () => {
+  await fs.remove(workDir);
+});
+
+async function writeInstalledPlugin(id: string, version: string, overrides: Record<string, unknown> = {}) {
+  const dir = path.join(pluginsDir, id);
+  await fs.ensureDir(dir);
+  await fs.writeJson(path.join(dir, 'plugin.json'), {
+    id,
+    name: `Plugin ${id}`,
+    version,
+    description: 'test plugin',
+    author: 'test',
+    fictionLabVersion: '*',
+    pluginType: 'utility',
+    entry: { main: 'index.js' },
+    permissions: [],
+    ...overrides,
+  });
+  await fs.writeFile(path.join(dir, 'index.js'), 'module.exports = {};');
+  return dir;
+}
+
+const SAMPLE_ASSET = { name: 'fictionlab-kanban-1.1.0.zip', browser_download_url: 'https://example.com/a.zip', size: 10, id: 999 };
+
+// ---------------------------------------------------------------------------
+// resolveUpdateSource
+// ---------------------------------------------------------------------------
+
+describe('resolveUpdateSource', () => {
+  it('falls back to the known-plugin map when the manifest has no updateSource', () => {
+    const source = resolveUpdateSource('fictionlab-kanban', { id: 'fictionlab-kanban', version: '1.0.0' } as any);
+    expect(source).toEqual(KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban']);
+  });
+
+  it('prefers a manifest-declared updateSource over the known-plugin map', () => {
+    const manifest: any = {
+      id: 'fictionlab-kanban',
+      version: '1.0.0',
+      updateSource: { repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false },
+    };
+    const source = resolveUpdateSource('fictionlab-kanban', manifest);
+    expect(source).toEqual({ repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false });
+  });
+
+  it('returns null for a plugin with no known or declared update source', () => {
+    expect(resolveUpdateSource('some-unrelated-plugin', { id: 'some-unrelated-plugin', version: '1.0.0' } as any)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMatchingAsset / maskToken / redactSecret / normalizeVersion
+// ---------------------------------------------------------------------------
+
+describe('findMatchingAsset', () => {
+  it('matches a wildcard pattern against asset names', () => {
+    const assets = [
+      { name: 'fictionlab-workflow-1.2.0.zip', downloadUrl: 'x', id: 1 },
+      { name: 'fictionlab-kanban-1.2.0.zip', downloadUrl: 'y', id: 2 },
+    ];
+    expect(findMatchingAsset(assets, 'fictionlab-kanban-*.zip')?.id).toBe(2);
+    expect(findMatchingAsset(assets, 'fictionlab-workflow-*.zip')?.id).toBe(1);
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findMatchingAsset([{ name: 'other.zip', downloadUrl: 'x' }], 'fictionlab-kanban-*.zip')).toBeUndefined();
+  });
+});
+
+describe('maskToken', () => {
+  it('returns only the last 4 characters', () => {
+    expect(maskToken('github_pat_11ABCDEFGH1234567890')).toBe('7890');
+  });
+
+  it('returns undefined for empty/missing tokens', () => {
+    expect(maskToken(undefined)).toBeUndefined();
+    expect(maskToken('')).toBeUndefined();
+  });
+});
+
+describe('redactSecret', () => {
+  it('removes every occurrence of the secret from a message', () => {
+    const msg = redactSecret('fetch failed for token ghp_secret123 near ghp_secret123', 'ghp_secret123');
+    expect(msg).not.toContain('ghp_secret123');
+    expect(msg).toBe('fetch failed for token [REDACTED] near [REDACTED]');
+  });
+});
+
+describe('normalizeVersion', () => {
+  it('strips a leading v', () => {
+    expect(normalizeVersion('v1.2.3')).toBe('1.2.3');
+    expect(normalizeVersion('1.2.3')).toBe('1.2.3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPluginUpdate -- token header injection / no-token public fallback /
+// missing-token private error path / version compare
+// ---------------------------------------------------------------------------
+
+describe('checkPluginUpdate', () => {
+  it('sends Authorization: Bearer when a token is supplied (private repo)', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse({ tag_name: 'v1.1.0', assets: [SAMPLE_ASSET] })
+    );
+
+    await checkPluginUpdate({
+      pluginId: 'fictionlab-kanban',
+      pluginsDir,
+      token: 'ghp_test_token',
+      fetchFn: fetchFn as any,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases/latest',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer ghp_test_token' }) })
+    );
+  });
+
+  it('checks a public-repo plugin with no token (no-token public fallback)', async () => {
+    await writeInstalledPlugin('public-plugin', '1.0.0', {
+      updateSource: { repo: 'someone/public-repo', assetPattern: 'public-plugin-*.zip', private: false },
+    });
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse({ tag_name: 'v2.0.0', assets: [{ name: 'public-plugin-2.0.0.zip', browser_download_url: 'x', id: 5 }] })
+    );
+
+    const result = await checkPluginUpdate({ pluginId: 'public-plugin', pluginsDir, fetchFn: fetchFn as any });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.not.objectContaining({ Authorization: expect.anything() }) })
+    );
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('2.0.0');
+  });
+
+  it('returns "token-required" for a private repo with no token, without making a network call', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn();
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('token-required');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('reports "up-to-date" when the latest release is not newer than the installed version', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.5.0');
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse({ tag_name: 'v1.5.0', assets: [SAMPLE_ASSET] }));
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('up-to-date');
+  });
+
+  it('reports "update-available" with the matched asset when the release is newer', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse({ tag_name: 'v1.1.0', assets: [SAMPLE_ASSET] }));
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('1.1.0');
+    expect(result.asset?.id).toBe(999);
+  });
+
+  it('reports "no-matching-asset" when the release has no asset for this plugin', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse({ tag_name: 'v1.1.0', assets: [{ name: 'fictionlab-workflow-1.1.0.zip', browser_download_url: 'x', id: 1 }] })
+    );
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('no-matching-asset');
+  });
+
+  it('reports "no-update-source" for a plugin with no known or declared source', async () => {
+    await writeInstalledPlugin('some-unrelated-plugin', '1.0.0');
+
+    const result = await checkPluginUpdate({ pluginId: 'some-unrelated-plugin', pluginsDir });
+
+    expect(result.status).toBe('no-update-source');
+  });
+
+  it('never includes the token in a returned error message', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn().mockRejectedValue(new Error('network failure while using token super-secret-123'));
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 'super-secret-123', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('error');
+    expect(result.error).not.toContain('super-secret-123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPluginDependencies -- dependency gate block
+// ---------------------------------------------------------------------------
+
+describe('checkPluginDependencies', () => {
+  it('passes when every requirement is satisfied', () => {
+    const manifest: any = {
+      id: 'fictionlab-kanban',
+      version: '1.1.0',
+      fictionLabVersion: '>=0.3.0',
+      dependencies: { plugins: ['fictionlab-workflow'], mcpServers: ['kanban-server'] },
+    };
+    const result = checkPluginDependencies(manifest, {
+      appVersion: '0.3.0',
+      loadedPlugins: [{ id: 'fictionlab-workflow', version: '1.0.0' }],
+      runningServiceNames: ['fictionlab-kanban-server-1'],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.blockers).toEqual([]);
+  });
+
+  it('blocks on an app-version mismatch with an actionable message', () => {
+    const manifest: any = { id: 'p', version: '1.0.0', fictionLabVersion: '>=99.0.0' };
+    const result = checkPluginDependencies(manifest, { appVersion: '0.3.0', loadedPlugins: [] });
+    expect(result.ok).toBe(false);
+    expect(result.blockers[0]).toMatch(/Requires FictionLab >=99\.0\.0/);
+  });
+
+  it('blocks when a required plugin is missing', () => {
+    const manifest: any = { id: 'p', version: '1.0.0', dependencies: { plugins: ['fictionlab-workflow'] } };
+    const result = checkPluginDependencies(manifest, { appVersion: '0.3.0', loadedPlugins: [] });
+    expect(result.ok).toBe(false);
+    expect(result.blockers[0]).toMatch(/Requires plugin "fictionlab-workflow"/);
+  });
+
+  it('blocks when a required plugin is installed but at the wrong version', () => {
+    const manifest: any = { id: 'p', version: '1.0.0', dependencies: { plugins: [{ id: 'fictionlab-workflow', version: '>=2.0.0' }] } };
+    const result = checkPluginDependencies(manifest, {
+      appVersion: '0.3.0',
+      loadedPlugins: [{ id: 'fictionlab-workflow', version: '1.0.0' }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.blockers[0]).toMatch(/>=2\.0\.0/);
+  });
+
+  it('blocks when a required MCP server is not running', () => {
+    const manifest: any = { id: 'p', version: '1.0.0', dependencies: { mcpServers: ['kanban-server'] } };
+    const result = checkPluginDependencies(manifest, {
+      appVersion: '0.3.0',
+      loadedPlugins: [],
+      runningServiceNames: ['some-other-container'],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.blockers[0]).toMatch(/Requires MCP server "kanban-server"/);
+  });
+
+  it('skips the MCP-server check when runningServiceNames is not provided (never auto-installs anything)', () => {
+    const manifest: any = { id: 'p', version: '1.0.0', dependencies: { mcpServers: ['kanban-server'] } };
+    const result = checkPluginDependencies(manifest, { appVersion: '0.3.0', loadedPlugins: [] });
+    expect(result.ok).toBe(true);
+  });
+
+  it('never treats "bd"/"beads" as an installable dependency -- it only blocks, it cannot act', () => {
+    // Even if a hostile/malformed manifest declared bd as a "plugin"
+    // dependency, the gate only ever compares against already-loaded
+    // plugins and returns a blocker string -- it has no code path that
+    // shells out or installs anything.
+    const manifest: any = { id: 'p', version: '1.0.0', dependencies: { plugins: ['bd'] } };
+    const result = checkPluginDependencies(manifest, { appVersion: '0.3.0', loadedPlugins: [] });
+    expect(result.ok).toBe(false);
+    expect(result.blockers[0]).toMatch(/Install it first/);
+    // No side effects beyond the plain object return -- nothing to spy on
+    // because there is no process/exec call anywhere in this function.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadAndInstallPluginUpdate -- end-to-end with a real temp dir
+// ---------------------------------------------------------------------------
+
+describe('downloadAndInstallPluginUpdate', () => {
+  it('downloads, extracts, gates, and installs when the dependency gate passes', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => new TextEncoder().encode('fake-zip-bytes').buffer,
+    });
+
+    const extract = jest.fn().mockImplementation(async (_zipPath: string, destPath: string) => {
+      await fs.ensureDir(destPath);
+      await fs.writeJson(path.join(destPath, 'plugin.json'), {
+        id: 'fictionlab-kanban',
+        name: 'Kanban',
+        version: '1.1.0',
+        description: 'test',
+        author: 'test',
+        fictionLabVersion: '*',
+        pluginType: 'utility',
+        entry: { main: 'index.js' },
+        permissions: [],
+      });
+      await fs.writeFile(path.join(destPath, 'index.js'), 'module.exports = {};');
+    });
+
+    const outcome = await downloadAndInstallPluginUpdate({
+      pluginId: 'fictionlab-kanban',
+      pluginsDir,
+      asset: SAMPLE_ASSET as any,
+      source: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'],
+      token: 't',
+      fetchFn: fetchFn as any,
+      extract,
+      dependencyGate: { appVersion: '0.3.0', loadedPlugins: [] },
+    });
+
+    expect(outcome.status).toBe('installed');
+    const installedManifest = await readPluginManifestSafe(path.join(pluginsDir, 'fictionlab-kanban'));
+    expect(installedManifest?.version).toBe('1.1.0');
+  });
+
+  it('blocks the install and touches nothing on disk when the dependency gate fails', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => new TextEncoder().encode('fake-zip-bytes').buffer,
+    });
+
+    const extract = jest.fn().mockImplementation(async (_zipPath: string, destPath: string) => {
+      await fs.ensureDir(destPath);
+      await fs.writeJson(path.join(destPath, 'plugin.json'), {
+        id: 'fictionlab-kanban',
+        name: 'Kanban',
+        version: '1.1.0',
+        description: 'test',
+        author: 'test',
+        fictionLabVersion: '*',
+        pluginType: 'utility',
+        entry: { main: 'index.js' },
+        permissions: [],
+        dependencies: { plugins: ['fictionlab-workflow'] },
+      });
+      await fs.writeFile(path.join(destPath, 'index.js'), 'module.exports = {};');
+    });
+
+    const outcome = await downloadAndInstallPluginUpdate({
+      pluginId: 'fictionlab-kanban',
+      pluginsDir,
+      asset: SAMPLE_ASSET as any,
+      source: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'],
+      token: 't',
+      fetchFn: fetchFn as any,
+      extract,
+      dependencyGate: { appVersion: '0.3.0', loadedPlugins: [] }, // fictionlab-workflow not loaded
+    });
+
+    expect(outcome.status).toBe('dependency-blocked');
+    if (outcome.status === 'dependency-blocked') {
+      expect(outcome.blockers[0]).toMatch(/fictionlab-workflow/);
+    }
+
+    // Installed version on disk must be untouched.
+    const installedManifest = await readPluginManifestSafe(path.join(pluginsDir, 'fictionlab-kanban'));
+    expect(installedManifest?.version).toBe('1.0.0');
+  });
+
+  it('reports "download-failed" without throwing when the asset fetch fails', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const outcome = await downloadAndInstallPluginUpdate({
+      pluginId: 'fictionlab-kanban',
+      pluginsDir,
+      asset: SAMPLE_ASSET as any,
+      source: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'],
+      token: 't',
+      fetchFn: fetchFn as any,
+      dependencyGate: { appVersion: '0.3.0', loadedPlugins: [] },
+    });
+
+    expect(outcome.status).toBe('download-failed');
+  });
+});

--- a/src/main/__tests__/release-notes.test.ts
+++ b/src/main/__tests__/release-notes.test.ts
@@ -12,6 +12,7 @@ import {
   fetchReleaseByTag,
   fetchCommitDelta,
   getChangeList,
+  downloadReleaseAsset,
 } from '../release-notes';
 
 function okJsonResponse(body: any) {
@@ -128,6 +129,51 @@ describe('fetchReleaseByTag', () => {
     const result = await fetchReleaseByTag('RLRyals/MCP-Electron-App', 'v9.9.9', { fetchFn: fetchFn as any });
 
     expect(result.status).toBe('not-found');
+  });
+});
+
+describe('downloadReleaseAsset (bead mea-6tt)', () => {
+  it('requests the asset-by-id endpoint with an octet-stream Accept header and the token', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => new TextEncoder().encode('zip-bytes').buffer,
+    });
+
+    const result = await downloadReleaseAsset('RLRyals/fictionlab-workflow', 12345, {
+      token: 'ghp_test',
+      fetchFn: fetchFn as any,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.data?.toString()).toBe('zip-bytes');
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases/assets/12345',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Authorization': 'Bearer ghp_test',
+          'Accept': 'application/octet-stream',
+        }),
+      })
+    );
+  });
+
+  it('returns "not-found" (not an error) on a 404', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const result = await downloadReleaseAsset('RLRyals/fictionlab-workflow', 1, { fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('not-found');
+  });
+
+  it('returns a graceful "error" on a network failure', async () => {
+    const fetchFn = jest.fn().mockRejectedValue(new Error('network down'));
+
+    const result = await downloadReleaseAsset('RLRyals/fictionlab-workflow', 1, { fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/network down/);
   });
 });
 

--- a/src/main/env-config.ts
+++ b/src/main/env-config.ts
@@ -34,6 +34,14 @@ export interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   GITHUB_TOKEN?: string;
+  /**
+   * Fine-grained GitHub PAT scoped ONLY to RLRyals/fictionlab-workflow,
+   * read-only Contents permission -- used exclusively by the BRAT-style
+   * plugin updater (bead mea-6tt) to check/download releases from that
+   * private repo. Deliberately a distinct field from GITHUB_TOKEN (a
+   * broader-scope token used elsewhere) so the two are never conflated.
+   */
+  GITHUB_PLUGINS_TOKEN?: string;
 }
 
 /**
@@ -54,6 +62,7 @@ export const DEFAULT_CONFIG: EnvConfig = {
   OUTLINE_PORT: 3013,
   KANBAN_PORT: 3015,
   GITHUB_TOKEN: '',
+  GITHUB_PLUGINS_TOKEN: '',
 };
 
 /**
@@ -645,6 +654,9 @@ export function parseEnvFile(content: string): Partial<EnvConfig> {
         case 'GITHUB_TOKEN':
           config.GITHUB_TOKEN = unquotedValue;
           break;
+        case 'GITHUB_PLUGINS_TOKEN':
+          config.GITHUB_PLUGINS_TOKEN = unquotedValue;
+          break;
       }
     }
   }
@@ -751,6 +763,11 @@ export function formatEnvFile(config: EnvConfig): string {
   // Only include GITHUB_TOKEN if it's set
   if (config.GITHUB_TOKEN) {
     lines.push(`GITHUB_TOKEN=${config.GITHUB_TOKEN}`);
+  }
+
+  // Only include GITHUB_PLUGINS_TOKEN if it's set (bead mea-6tt)
+  if (config.GITHUB_PLUGINS_TOKEN) {
+    lines.push(`GITHUB_PLUGINS_TOKEN=${config.GITHUB_PLUGINS_TOKEN}`);
   }
 
   lines.push('');

--- a/src/main/handlers/plugin-github-update-handlers.ts
+++ b/src/main/handlers/plugin-github-update-handlers.ts
@@ -1,0 +1,168 @@
+/**
+ * Plugin GitHub Update Handlers (bead mea-6tt)
+ *
+ * IPC surface for the BRAT-style plugin updater: check installed plugins
+ * against their GitHub Releases (public or private via GITHUB_PLUGINS_TOKEN)
+ * and install an available update through the same atomic swap path the
+ * local-folder updater (issue #182 / plugin-update-handlers.ts) already
+ * uses. All GitHub-fetch and dependency-gate logic lives in
+ * `plugin-github-updater.ts`; this file is the thin Electron-facing wrapper
+ * (dialogs, IPC registration, .env token plumbing) around it.
+ *
+ * Token handling: GITHUB_PLUGINS_TOKEN is read from env-config.ts (same
+ * storage as every other .env-backed setting) and is NEVER included in any
+ * IPC response other than `plugin-updates:get-token-status`, which returns
+ * only a boolean + the last 4 characters -- never the token itself.
+ */
+
+import { ipcMain, app, dialog, BrowserWindow } from 'electron';
+import * as path from 'path';
+import { logWithCategory, LogCategory } from '../logger';
+import * as envConfig from '../env-config';
+import { pluginManager } from '../plugin-manager';
+import {
+  checkPluginUpdate,
+  downloadAndInstallPluginUpdate,
+  maskToken,
+  type LoadedPluginRef,
+} from '../plugin-github-updater';
+
+function getPluginsDirectory(): string {
+  return path.join(app.getPath('userData'), 'plugins');
+}
+
+function showMessageBox(
+  window: Electron.BrowserWindow | undefined,
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  return window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options);
+}
+
+/**
+ * Best-effort list of currently running service/container names, for the
+ * dependency gate's mcpServers check. Never throws -- an inability to
+ * determine what's running just means that part of the gate is skipped
+ * rather than blocking every install.
+ */
+async function getRunningServiceNames(): Promise<string[] | undefined> {
+  try {
+    const { getSystemStatus } = await import('../mcp-system');
+    const status = await getSystemStatus();
+    return status.containers?.map((c) => c.name).filter(Boolean) ?? [];
+  } catch (error: any) {
+    logWithCategory('warn', LogCategory.SYSTEM, `Could not determine running services for dependency gate: ${error?.message || error}`);
+    return undefined;
+  }
+}
+
+function getLoadedPluginRefs(): LoadedPluginRef[] {
+  return pluginManager.getAllPlugins().map((p) => ({ id: p.id, version: p.manifest.version }));
+}
+
+export function registerPluginGithubUpdateHandlers() {
+  // Token status for the masked UI display -- last 4 chars only, never the
+  // full token.
+  ipcMain.handle('plugin-updates:get-token-status', async () => {
+    const config = await envConfig.loadEnvConfig();
+    const last4 = maskToken(config.GITHUB_PLUGINS_TOKEN);
+    return { configured: !!last4, last4 };
+  });
+
+  // Set/replace/clear GITHUB_PLUGINS_TOKEN. Never logged.
+  ipcMain.handle('plugin-updates:set-token', async (_event, token: string) => {
+    logWithCategory('info', LogCategory.SYSTEM, 'IPC: Set GITHUB_PLUGINS_TOKEN (value not logged)');
+    const config = await envConfig.loadEnvConfig();
+    config.GITHUB_PLUGINS_TOKEN = (token || '').trim();
+    const result = await envConfig.saveEnvConfig(config);
+    return { success: result.success, error: result.error, last4: maskToken(config.GITHUB_PLUGINS_TOKEN) };
+  });
+
+  // Check a single installed plugin against its GitHub release feed.
+  ipcMain.handle('plugin-updates:check', async (_event, pluginId: string) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: Check GitHub update for plugin ${pluginId}`);
+    const config = await envConfig.loadEnvConfig();
+    const result = await checkPluginUpdate({
+      pluginId,
+      pluginsDir: getPluginsDirectory(),
+      token: config.GITHUB_PLUGINS_TOKEN || undefined,
+    });
+    // Strip the asset's GitHub API `id` bookkeeping isn't sensitive, but do
+    // not echo the token back under any circumstance -- `result` never
+    // contains it (checkPluginUpdate only accepts it, never returns it).
+    return result;
+  });
+
+  // Download + dependency-gate + atomically swap in an available update.
+  ipcMain.handle('plugin-updates:install', async (event, pluginId: string) => {
+    logWithCategory('info', LogCategory.SYSTEM, `IPC: Install GitHub update for plugin ${pluginId}`);
+    const window = BrowserWindow.fromWebContents(event.sender) ?? undefined;
+    const config = await envConfig.loadEnvConfig();
+    const token = config.GITHUB_PLUGINS_TOKEN || undefined;
+
+    const check = await checkPluginUpdate({
+      pluginId,
+      pluginsDir: getPluginsDirectory(),
+      token,
+    });
+
+    if (check.status !== 'update-available' || !check.asset || !check.source) {
+      return { success: false, status: check.status, error: check.error };
+    }
+
+    const runningServiceNames = await getRunningServiceNames();
+
+    const outcome = await downloadAndInstallPluginUpdate({
+      pluginId,
+      pluginsDir: getPluginsDirectory(),
+      asset: check.asset,
+      source: check.source,
+      token,
+      dependencyGate: {
+        appVersion: app.getVersion(),
+        loadedPlugins: getLoadedPluginRefs(),
+        runningServiceNames,
+      },
+    });
+
+    if (outcome.status === 'dependency-blocked') {
+      logWithCategory('warn', LogCategory.SYSTEM, `Update for ${pluginId} blocked by dependency gate: ${outcome.blockers.join('; ')}`);
+      return { success: false, status: 'dependency-blocked', blockers: outcome.blockers };
+    }
+
+    if (outcome.status === 'download-failed') {
+      logWithCategory('error', LogCategory.SYSTEM, `Update download failed for ${pluginId}: ${outcome.error}`);
+      return { success: false, status: 'download-failed', error: outcome.error };
+    }
+
+    if (outcome.status === 'refused') {
+      logWithCategory('warn', LogCategory.SYSTEM, `Update for ${pluginId} refused: ${outcome.message}`);
+      return { success: false, status: 'refused', code: outcome.code, message: outcome.message };
+    }
+
+    logWithCategory('info', LogCategory.SYSTEM, `Plugin ${pluginId} updated to ${outcome.validation.manifest.version} via GitHub release`);
+
+    const restart = await showMessageBox(window, {
+      type: 'info',
+      buttons: ['Restart Now', 'Later'],
+      defaultId: 0,
+      cancelId: 1,
+      title: 'Update Complete',
+      message: `Restart FictionLab to load ${outcome.validation.manifest.name || pluginId} v${outcome.validation.manifest.version}`,
+    });
+
+    if (restart.response === 0) {
+      app.relaunch();
+      app.exit(0);
+    }
+
+    return {
+      success: true,
+      status: 'installed',
+      version: outcome.validation.manifest.version,
+      previousVersion: outcome.validation.currentVersion,
+      restarting: restart.response === 0,
+    };
+  });
+
+  logWithCategory('info', LogCategory.SYSTEM, 'Plugin GitHub update handlers registered');
+}

--- a/src/main/handlers/plugin-update-handlers.ts
+++ b/src/main/handlers/plugin-update-handlers.ts
@@ -74,28 +74,6 @@ function showMessageBox(
 }
 
 /**
- * Extract a zip file
- */
-async function extractZip(zipPath: string, destPath: string): Promise<void> {
-  const { exec } = require('child_process');
-  const { promisify } = require('util');
-  const execAsync = promisify(exec);
-
-  await fs.ensureDir(destPath);
-
-  if (process.platform === 'win32') {
-    // Use PowerShell on Windows
-    await execAsync(
-      `powershell -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${destPath}' -Force"`,
-      { timeout: 60000 }
-    );
-  } else {
-    // Use unzip on Unix
-    await execAsync(`unzip -o "${zipPath}" -d "${destPath}"`, { timeout: 60000 });
-  }
-}
-
-/**
  * Register plugin update handlers
  */
 export function registerPluginUpdateHandlers() {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -443,6 +443,7 @@ import { registerImportHandlers } from './handlers/import-handlers';
 import { registerBundledPluginsHandlers } from './handlers/bundled-plugins-handlers';
 import { registerWorkflowHandlers } from './handlers/workflow-handlers';
 import { registerPluginUpdateHandlers } from './handlers/plugin-update-handlers';
+import { registerPluginGithubUpdateHandlers } from './handlers/plugin-github-update-handlers';
 import { registerGenrePackHandlers } from './handlers/genre-pack-handlers';
 import { registerLinkHandlers } from './handlers/link-handlers';
 
@@ -506,6 +507,9 @@ function setupIPC(): void {
 
   // Register plugin update handlers
   registerPluginUpdateHandlers();
+
+  // Register GitHub-release plugin update handlers (bead mea-6tt)
+  registerPluginGithubUpdateHandlers();
 
   // Register workflow handlers
   registerWorkflowHandlers();

--- a/src/main/plugin-github-updater.ts
+++ b/src/main/plugin-github-updater.ts
@@ -1,0 +1,510 @@
+/**
+ * Plugin GitHub Updater (bead mea-6tt)
+ *
+ * BRAT-style update checking + install for plugins distributed as GitHub
+ * Releases, including from a PRIVATE repo (RLRyals/fictionlab-workflow)
+ * accessed via a fine-grained PAT stored as GITHUB_PLUGINS_TOKEN in .env
+ * (see env-config.ts). Deliberately Electron-light -- the network/version
+ * logic here takes plain injectable params so it unit-tests the same way
+ * release-notes.ts does, without mocking `electron` or `app`.
+ *
+ * Builds entirely on the shared release-fetch module (release-notes.ts,
+ * bead mea-1j9) for every GitHub API call -- no duplicate fetch logic here.
+ *
+ * Flow:
+ *   1. `checkPluginUpdate()` -- resolve where this plugin's releases live
+ *      (manifest-declared `updateSource`, falling back to
+ *      `KNOWN_PLUGIN_UPDATE_SOURCES` for already-shipped plugins), fetch the
+ *      latest release, compare versions, find the asset matching this
+ *      plugin's `assetPattern`.
+ *   2. `checkPluginDependencies()` -- a pure, synchronous gate run against
+ *      the *downloaded* candidate's manifest (its dependencies may differ
+ *      from what's currently installed) before any swap happens.
+ *   3. `downloadAndInstallPluginUpdate()` -- download the matched asset,
+ *      extract it (reusing `extractZip` from utils/zip-extract.ts), run the
+ *      dependency gate, then hand off to plugin-update-swap.ts's
+ *      `updatePluginInPlace()` -- the same atomic validate+swap path the
+ *      local-folder updater (issue #182) already uses and this module does
+ *      not reimplement.
+ *
+ * Security:
+ *   - The token is never logged (only a boolean "token present" and, for
+ *     UI display, its last 4 characters -- see `maskToken`).
+ *   - `redactSecret()` strips any literal occurrence of the token out of a
+ *     message before it is logged or returned to a caller, and
+ *     `stripCredentialedUrl()` additionally scrubs auth-bearing URL
+ *     patterns (belt-and-suspenders; GitHub's API surface used here never
+ *     embeds the token in a URL, but a future asset host might).
+ *   - `beads`/`bd` is Rebecca's dev-side issue tracker, not a plugin
+ *     runtime dependency. This module has exactly one thing it ever
+ *     installs -- the downloaded plugin bundle itself, via
+ *     `updatePluginInPlace()` -- and the dependency gate below is
+ *     validate-only: it BLOCKS with an actionable message, it never
+ *     auto-installs a missing dependency (plugin, MCP server, or anything
+ *     else).
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs-extra';
+import * as semver from 'semver';
+import {
+  fetchLatestRelease,
+  downloadReleaseAsset,
+  ReleaseFetchOptions,
+  ReleaseInfo,
+  ReleaseAssetInfo,
+} from './release-notes';
+import { extractZip } from './utils/zip-extract';
+import {
+  updatePluginInPlace,
+  readPluginManifestSafe,
+  PluginUpdateError,
+  MinimalPluginManifest,
+} from './plugin-update-swap';
+
+// ---------------------------------------------------------------------------
+// Known update sources
+// ---------------------------------------------------------------------------
+
+export interface PluginUpdateSource {
+  /** GitHub "owner/repo". */
+  repo: string;
+  /** `*`-wildcard pattern matched against release asset filenames. */
+  assetPattern: string;
+  /** True when `repo` requires GITHUB_PLUGINS_TOKEN to read releases at all. */
+  private?: boolean;
+}
+
+/**
+ * Fallback update sources for plugins that were shipped before the
+ * manifest-declared `updateSource` field existed. A plugin whose manifest
+ * *does* declare `updateSource` always wins (see `resolveUpdateSource`) --
+ * this map only fills the gap for already-installed fictionlab-workflow /
+ * fictionlab-kanban copies.
+ */
+export const KNOWN_PLUGIN_UPDATE_SOURCES: Record<string, PluginUpdateSource> = {
+  'fictionlab-workflow': {
+    repo: 'RLRyals/fictionlab-workflow',
+    assetPattern: 'fictionlab-workflow-*.zip',
+    private: true,
+  },
+  'fictionlab-kanban': {
+    repo: 'RLRyals/fictionlab-workflow',
+    assetPattern: 'fictionlab-kanban-*.zip',
+    private: true,
+  },
+};
+
+export function resolveUpdateSource(
+  pluginId: string,
+  manifest: MinimalPluginManifest | null
+): PluginUpdateSource | null {
+  const declared = (manifest as any)?.updateSource;
+  if (declared && typeof declared.repo === 'string' && typeof declared.assetPattern === 'string') {
+    return {
+      repo: declared.repo,
+      assetPattern: declared.assetPattern,
+      private: !!declared.private,
+    };
+  }
+  return KNOWN_PLUGIN_UPDATE_SOURCES[pluginId] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Token masking / redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Last-4 mask for UI display. Never returns anything longer than 4 visible
+ * characters; the caller is expected to render it as "•••• <last4>".
+ */
+export function maskToken(token?: string | null): string | undefined {
+  if (!token) return undefined;
+  const trimmed = token.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length <= 4 ? trimmed : trimmed.slice(-4);
+}
+
+/**
+ * Remove every literal occurrence of `secret` from `message`. Used before
+ * logging or surfacing any error that might have interpolated raw fetch
+ * error text.
+ */
+export function redactSecret(message: string, secret?: string | null): string {
+  if (!message) return message;
+  if (!secret || !secret.trim()) return message;
+  return message.split(secret).join('[REDACTED]');
+}
+
+/**
+ * Strip credentials embedded in a URL (e.g. `https://user:pass@host/...` or
+ * `?token=...` / `?access_token=...` query params) out of a message before
+ * it is logged. Defense in depth: none of this module's own GitHub API
+ * calls put the token in a URL (it's always an Authorization header), but
+ * an upstream error message (network library, proxy) could.
+ */
+export function stripCredentialedUrl(message: string): string {
+  if (!message) return message;
+  return message
+    .replace(/:\/\/([^:/@\s]+):([^@\s]+)@/g, '://$1:[REDACTED]@')
+    .replace(/([?&])(token|access_token|api[_-]?key)=[^&\s]+/gi, '$1$2=[REDACTED]');
+}
+
+function sanitizeMessage(message: string, token?: string | null): string {
+  return stripCredentialedUrl(redactSecret(message, token));
+}
+
+// ---------------------------------------------------------------------------
+// Asset matching
+// ---------------------------------------------------------------------------
+
+/** Convert a `*`-wildcard pattern into an anchored, case-insensitive RegExp. */
+function patternToRegExp(pattern: string): RegExp {
+  const escaped = pattern
+    .split('*')
+    .map((segment) => segment.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+export function findMatchingAsset(
+  assets: ReleaseAssetInfo[] | undefined,
+  assetPattern: string
+): ReleaseAssetInfo | undefined {
+  if (!assets || assets.length === 0) return undefined;
+  const regex = patternToRegExp(assetPattern);
+  return assets.find((asset) => regex.test(asset.name || ''));
+}
+
+// ---------------------------------------------------------------------------
+// Version compare
+// ---------------------------------------------------------------------------
+
+/** Strip a leading "v"/"V" so GitHub's `v1.2.3` tags compare against plain semver. */
+export function normalizeVersion(version: string): string {
+  const trimmed = (version || '').trim();
+  return trimmed.replace(/^v/i, '');
+}
+
+// ---------------------------------------------------------------------------
+// Update check
+// ---------------------------------------------------------------------------
+
+export type PluginUpdateCheckStatus =
+  | 'up-to-date'
+  | 'update-available'
+  | 'no-update-source'
+  | 'token-required'
+  | 'no-releases'
+  | 'no-matching-asset'
+  | 'error';
+
+export interface PluginUpdateCheckResult {
+  status: PluginUpdateCheckStatus;
+  pluginId: string;
+  currentVersion?: string;
+  latestVersion?: string;
+  release?: ReleaseInfo;
+  asset?: ReleaseAssetInfo;
+  source?: PluginUpdateSource;
+  error?: string;
+}
+
+export interface CheckPluginUpdateParams {
+  pluginId: string;
+  pluginsDir: string;
+  /** GITHUB_PLUGINS_TOKEN, if configured. Never logged. */
+  token?: string;
+  fetchFn?: ReleaseFetchOptions['fetchFn'];
+  /** Injectable for tests; defaults to reading plugin.json off disk. */
+  readInstalledManifest?: (pluginPath: string) => Promise<MinimalPluginManifest | null>;
+}
+
+/**
+ * Check whether a newer release is available for an installed plugin.
+ * Never throws -- every failure path resolves to a first-class status so
+ * the caller (IPC handler / UI) can render a clean message.
+ */
+export async function checkPluginUpdate(
+  params: CheckPluginUpdateParams
+): Promise<PluginUpdateCheckResult> {
+  const { pluginId, pluginsDir, token } = params;
+  const readManifest = params.readInstalledManifest ?? readPluginManifestSafe;
+
+  const installedManifest = await readManifest(path.join(pluginsDir, pluginId));
+  const currentVersion = installedManifest?.version;
+
+  const source = resolveUpdateSource(pluginId, installedManifest);
+  if (!source) {
+    return { status: 'no-update-source', pluginId, currentVersion };
+  }
+
+  if (source.private && !token) {
+    return { status: 'token-required', pluginId, currentVersion, source };
+  }
+
+  const result = await fetchLatestRelease(source.repo, { token, fetchFn: params.fetchFn });
+
+  if (result.status === 'not-found') {
+    return { status: 'no-releases', pluginId, currentVersion, source };
+  }
+
+  if (result.status === 'error' || !result.release) {
+    return {
+      status: 'error',
+      pluginId,
+      currentVersion,
+      source,
+      error: sanitizeMessage(result.error || 'Unknown error fetching latest release.', token),
+    };
+  }
+
+  const release = result.release;
+  const latestVersion = normalizeVersion(release.tagName);
+
+  const isNewer = currentVersion
+    ? semver.valid(latestVersion) && semver.valid(currentVersion)
+      ? semver.gt(latestVersion, currentVersion)
+      : latestVersion !== currentVersion
+    : true;
+
+  if (!isNewer) {
+    return { status: 'up-to-date', pluginId, currentVersion, latestVersion, release, source };
+  }
+
+  const asset = findMatchingAsset(release.assets, source.assetPattern);
+  if (!asset) {
+    return {
+      status: 'no-matching-asset',
+      pluginId,
+      currentVersion,
+      latestVersion,
+      release,
+      source,
+      error: `Release ${release.tagName} has no asset matching pattern "${source.assetPattern}".`,
+    };
+  }
+
+  return {
+    status: 'update-available',
+    pluginId,
+    currentVersion,
+    latestVersion,
+    release,
+    asset,
+    source,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dependency gate (runs against the DOWNLOADED candidate's manifest, before
+// any file is swapped into place)
+// ---------------------------------------------------------------------------
+
+export interface LoadedPluginRef {
+  id: string;
+  version: string;
+}
+
+export interface DependencyGateOptions {
+  /** Running app version (e.g. `app.getVersion()`). */
+  appVersion: string;
+  /** Currently loaded/installed plugins, for `dependencies.plugins` checks. */
+  loadedPlugins: LoadedPluginRef[];
+  /**
+   * Names of currently-running services/containers, for
+   * `dependencies.mcpServers` checks (best-effort substring match against
+   * declared server ids -- see mcp-system.ts's `getSystemStatus()` for the
+   * real source). Omit to skip the MCP-server check entirely (e.g. when the
+   * caller can't cheaply determine this).
+   */
+  runningServiceNames?: string[];
+}
+
+export interface DependencyGateResult {
+  ok: boolean;
+  /** Human-readable, actionable reasons the install is blocked. Empty when ok. */
+  blockers: string[];
+}
+
+/**
+ * Validate a candidate plugin manifest's declared requirements against the
+ * current app/plugin/service state. Pure and synchronous by design: it only
+ * ever returns a verdict + reasons, it never installs, starts, or modifies
+ * anything -- including, explicitly, beads/bd, which is never a plugin
+ * dependency this app understands or acts on.
+ */
+export function checkPluginDependencies(
+  manifest: MinimalPluginManifest,
+  options: DependencyGateOptions
+): DependencyGateResult {
+  const blockers: string[] = [];
+  const deps = (manifest as any)?.dependencies as
+    | { mcpServers?: Array<string | { id: string; version?: string }>; plugins?: Array<string | { id: string; version?: string }>; fictionlabApi?: string }
+    | undefined;
+  const fictionLabVersion = (manifest as any)?.fictionLabVersion as string | undefined;
+
+  if (fictionLabVersion) {
+    if (!semver.validRange(fictionLabVersion)) {
+      blockers.push(`Plugin declares an invalid required app version range: "${fictionLabVersion}".`);
+    } else if (!semver.satisfies(options.appVersion, fictionLabVersion)) {
+      blockers.push(
+        `Requires FictionLab ${fictionLabVersion}, but this app is running ${options.appVersion}. Update FictionLab first.`
+      );
+    }
+  }
+
+  if (deps?.plugins?.length) {
+    const loadedById = new Map(options.loadedPlugins.map((p) => [p.id, p.version]));
+    for (const dep of deps.plugins) {
+      const depId = typeof dep === 'string' ? dep : dep.id;
+      const depVersionRange = typeof dep === 'object' ? dep.version : undefined;
+      const installedVersion = loadedById.get(depId);
+
+      if (!installedVersion) {
+        blockers.push(`Requires plugin "${depId}", which is not installed. Install it first.`);
+      } else if (depVersionRange && !semver.satisfies(installedVersion, depVersionRange)) {
+        blockers.push(
+          `Requires plugin "${depId}" ${depVersionRange}, but ${installedVersion} is installed. Update "${depId}" first.`
+        );
+      }
+    }
+  }
+
+  if (deps?.mcpServers?.length && options.runningServiceNames) {
+    const running = options.runningServiceNames.map((n) => n.toLowerCase());
+    for (const dep of deps.mcpServers) {
+      const depId = typeof dep === 'string' ? dep : dep.id;
+      const isRunning = running.some((name) => name.includes(depId.toLowerCase()));
+      if (!isRunning) {
+        blockers.push(`Requires MCP server "${depId}" to be running. Start it first (Settings → Services).`);
+      }
+    }
+  }
+
+  return { ok: blockers.length === 0, blockers };
+}
+
+// ---------------------------------------------------------------------------
+// Download + install
+// ---------------------------------------------------------------------------
+
+export interface DownloadAndInstallParams {
+  pluginId: string;
+  pluginsDir: string;
+  asset: ReleaseAssetInfo;
+  source: PluginUpdateSource;
+  token?: string;
+  fetchFn?: ReleaseFetchOptions['fetchFn'];
+  dependencyGate: DependencyGateOptions;
+  /** Injectable temp-dir root for tests; defaults to os.tmpdir(). */
+  tmpRoot?: string;
+  /** Injectable zip extraction for tests; defaults to the real extractZip. */
+  extract?: (zipPath: string, destPath: string) => Promise<void>;
+}
+
+export type PluginInstallOutcome =
+  | { status: 'installed'; validation: { manifest: MinimalPluginManifest; currentVersion: string | null } }
+  | { status: 'dependency-blocked'; blockers: string[] }
+  | { status: 'download-failed'; error: string }
+  | { status: 'refused'; code: PluginUpdateError['code']; message: string };
+
+/**
+ * Download the matched release asset, extract it, gate it on its declared
+ * dependencies, and -- only if the gate passes -- hand off to
+ * `updatePluginInPlace()` for the same atomic validate+swap path the
+ * local-folder updater uses. Never throws for expected failure modes
+ * (download error, dependency block, refused swap); only an unexpected
+ * filesystem error propagates.
+ */
+export async function downloadAndInstallPluginUpdate(
+  params: DownloadAndInstallParams
+): Promise<PluginInstallOutcome> {
+  const { pluginId, pluginsDir, asset, source, token } = params;
+  const extract = params.extract ?? extractZip;
+  const tmpRoot = params.tmpRoot ?? os.tmpdir();
+
+  if (typeof asset.id !== 'number') {
+    return {
+      status: 'download-failed',
+      error: 'Release asset is missing its numeric id; cannot download.',
+    };
+  }
+
+  const downloadResult = await downloadReleaseAsset(source.repo, asset.id, {
+    token,
+    fetchFn: params.fetchFn,
+  });
+
+  if (downloadResult.status !== 'ok' || !downloadResult.data) {
+    return {
+      status: 'download-failed',
+      error: sanitizeMessage(downloadResult.error || 'Failed to download release asset.', token),
+    };
+  }
+
+  const workDir = await fs.mkdtemp(path.join(tmpRoot, `fictionlab-plugin-update-${pluginId}-`));
+  try {
+    const zipPath = path.join(workDir, asset.name || 'plugin-update.zip');
+    await fs.writeFile(zipPath, downloadResult.data);
+
+    const extractedDir = path.join(workDir, 'extracted');
+    await extract(zipPath, extractedDir);
+
+    // A release zip may either contain plugin.json at its root, or wrap
+    // everything in a single top-level folder (common for GitHub's
+    // "Source code" style archives and hand-built release zips alike).
+    // Resolve to whichever level actually has plugin.json.
+    const candidateDir = await resolvePluginRoot(extractedDir);
+
+    const candidateManifest = await readPluginManifestSafe(candidateDir);
+    if (!candidateManifest) {
+      return {
+        status: 'download-failed',
+        error: 'Downloaded plugin bundle does not contain a valid plugin.json.',
+      };
+    }
+
+    const gate = checkPluginDependencies(candidateManifest, params.dependencyGate);
+    if (!gate.ok) {
+      return { status: 'dependency-blocked', blockers: gate.blockers };
+    }
+
+    try {
+      const validation = await updatePluginInPlace(pluginsDir, pluginId, candidateDir);
+      return { status: 'installed', validation };
+    } catch (error: any) {
+      if (error instanceof PluginUpdateError) {
+        return { status: 'refused', code: error.code, message: error.message };
+      }
+      throw error;
+    }
+  } finally {
+    await fs.remove(workDir).catch(() => {
+      /* best effort -- OS temp cleanup will eventually reclaim this */
+    });
+  }
+}
+
+/** Find the directory (extractedDir itself, or its sole child) containing plugin.json. */
+async function resolvePluginRoot(extractedDir: string): Promise<string> {
+  if (await fs.pathExists(path.join(extractedDir, 'plugin.json'))) {
+    return extractedDir;
+  }
+
+  try {
+    const entries = await fs.readdir(extractedDir, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory());
+    if (dirs.length === 1) {
+      const nested = path.join(extractedDir, dirs[0].name);
+      if (await fs.pathExists(path.join(nested, 'plugin.json'))) {
+        return nested;
+      }
+    }
+  } catch {
+    // fall through -- readPluginManifestSafe on extractedDir will report "invalid"
+  }
+
+  return extractedDir;
+}

--- a/src/main/release-notes.ts
+++ b/src/main/release-notes.ts
@@ -7,9 +7,10 @@
  *   - `app-updater.ts` (the FictionLab self-update check, issue #213 / PR #218)
  *   - `whats-new.ts` (the post-update "What's New" panel)
  *   - `updater.ts` (managed-repo commit deltas around the mws pull)
- *   - the upcoming private-repo plugin updater (bead mea-6tt) -- every
- *     function takes an optional `token` for `Authorization: Bearer` access
- *     to private repos, so that feature can reuse this module as-is.
+ *   - `plugin-github-updater.ts` (private-repo plugin updater, bead mea-6tt)
+ *     -- every function takes an optional `token` for `Authorization: Bearer`
+ *     access to private repos; `downloadReleaseAsset` additionally streams
+ *     an asset's raw bytes via the same authenticated path.
  *
  * All functions never throw: failures resolve to `{ status: 'error' }` (or
  * the first-class `'not-found'` state) so callers can degrade gracefully --
@@ -30,6 +31,15 @@ export interface ReleaseAssetInfo {
   name: string;
   downloadUrl: string;
   size?: number;
+  /**
+   * GitHub's numeric asset id. Needed to download from a PRIVATE repo:
+   * `downloadUrl` (browser_download_url) redirects to a signed storage URL
+   * that only works for public assets or an authenticated browser session,
+   * while the `/releases/assets/{id}` API endpoint (see
+   * `downloadReleaseAsset` below) accepts the same `Authorization: Bearer`
+   * header as every other call in this module (bead mea-6tt).
+   */
+  id?: number;
 }
 
 export interface ReleaseInfo {
@@ -101,6 +111,7 @@ function parseRelease(release: any): ReleaseFetchResult {
         name: asset?.name,
         downloadUrl: asset?.browser_download_url,
         size: asset?.size,
+        id: typeof asset?.id === 'number' ? asset.id : undefined,
       }))
     : undefined;
 
@@ -214,6 +225,59 @@ export async function fetchCommitDelta(
     // Newest first, matching `git log` ordering (the compare API returns
     // oldest first).
     return { status: 'ok', commits: commits.reverse() };
+  } catch (error: any) {
+    return { status: 'error', error: error?.message || String(error) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Release asset download (bead mea-6tt: private-repo plugin updater)
+// ---------------------------------------------------------------------------
+
+export interface AssetDownloadResult {
+  status: FetchStatus;
+  /** Raw asset bytes on success. */
+  data?: Buffer;
+  error?: string;
+}
+
+/**
+ * Download a release asset by its numeric id via the GitHub API, using
+ * `Accept: application/octet-stream` so GitHub streams the raw bytes
+ * instead of the asset's JSON metadata. Works uniformly for public and
+ * private repos (unlike `browser_download_url`, which requires either no
+ * auth (public) or an authenticated browser session (private) -- the API
+ * endpoint accepts the same Bearer token as every other call here).
+ *
+ * Never throws; failures resolve to `{ status: 'error' }` so callers can
+ * show a clean message instead of an unhandled rejection. The error
+ * message intentionally never includes the request URL (it carries no
+ * credentials, but keeping this module's error surface URL-free avoids
+ * ever having to reason about what a future asset URL might embed).
+ */
+export async function downloadReleaseAsset(
+  repo: string,
+  assetId: number,
+  options: ReleaseFetchOptions = {}
+): Promise<AssetDownloadResult> {
+  const fetchFn = options.fetchFn ?? fetch;
+
+  try {
+    const url = `${GITHUB_API_BASE}/repos/${repo}/releases/assets/${assetId}`;
+    const response = await fetchFn(url, {
+      headers: {
+        ...buildHeaders(options.token),
+        'Accept': 'application/octet-stream',
+      },
+    });
+
+    if (!response.ok) {
+      const mapped = mapErrorResponse(response);
+      return { status: mapped.status, error: mapped.error };
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return { status: 'ok', data: Buffer.from(arrayBuffer) };
   } catch (error: any) {
     return { status: 'error', error: error?.message || String(error) };
   }

--- a/src/main/utils/zip-extract.ts
+++ b/src/main/utils/zip-extract.ts
@@ -1,0 +1,38 @@
+/**
+ * Zip extraction utility.
+ *
+ * Deliberately Electron-free (only `child_process`/`fs-extra`) so it can be
+ * imported by Electron-light modules without dragging in the main process's
+ * full bootstrap chain (`ipcMain`, `app`, the plugin manager, etc.).
+ * Originally lived inline in handlers/plugin-update-handlers.ts; pulled out
+ * here so the GitHub-release plugin updater (bead mea-6tt,
+ * plugin-github-updater.ts) can reuse it without importing that handler
+ * file's `electron`/`plugin-manager` dependencies -- which pull in
+ * `main/index.ts`'s app-bootstrap side effects and made plugin-github-updater
+ * tests noisy (stray post-teardown logging from `ensureDockerReadyForLaunch`).
+ */
+
+import * as fs from 'fs-extra';
+
+/**
+ * Extract a zip file to a destination directory (created if missing).
+ * Uses PowerShell's Expand-Archive on Windows, `unzip` elsewhere.
+ */
+export async function extractZip(zipPath: string, destPath: string): Promise<void> {
+  const { exec } = require('child_process');
+  const { promisify } = require('util');
+  const execAsync = promisify(exec);
+
+  await fs.ensureDir(destPath);
+
+  if (process.platform === 'win32') {
+    // Use PowerShell on Windows
+    await execAsync(
+      `powershell -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${destPath}' -Force"`,
+      { timeout: 60000 }
+    );
+  } else {
+    // Use unzip on Unix
+    await execAsync(`unzip -o "${zipPath}" -d "${destPath}"`, { timeout: 60000 });
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -80,6 +80,9 @@ interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  GITHUB_TOKEN?: string;
+  /** Fine-grained PAT for the private plugin repo (bead mea-6tt). */
+  GITHUB_PLUGINS_TOKEN?: string;
 }
 
 /**
@@ -2387,6 +2390,35 @@ contextBridge.exposeInMainWorld('electronAPI', {
      */
     getPluginPath: (pluginId: string): Promise<string> => {
       return ipcRenderer.invoke('plugin:get-path', pluginId);
+    },
+
+    /**
+     * GitHub Plugins Token status for masked UI display (bead mea-6tt).
+     * Returns only `configured` + the last 4 characters -- never the token.
+     */
+    getGithubTokenStatus: (): Promise<{ configured: boolean; last4?: string }> => {
+      return ipcRenderer.invoke('plugin-updates:get-token-status');
+    },
+
+    /**
+     * Set/replace/clear GITHUB_PLUGINS_TOKEN.
+     */
+    setGithubToken: (token: string): Promise<{ success: boolean; error?: string; last4?: string }> => {
+      return ipcRenderer.invoke('plugin-updates:set-token', token);
+    },
+
+    /**
+     * Check an installed plugin against its GitHub release feed.
+     */
+    checkGithubUpdate: (pluginId: string): Promise<any> => {
+      return ipcRenderer.invoke('plugin-updates:check', pluginId);
+    },
+
+    /**
+     * Download + dependency-gate + install an available GitHub-release update.
+     */
+    installGithubUpdate: (pluginId: string): Promise<any> => {
+      return ipcRenderer.invoke('plugin-updates:install', pluginId);
     },
   },
 

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -19,6 +19,7 @@ interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   GITHUB_TOKEN?: string;
+  GITHUB_PLUGINS_TOKEN?: string;
 }
 
 /**
@@ -239,6 +240,10 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       // Not exposed as a form field on this form - preserve existing value so a
       // re-save doesn't silently erase a stored GitHub token
       GITHUB_TOKEN: currentEnvConfig?.GITHUB_TOKEN,
+      // Not exposed as a form field here either - set from the Plugins settings
+      // surface (bead mea-6tt); preserve existing value so a re-save here
+      // doesn't silently erase it
+      GITHUB_PLUGINS_TOKEN: currentEnvConfig?.GITHUB_PLUGINS_TOKEN,
     };
 
     const validation = await (window as any).electronAPI.envConfig.validateConfig(config);

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -734,6 +734,9 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             // Not exposed in this wizard step - preserve existing value so a re-save
             // doesn't silently erase a stored GitHub token
             GITHUB_TOKEN: currentConfig?.GITHUB_TOKEN,
+            // Not exposed in this wizard step either - set from the Plugins
+            // settings surface (bead mea-6tt); preserve existing value
+            GITHUB_PLUGINS_TOKEN: currentConfig?.GITHUB_PLUGINS_TOKEN,
         };
 
         // Check if .env file actually exists on disk

--- a/src/renderer/views/PluginsLauncher.ts
+++ b/src/renderer/views/PluginsLauncher.ts
@@ -440,6 +440,54 @@ export class PluginsLauncher implements View {
         <h2 style="margin: 0; color: var(--text-primary, #fff);">Manage Plugins</h2>
         <button id="close-manage-dialog" style="background: none; border: none; color: var(--text-secondary, #888); font-size: 24px; cursor: pointer;">&times;</button>
       </div>
+      <div id="github-token-section" style="
+        background: var(--bg-tertiary, #2a2a2a);
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-bottom: 16px;
+        color: var(--text-primary, #fff);
+        font-size: 13px;
+      ">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px;">
+          <div>
+            <strong>GitHub Plugins Token</strong>
+            <div id="github-token-status" style="color: var(--text-secondary, #888); margin-top: 2px;">Checking…</div>
+          </div>
+          <button id="github-token-edit-btn" style="
+            background: var(--bg-quaternary, #3a3a3a);
+            color: var(--text-primary, #fff);
+            border: none;
+            padding: 6px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+          ">Set Token…</button>
+        </div>
+        <div id="github-token-edit-row" style="display: none; margin-top: 10px; gap: 8px; align-items: center;">
+          <input type="password" id="github-token-input" placeholder="Fine-grained PAT (Contents: read-only)" style="
+            flex: 1;
+            padding: 6px 8px;
+            border-radius: 6px;
+            border: 1px solid var(--border-color, #444);
+            background: var(--bg-secondary, #1e1e1e);
+            color: var(--text-primary, #fff);
+            font-size: 12px;
+            width: 70%;
+          ">
+          <button id="github-token-save-btn" style="
+            background: var(--accent-color, #4a7dfc);
+            color: white;
+            border: none;
+            padding: 6px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 12px;
+          ">Save</button>
+        </div>
+        <p style="color: var(--text-tertiary, #666); margin: 8px 0 0 0; font-size: 11px;">
+          Scoped to RLRyals/fictionlab-workflow only, read-only Contents access. Required to check/install updates for private-repo plugins (fictionlab-workflow, fictionlab-kanban).
+        </p>
+      </div>
       <div id="plugin-list-container" style="color: var(--text-primary, #fff);">
         <div style="text-align: center; padding: 20px;">Loading plugins...</div>
       </div>
@@ -454,6 +502,9 @@ export class PluginsLauncher implements View {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) overlay.remove();
     });
+
+    // GitHub Plugins Token (bead mea-6tt): masked status + set/change.
+    await this.setupGithubTokenSection(dialog);
 
     // Load plugins
     const container = dialog.querySelector('#plugin-list-container');
@@ -494,6 +545,15 @@ export class PluginsLauncher implements View {
               </div>
             </div>
             <div style="display: flex; gap: 8px; flex-shrink: 0; flex-wrap: wrap;">
+              <button class="plugin-github-check-btn" data-plugin-id="${this.escapeHtml(plugin.id)}" title="Check GitHub releases for an update" style="
+                background: var(--bg-quaternary, #3a3a3a);
+                color: var(--text-primary, #fff);
+                border: none;
+                padding: 8px 12px;
+                border-radius: 6px;
+                cursor: pointer;
+                font-size: 13px;
+              ">Check for Updates</button>
               <button class="plugin-folder-btn" data-plugin-id="${this.escapeHtml(plugin.id)}" title="Update this plugin in place from a local plugin folder" style="
                 background: var(--bg-quaternary, #3a3a3a);
                 color: var(--text-primary, #fff);
@@ -593,6 +653,84 @@ export class PluginsLauncher implements View {
         });
       });
 
+      // Add event listeners for "Check for Updates" buttons (bead mea-6tt:
+      // GitHub-release plugin updater). Flow lives in the main process
+      // (plugin-github-updater.ts + handlers/plugin-github-update-handlers.ts):
+      // resolve update source -> fetch latest release -> compare versions ->
+      // on "Install", download the matching asset, gate on its declared
+      // dependencies, then reuse the same atomic swap as the folder updater.
+      container.querySelectorAll('.plugin-github-check-btn').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          const pluginId = (e.target as HTMLElement).getAttribute('data-plugin-id');
+          if (!pluginId) return;
+
+          const statusEl = container.querySelector(`.plugin-status[data-plugin-id="${pluginId}"]`) as HTMLElement;
+          const button = e.target as HTMLButtonElement;
+
+          button.disabled = true;
+          button.textContent = 'Checking…';
+          if (statusEl) {
+            statusEl.style.display = 'block';
+            statusEl.style.color = 'var(--text-secondary, #888)';
+            statusEl.textContent = 'Checking GitHub for a newer release…';
+          }
+
+          try {
+            const result = await (window as any).electronAPI.plugins.checkGithubUpdate(pluginId);
+            button.disabled = false;
+            button.textContent = 'Check for Updates';
+
+            if (!statusEl) return;
+
+            switch (result.status) {
+              case 'update-available':
+                statusEl.style.color = 'var(--accent-color, #4a7dfc)';
+                statusEl.innerHTML = '';
+                statusEl.textContent = `Update available: ${result.currentVersion ?? 'unknown'} → ${result.latestVersion}. `;
+                {
+                  const installBtn = document.createElement('button');
+                  installBtn.textContent = 'Install Update';
+                  installBtn.style.cssText = 'margin-left: 6px; background: var(--accent-color, #4a7dfc); color: white; border: none; padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 12px;';
+                  installBtn.addEventListener('click', () => this.installGithubUpdate(pluginId, statusEl, installBtn));
+                  statusEl.appendChild(installBtn);
+                }
+                break;
+              case 'up-to-date':
+                statusEl.style.color = 'var(--success-color, #4caf50)';
+                statusEl.textContent = `Already up to date (v${result.currentVersion}).`;
+                break;
+              case 'token-required':
+                statusEl.style.color = 'var(--danger-color, #d32f2f)';
+                statusEl.textContent = 'This plugin\'s repo is private. Set a GitHub Plugins Token above to check for updates.';
+                break;
+              case 'no-update-source':
+                statusEl.style.color = 'var(--text-secondary, #888)';
+                statusEl.textContent = 'No update source configured for this plugin.';
+                break;
+              case 'no-releases':
+                statusEl.style.color = 'var(--text-secondary, #888)';
+                statusEl.textContent = 'No published releases found yet.';
+                break;
+              case 'no-matching-asset':
+                statusEl.style.color = 'var(--danger-color, #d32f2f)';
+                statusEl.textContent = result.error || 'Release found but no matching asset.';
+                break;
+              default:
+                statusEl.style.color = 'var(--danger-color, #d32f2f)';
+                statusEl.textContent = result.error || 'Update check failed.';
+            }
+          } catch (error: any) {
+            button.disabled = false;
+            button.textContent = 'Check for Updates';
+            if (statusEl) {
+              statusEl.style.display = 'block';
+              statusEl.style.color = 'var(--danger-color, #d32f2f)';
+              statusEl.textContent = `Update check failed: ${error.message}`;
+            }
+          }
+        });
+      });
+
       // Add event listeners for "Open Folder" buttons
       container.querySelectorAll('.plugin-open-btn').forEach(btn => {
         btn.addEventListener('click', async (e) => {
@@ -652,6 +790,102 @@ export class PluginsLauncher implements View {
         </div>
       `;
     }
+  }
+
+  /**
+   * Install a checked GitHub-release update for a plugin (bead mea-6tt).
+   * Called from the "Install Update" button injected by the "Check for
+   * Updates" handler above.
+   */
+  private async installGithubUpdate(pluginId: string, statusEl: HTMLElement, installBtn: HTMLButtonElement): Promise<void> {
+    installBtn.disabled = true;
+    installBtn.textContent = 'Installing…';
+
+    try {
+      const result = await (window as any).electronAPI.plugins.installGithubUpdate(pluginId);
+
+      if (result.success) {
+        statusEl.style.color = 'var(--success-color, #4caf50)';
+        statusEl.textContent = result.restarting
+          ? `Updated to v${result.version}. Restarting…`
+          : `Updated to v${result.version}. Restart FictionLab whenever you're ready to load it.`;
+        return;
+      }
+
+      statusEl.style.color = 'var(--danger-color, #d32f2f)';
+      if (result.status === 'dependency-blocked') {
+        statusEl.textContent = `Update blocked: ${(result.blockers || []).join(' ')}`;
+      } else if (result.status === 'refused') {
+        statusEl.textContent = result.message || 'Update refused.';
+      } else {
+        statusEl.textContent = result.error || 'Update failed.';
+      }
+      installBtn.disabled = false;
+      installBtn.textContent = 'Install Update';
+    } catch (error: any) {
+      statusEl.style.color = 'var(--danger-color, #d32f2f)';
+      statusEl.textContent = `Update failed: ${error.message}`;
+      installBtn.disabled = false;
+      installBtn.textContent = 'Install Update';
+    }
+  }
+
+  /**
+   * Wire up the masked GitHub Plugins Token display + set/change control
+   * (bead mea-6tt). The full token is only ever sent from this input,
+   * directly to `plugins.setGithubToken` -- it is never fetched back for
+   * display; the status line only shows `configured` + last 4 characters.
+   */
+  private async setupGithubTokenSection(dialog: HTMLElement): Promise<void> {
+    const statusEl = dialog.querySelector('#github-token-status') as HTMLElement;
+    const editBtn = dialog.querySelector('#github-token-edit-btn') as HTMLButtonElement;
+    const editRow = dialog.querySelector('#github-token-edit-row') as HTMLElement;
+    const input = dialog.querySelector('#github-token-input') as HTMLInputElement;
+    const saveBtn = dialog.querySelector('#github-token-save-btn') as HTMLButtonElement;
+    if (!statusEl || !editBtn || !editRow || !input || !saveBtn) return;
+
+    const refreshStatus = async () => {
+      try {
+        const status = await (window as any).electronAPI.plugins.getGithubTokenStatus();
+        statusEl.textContent = status.configured
+          ? `Configured (••••${status.last4})`
+          : 'Not configured — private-repo plugin updates unavailable.';
+      } catch (error: any) {
+        statusEl.textContent = `Could not read token status: ${error.message}`;
+      }
+    };
+
+    editBtn.addEventListener('click', () => {
+      editRow.style.display = editRow.style.display === 'none' ? 'flex' : 'none';
+      if (editRow.style.display === 'flex') input.focus();
+    });
+
+    saveBtn.addEventListener('click', async () => {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
+      try {
+        const result = await (window as any).electronAPI.plugins.setGithubToken(input.value);
+        if (result.success) {
+          input.value = '';
+          editRow.style.display = 'none';
+          await refreshStatus();
+          if ((window as any).showNotification) {
+            (window as any).showNotification('GitHub Plugins Token saved', 'success');
+          }
+        } else if ((window as any).showNotification) {
+          (window as any).showNotification(`Failed to save token: ${result.error}`, 'error');
+        }
+      } catch (error: any) {
+        if ((window as any).showNotification) {
+          (window as any).showNotification(`Failed to save token: ${error.message}`, 'error');
+        }
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+      }
+    });
+
+    await refreshStatus();
   }
 
   /**

--- a/src/types/plugin-api.ts
+++ b/src/types/plugin-api.ts
@@ -70,6 +70,27 @@ export interface PluginManifest {
     fictionlabApi?: string;
   };
 
+  /**
+   * Where to check for updates (bead mea-6tt, BRAT-style private-repo
+   * plugin updater). Optional: when a plugin omits this, the app falls
+   * back to a small built-in map of known plugin repos (see
+   * `KNOWN_PLUGIN_UPDATE_SOURCES` in `src/main/plugin-github-updater.ts`)
+   * so already-shipped plugins (fictionlab-workflow, fictionlab-kanban)
+   * still update without needing a manifest change first.
+   */
+  updateSource?: {
+    /** GitHub "owner/repo", e.g. "RLRyals/fictionlab-workflow". */
+    repo: string;
+    /**
+     * Glob-ish pattern (only `*` is special) matched against release asset
+     * filenames to pick this plugin's zip out of a release that may bundle
+     * multiple plugins' assets together.
+     */
+    assetPattern: string;
+    /** True when `repo` requires a token (see GITHUB_PLUGINS_TOKEN). */
+    private?: boolean;
+  };
+
   /** UI integration points */
   ui?: PluginUIConfig;
 


### PR DESCRIPTION
## Summary

- Adds GitHub-release-based update checking + install for plugins, including plugins hosted in a private repo, accessed via a fine-grained PAT (`GITHUB_PLUGINS_TOKEN`) stored in `.env`. The token is masked to its last 4 characters everywhere in the UI and is never logged.
- Reuses the existing shared GitHub-release-fetch module for all network calls (no duplicate fetch logic) and the existing atomic validate+swap path for installing plugin updates (no reimplemented plugin installation).
- Before installing an update, gates it against the downloaded plugin's own declared requirements: minimum app version, required sibling plugins (with version ranges), and required running MCP servers. A missing requirement blocks the install with an actionable message instead of failing at runtime.
- `beads`/`bd` (the maintainer's dev-side issue tracker) is explicitly never treated as a plugin dependency anywhere in this feature — the dependency gate only ever blocks with a message; it has no code path that installs anything beyond the plugin bundle itself.
- Token settings live in the Plugins management surface (not a Services/port row — a secret doesn't belong there), alongside a per-plugin "Check for Updates" / "Install Update" flow.

## Test plan

- [x] `npm run build` — clean (renderer + main TypeScript compile, asset copy)
- [x] `npx jest --config jest.config.ci.cjs` — 42 suites / 444 tests passed (0 failures)
- [x] New unit tests cover: Authorization header sent when a token is supplied; public-repo plugins update with no token; a private-repo plugin with no token returns a clear "token required" result without making a network call; version comparison (up-to-date / update-available / no-matching-asset); and the dependency gate blocking on app-version, missing-plugin, wrong-plugin-version, and missing-MCP-server cases
- [x] End-to-end install path tested against a real temp directory: download → extract → dependency gate → atomic swap, including a case where the gate blocks and the on-disk plugin version is verified unchanged
- [ ] Manual verification against the real private repo with a real fine-grained PAT (not exercised in this environment)

Closes bead: mea-6tt

🤖 Generated with [Claude Code](https://claude.com/claude-code)