### PR TITLE
docker-compose: publish story-analysis (3016) HTTP port to the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       - "${WORKFLOW_MANAGER_PORT}:3012"  # Workflow Manager (host side remappable, container fixed at 3012)
       - "${OUTLINE_PORT}:3013"  # Outline Server (host side remappable, container fixed at 3013)
       - "${KANBAN_PORT}:3015"  # Kanban Server (host side remappable, container fixed at 3015)
+      - "${STORY_ANALYSIS_PORT}:3016"  # Story Analysis Server (host side remappable, container fixed at 3016)
     environment:
       # PRIMARY: Use PgBouncer for connection pooling (internal Docker network port)
       # CRITICAL: Use container name and INTERNAL port (6432), NOT the external ${PGBOUNCER_PORT} variable

--- a/src/main/env-config.ts
+++ b/src/main/env-config.ts
@@ -33,6 +33,7 @@ export interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  STORY_ANALYSIS_PORT: number;
   GITHUB_TOKEN?: string;
 }
 
@@ -53,6 +54,7 @@ export const DEFAULT_CONFIG: EnvConfig = {
   WORKFLOW_MANAGER_PORT: 3012,
   OUTLINE_PORT: 3013,
   KANBAN_PORT: 3015,
+  STORY_ANALYSIS_PORT: 3016,
   GITHUB_TOKEN: '',
 };
 
@@ -463,6 +465,7 @@ export async function checkAllPortsAndSuggestAlternatives(
     { port: config.WORKFLOW_MANAGER_PORT, name: 'Workflow Manager', key: 'WORKFLOW_MANAGER_PORT' as const },
     { port: config.OUTLINE_PORT, name: 'Outline Server', key: 'OUTLINE_PORT' as const },
     { port: config.KANBAN_PORT, name: 'Kanban Server', key: 'KANBAN_PORT' as const },
+    { port: config.STORY_ANALYSIS_PORT, name: 'Story Analysis Server', key: 'STORY_ANALYSIS_PORT' as const },
   ];
 
   // Check configurable ports
@@ -642,6 +645,9 @@ export function parseEnvFile(content: string): Partial<EnvConfig> {
         case 'KANBAN_PORT':
           config.KANBAN_PORT = parseInt(unquotedValue, 10);
           break;
+        case 'STORY_ANALYSIS_PORT':
+          config.STORY_ANALYSIS_PORT = parseInt(unquotedValue, 10);
+          break;
         case 'GITHUB_TOKEN':
           config.GITHUB_TOKEN = unquotedValue;
           break;
@@ -746,6 +752,7 @@ export function formatEnvFile(config: EnvConfig): string {
     `WORKFLOW_MANAGER_PORT=${config.WORKFLOW_MANAGER_PORT}`,
     `OUTLINE_PORT=${config.OUTLINE_PORT}`,
     `KANBAN_PORT=${config.KANBAN_PORT}`,
+    `STORY_ANALYSIS_PORT=${config.STORY_ANALYSIS_PORT}`,
   ];
 
   // Only include GITHUB_TOKEN if it's set
@@ -855,6 +862,11 @@ export function validateConfig(config: EnvConfig): { valid: boolean; errors: str
   const kanbanPortValidation = validatePort(config.KANBAN_PORT);
   if (!kanbanPortValidation.valid) {
     errors.push(`Kanban port: ${kanbanPortValidation.error}`);
+  }
+
+  const storyAnalysisPortValidation = validatePort(config.STORY_ANALYSIS_PORT);
+  if (!storyAnalysisPortValidation.valid) {
+    errors.push(`Story Analysis port: ${storyAnalysisPortValidation.error}`);
   }
 
   // Validate auth token

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -678,6 +678,7 @@ async function execDockerCompose(
         WORKFLOW_MANAGER_PORT: String(config.WORKFLOW_MANAGER_PORT),
         OUTLINE_PORT: String(config.OUTLINE_PORT),
         KANBAN_PORT: String(config.KANBAN_PORT),
+        STORY_ANALYSIS_PORT: String(config.STORY_ANALYSIS_PORT),
         MCP_AUTH_TOKEN: config.MCP_AUTH_TOKEN,
         // Path to MCP config file for Docker volume mounting
         MCP_CONFIG_FILE_PATH: mcpConfigPath,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -80,6 +80,7 @@ interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  STORY_ANALYSIS_PORT: number;
 }
 
 /**

--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -40,6 +40,7 @@ interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  STORY_ANALYSIS_PORT: number;
 }
 
 /**
@@ -109,7 +110,7 @@ const MCP_SERVERS: Array<{
  * A single row in the Ports settings table
  */
 interface PortRowDefinition {
-  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT' | 'OUTLINE_PORT' | 'KANBAN_PORT';
+  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT' | 'OUTLINE_PORT' | 'KANBAN_PORT' | 'STORY_ANALYSIS_PORT';
   name: string;
 }
 
@@ -126,6 +127,7 @@ const PORT_ROWS: PortRowDefinition[] = [
   { key: 'WORKFLOW_MANAGER_PORT', name: 'Workflow Manager' },
   { key: 'OUTLINE_PORT', name: 'Outline Server' },
   { key: 'KANBAN_PORT', name: 'Kanban Server' },
+  { key: 'STORY_ANALYSIS_PORT', name: 'Story Analysis Server' },
 ];
 
 export class ServicesTab {

--- a/src/renderer/components/__tests__/ServicesTab.test.ts
+++ b/src/renderer/components/__tests__/ServicesTab.test.ts
@@ -60,6 +60,7 @@ const CONFIG_FIXTURE = {
   WORKFLOW_MANAGER_PORT: 8766,
   OUTLINE_PORT: 8767,
   KANBAN_PORT: 8768,
+  STORY_ANALYSIS_PORT: 8769,
 };
 
 /**
@@ -195,7 +196,7 @@ describe('Services tab (issue #124)', () => {
     expect(container.textContent).toContain('Docker Desktop');
 
     const portRows = document.querySelectorAll('#ports-table-body tr');
-    expect(portRows.length).toBe(9);
+    expect(portRows.length).toBe(10);
   });
 
   it('shows PostgreSQL connection info (host, port, database) from the env config', async () => {

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -18,6 +18,7 @@ interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  STORY_ANALYSIS_PORT: number;
   GITHUB_TOKEN?: string;
 }
 
@@ -236,6 +237,7 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       WORKFLOW_MANAGER_PORT: currentEnvConfig?.WORKFLOW_MANAGER_PORT || 3012,
       OUTLINE_PORT: currentEnvConfig?.OUTLINE_PORT || 3013,
       KANBAN_PORT: currentEnvConfig?.KANBAN_PORT || 3015,
+      STORY_ANALYSIS_PORT: currentEnvConfig?.STORY_ANALYSIS_PORT || 3016,
       // Not exposed as a form field on this form - preserve existing value so a
       // re-save doesn't silently erase a stored GitHub token
       GITHUB_TOKEN: currentEnvConfig?.GITHUB_TOKEN,

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -75,6 +75,7 @@ interface EnvConfig {
   WORKFLOW_MANAGER_PORT: number;
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
+  STORY_ANALYSIS_PORT: number;
 }
 
 interface PortConflictDetail {

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -731,6 +731,7 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             WORKFLOW_MANAGER_PORT: currentConfig?.WORKFLOW_MANAGER_PORT || 3012,
             OUTLINE_PORT: currentConfig?.OUTLINE_PORT || 3013,
             KANBAN_PORT: currentConfig?.KANBAN_PORT || 3015,
+            STORY_ANALYSIS_PORT: currentConfig?.STORY_ANALYSIS_PORT || 3016,
             // Not exposed in this wizard step - preserve existing value so a re-save
             // doesn't silently erase a stored GitHub token
             GITHUB_TOKEN: currentConfig?.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary
- Follow-up to MCP-Writing-Servers PR #86, which registers the story-analysis config-mcp wrapper on container port 3016.
- Per the mcp-server-port-ripple rule, adds a matching host port mapping (`STORY_ANALYSIS_PORT` -> `3016`) and wires it through every site the existing `OUTLINE_PORT`/`KANBAN_PORT` vars touch, mirroring merged PR #226 exactly:
  - `docker-compose.yml` - new port mapping on `mcp-writing-servers`
  - `src/main/env-config.ts` - interface field, default (3016), port-conflict check, parse/format, validation
  - `src/main/mcp-system.ts` - env passthrough to `docker compose`
  - `src/preload/preload.ts` - interface field
  - `src/renderer/components/ServicesTab.ts` - interface field, `PortRowDefinition` union, new `PORT_ROWS` entry
  - `src/renderer/components/__tests__/ServicesTab.test.ts` - fixture value + updated row count (9 -> 10)
  - `src/renderer/env-config-handlers.ts` - interface field, save handler default
  - `src/renderer/renderer.ts` - interface field
  - `src/renderer/setup-wizard-handlers.ts` - save handler default
- Safe to merge before or after mws #86 (a mapping to a not-yet-listening container port is harmless).

## Test plan
- [x] `npm run build` - passes (renderer + main tsc, asset copy)
- [x] `npx jest --config jest.config.ci.cjs` - 41 suites / 414 tests passed, including updated `ServicesTab.test.ts`
- [x] `docker compose --env-file <full env> config` - confirmed `STORY_ANALYSIS_PORT` correctly maps host port to container `3016` (tested with a distinct host value to rule out coincidental match)
- [ ] Live container restart - intentionally not performed per task scope

Closes bead: mea-g5z

🤖 Generated with [Claude Code](https://claude.com/claude-code)