### PR TITLE
fix: resolve plugin releases per-plugin tag prefix, not repo-wide latest

### DIFF
--- a/src/main/__tests__/plugin-github-updater.test.ts
+++ b/src/main/__tests__/plugin-github-updater.test.ts
@@ -80,7 +80,17 @@ describe('resolveUpdateSource', () => {
       updateSource: { repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false },
     };
     const source = resolveUpdateSource('fictionlab-kanban', manifest);
-    expect(source).toEqual({ repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false });
+    expect(source).toEqual({ repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false, tagPrefix: undefined });
+  });
+
+  it('carries a manifest-declared tagPrefix through (bead mea-ecp)', () => {
+    const manifest: any = {
+      id: 'fictionlab-kanban',
+      version: '1.0.0',
+      updateSource: { repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false, tagPrefix: 'custom-plugin-' },
+    };
+    const source = resolveUpdateSource('fictionlab-kanban', manifest);
+    expect(source?.tagPrefix).toBe('custom-plugin-');
   });
 
   it('returns null for a plugin with no known or declared update source', () => {
@@ -131,6 +141,28 @@ describe('normalizeVersion', () => {
     expect(normalizeVersion('v1.2.3')).toBe('1.2.3');
     expect(normalizeVersion('1.2.3')).toBe('1.2.3');
   });
+
+  it('strips a tagPrefix before the leading v (per-plugin tags, bead mea-ecp)', () => {
+    expect(normalizeVersion('workflow-plugin-v1.2.0', 'workflow-plugin-')).toBe('1.2.0');
+    expect(normalizeVersion('kanban-plugin-v2.0.0', 'kanban-plugin-')).toBe('2.0.0');
+  });
+
+  it('is a no-op when the tagPrefix does not match', () => {
+    expect(normalizeVersion('workflow-plugin-v1.2.0', 'kanban-plugin-')).toBe('workflow-plugin-v1.2.0');
+  });
+});
+
+describe('KNOWN_PLUGIN_UPDATE_SOURCES tagPrefix (bead mea-ecp)', () => {
+  it('declares a distinct tagPrefix for every known plugin, including fictionlab-agent-factory', () => {
+    expect(KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-workflow'].tagPrefix).toBe('workflow-plugin-');
+    expect(KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'].tagPrefix).toBe('kanban-plugin-');
+    expect(KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory']).toEqual({
+      repo: 'RLRyals/fictionlab-workflow',
+      assetPattern: 'fictionlab-agent-factory-*.zip',
+      private: true,
+      tagPrefix: 'agent-factory-plugin-',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -142,7 +174,7 @@ describe('checkPluginUpdate', () => {
   it('sends Authorization: Bearer when a token is supplied (private repo)', async () => {
     await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
     const fetchFn = jest.fn().mockResolvedValue(
-      okJsonResponse({ tag_name: 'v1.1.0', assets: [SAMPLE_ASSET] })
+      okJsonResponse([{ tag_name: 'kanban-plugin-v1.1.0', assets: [SAMPLE_ASSET] }])
     );
 
     await checkPluginUpdate({
@@ -153,7 +185,7 @@ describe('checkPluginUpdate', () => {
     });
 
     expect(fetchFn).toHaveBeenCalledWith(
-      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases/latest',
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases?per_page=30&page=1',
       expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer ghp_test_token' }) })
     );
   });
@@ -188,7 +220,7 @@ describe('checkPluginUpdate', () => {
 
   it('reports "up-to-date" when the latest release is not newer than the installed version', async () => {
     await writeInstalledPlugin('fictionlab-kanban', '1.5.0');
-    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse({ tag_name: 'v1.5.0', assets: [SAMPLE_ASSET] }));
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'kanban-plugin-v1.5.0', assets: [SAMPLE_ASSET] }]));
 
     const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
 
@@ -197,7 +229,7 @@ describe('checkPluginUpdate', () => {
 
   it('reports "update-available" with the matched asset when the release is newer', async () => {
     await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
-    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse({ tag_name: 'v1.1.0', assets: [SAMPLE_ASSET] }));
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'kanban-plugin-v1.1.0', assets: [SAMPLE_ASSET] }]));
 
     const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
 
@@ -209,7 +241,7 @@ describe('checkPluginUpdate', () => {
   it('reports "no-matching-asset" when the release has no asset for this plugin', async () => {
     await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
     const fetchFn = jest.fn().mockResolvedValue(
-      okJsonResponse({ tag_name: 'v1.1.0', assets: [{ name: 'fictionlab-workflow-1.1.0.zip', browser_download_url: 'x', id: 1 }] })
+      okJsonResponse([{ tag_name: 'kanban-plugin-v1.1.0', assets: [{ name: 'fictionlab-workflow-1.1.0.zip', browser_download_url: 'x', id: 1 }] }])
     );
 
     const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
@@ -223,6 +255,34 @@ describe('checkPluginUpdate', () => {
     const result = await checkPluginUpdate({ pluginId: 'some-unrelated-plugin', pluginsDir });
 
     expect(result.status).toBe('no-update-source');
+  });
+
+  it('resolves the correct plugin release out of a mixed-plugin release list, not the repo-wide latest (bead mea-ecp)', async () => {
+    await writeInstalledPlugin('fictionlab-workflow', '1.0.0');
+    // /releases/latest would be the kanban plugin (released most recently);
+    // the fix must walk /releases and pick the workflow-prefixed tag instead.
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        { tag_name: 'kanban-plugin-v3.0.0', assets: [{ name: 'fictionlab-kanban-3.0.0.zip', browser_download_url: 'x', id: 1 }] },
+        {
+          tag_name: 'workflow-plugin-v1.2.0',
+          assets: [{ name: 'fictionlab-workflow-1.2.0.zip', browser_download_url: 'y', id: 2 }],
+        },
+      ],
+    });
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-workflow', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases?per_page=30&page=1',
+      expect.anything()
+    );
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('1.2.0');
+    expect(result.asset?.id).toBe(2);
   });
 
   it('never includes the token in a returned error message', async () => {

--- a/src/main/__tests__/release-notes.test.ts
+++ b/src/main/__tests__/release-notes.test.ts
@@ -9,6 +9,7 @@
 
 import {
   fetchLatestRelease,
+  fetchLatestReleaseForPrefix,
   fetchReleaseByTag,
   fetchCommitDelta,
   getChangeList,
@@ -129,6 +130,89 @@ describe('fetchReleaseByTag', () => {
     const result = await fetchReleaseByTag('RLRyals/MCP-Electron-App', 'v9.9.9', { fetchFn: fetchFn as any });
 
     expect(result.status).toBe('not-found');
+  });
+});
+
+describe('fetchLatestReleaseForPrefix (bead mea-ecp)', () => {
+  it('delegates to fetchLatestRelease when tagPrefix is falsy (backward compat)', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse(SAMPLE_RELEASE));
+
+    const result = await fetchLatestReleaseForPrefix('RLRyals/MCP-Electron-App', undefined, { fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('ok');
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/MCP-Electron-App/releases/latest',
+      expect.anything()
+    );
+  });
+
+  it('picks the first non-draft, non-prerelease release matching the prefix out of a mixed-plugin list', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse([
+        { tag_name: 'kanban-plugin-v2.0.0', assets: [] },
+        { tag_name: 'workflow-plugin-v1.5.0', assets: [] },
+        { tag_name: 'agent-factory-plugin-v0.1.0', assets: [] },
+      ])
+    );
+
+    const result = await fetchLatestReleaseForPrefix('RLRyals/fictionlab-workflow', 'workflow-plugin-', {
+      fetchFn: fetchFn as any,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.release?.tagName).toBe('workflow-plugin-v1.5.0');
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases?per_page=30&page=1',
+      expect.anything()
+    );
+  });
+
+  it('skips draft and prerelease releases even when the tag matches', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse([
+        { tag_name: 'workflow-plugin-v2.0.0', draft: true, assets: [] },
+        { tag_name: 'workflow-plugin-v1.9.0', prerelease: true, assets: [] },
+        { tag_name: 'workflow-plugin-v1.5.0', assets: [] },
+      ])
+    );
+
+    const result = await fetchLatestReleaseForPrefix('RLRyals/fictionlab-workflow', 'workflow-plugin-', {
+      fetchFn: fetchFn as any,
+    });
+
+    expect(result.release?.tagName).toBe('workflow-plugin-v1.5.0');
+  });
+
+  it('returns "not-found" when no release in the list matches the prefix', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse([{ tag_name: 'kanban-plugin-v2.0.0', assets: [] }])
+    );
+
+    const result = await fetchLatestReleaseForPrefix('RLRyals/fictionlab-workflow', 'workflow-plugin-', {
+      fetchFn: fetchFn as any,
+    });
+
+    expect(result.status).toBe('not-found');
+  });
+
+  it('paginates when the first page is full and has no match', async () => {
+    const page1 = Array.from({ length: 30 }, (_, i) => ({ tag_name: `kanban-plugin-v${i}.0.0`, assets: [] }));
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce(okJsonResponse(page1))
+      .mockResolvedValueOnce(okJsonResponse([{ tag_name: 'workflow-plugin-v1.0.0', assets: [] }]));
+
+    const result = await fetchLatestReleaseForPrefix('RLRyals/fictionlab-workflow', 'workflow-plugin-', {
+      fetchFn: fetchFn as any,
+    });
+
+    expect(result.release?.tagName).toBe('workflow-plugin-v1.0.0');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/RLRyals/fictionlab-workflow/releases?per_page=30&page=2',
+      expect.anything()
+    );
   });
 });
 

--- a/src/main/plugin-github-updater.ts
+++ b/src/main/plugin-github-updater.ts
@@ -49,7 +49,7 @@ import * as os from 'os';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
 import {
-  fetchLatestRelease,
+  fetchLatestReleaseForPrefix,
   downloadReleaseAsset,
   ReleaseFetchOptions,
   ReleaseInfo,
@@ -74,6 +74,16 @@ export interface PluginUpdateSource {
   assetPattern: string;
   /** True when `repo` requires GITHUB_PLUGINS_TOKEN to read releases at all. */
   private?: boolean;
+  /**
+   * Prefix of this plugin's release tags (e.g. `workflow-plugin-`) in a repo
+   * that publishes one GitHub Release per plugin (bead mea-ecp). When set,
+   * `checkPluginUpdate` resolves the latest release by walking
+   * `/repos/{repo}/releases` for the first non-draft, non-prerelease tag
+   * starting with this prefix instead of the repo-wide `/releases/latest`,
+   * and strips it before comparing versions. Omit for repos that still cut
+   * one release per repo.
+   */
+  tagPrefix?: string;
 }
 
 /**
@@ -81,18 +91,29 @@ export interface PluginUpdateSource {
  * manifest-declared `updateSource` field existed. A plugin whose manifest
  * *does* declare `updateSource` always wins (see `resolveUpdateSource`) --
  * this map only fills the gap for already-installed fictionlab-workflow /
- * fictionlab-kanban copies.
+ * fictionlab-kanban / fictionlab-agent-factory copies. fictionlab-workflow
+ * publishes one GitHub Release per plugin (`workflow-plugin-vX.Y.Z`,
+ * `kanban-plugin-vX.Y.Z`, `agent-factory-plugin-vX.Y.Z`), hence `tagPrefix`
+ * on every entry here (bead mea-ecp).
  */
 export const KNOWN_PLUGIN_UPDATE_SOURCES: Record<string, PluginUpdateSource> = {
   'fictionlab-workflow': {
     repo: 'RLRyals/fictionlab-workflow',
     assetPattern: 'fictionlab-workflow-*.zip',
     private: true,
+    tagPrefix: 'workflow-plugin-',
   },
   'fictionlab-kanban': {
     repo: 'RLRyals/fictionlab-workflow',
     assetPattern: 'fictionlab-kanban-*.zip',
     private: true,
+    tagPrefix: 'kanban-plugin-',
+  },
+  'fictionlab-agent-factory': {
+    repo: 'RLRyals/fictionlab-workflow',
+    assetPattern: 'fictionlab-agent-factory-*.zip',
+    private: true,
+    tagPrefix: 'agent-factory-plugin-',
   },
 };
 
@@ -106,6 +127,7 @@ export function resolveUpdateSource(
       repo: declared.repo,
       assetPattern: declared.assetPattern,
       private: !!declared.private,
+      tagPrefix: typeof declared.tagPrefix === 'string' ? declared.tagPrefix : undefined,
     };
   }
   return KNOWN_PLUGIN_UPDATE_SOURCES[pluginId] ?? null;
@@ -181,9 +203,16 @@ export function findMatchingAsset(
 // Version compare
 // ---------------------------------------------------------------------------
 
-/** Strip a leading "v"/"V" so GitHub's `v1.2.3` tags compare against plain semver. */
-export function normalizeVersion(version: string): string {
-  const trimmed = (version || '').trim();
+/**
+ * Strip a source's `tagPrefix` (if any), then a leading "v"/"V", so both
+ * plain `v1.2.3` tags and per-plugin tags like `workflow-plugin-v1.2.0`
+ * compare against plain semver.
+ */
+export function normalizeVersion(version: string, tagPrefix?: string): string {
+  let trimmed = (version || '').trim();
+  if (tagPrefix && trimmed.startsWith(tagPrefix)) {
+    trimmed = trimmed.slice(tagPrefix.length);
+  }
   return trimmed.replace(/^v/i, '');
 }
 
@@ -244,7 +273,7 @@ export async function checkPluginUpdate(
     return { status: 'token-required', pluginId, currentVersion, source };
   }
 
-  const result = await fetchLatestRelease(source.repo, { token, fetchFn: params.fetchFn });
+  const result = await fetchLatestReleaseForPrefix(source.repo, source.tagPrefix, { token, fetchFn: params.fetchFn });
 
   if (result.status === 'not-found') {
     return { status: 'no-releases', pluginId, currentVersion, source };
@@ -261,7 +290,7 @@ export async function checkPluginUpdate(
   }
 
   const release = result.release;
-  const latestVersion = normalizeVersion(release.tagName);
+  const latestVersion = normalizeVersion(release.tagName, source.tagPrefix);
 
   const isNewer = currentVersion
     ? semver.valid(latestVersion) && semver.valid(currentVersion)

--- a/src/main/release-notes.ts
+++ b/src/main/release-notes.ts
@@ -170,6 +170,68 @@ export async function fetchReleaseByTag(
   );
 }
 
+const RELEASES_PAGE_SIZE = 30;
+const RELEASES_MAX_PAGES = 10;
+
+/**
+ * Fetch the latest published release for a repo whose tag_name starts with
+ * `tagPrefix` (bead mea-ecp). Repos that publish one GitHub Release per
+ * plugin (fictionlab-workflow: `workflow-plugin-vX.Y.Z`,
+ * `kanban-plugin-vX.Y.Z`, `agent-factory-plugin-vX.Y.Z`, ...) can't rely on
+ * `/releases/latest`, which is whichever plugin released most recently
+ * repo-wide -- this walks `/repos/{repo}/releases` (paginated, newest first)
+ * and returns the first non-draft, non-prerelease release matching the
+ * prefix.
+ *
+ * When `tagPrefix` is falsy this delegates to `fetchLatestRelease` --
+ * backward compat for single-plugin repos and already-installed manifests
+ * that predate `tagPrefix` (asset-pattern matching remains the final arbiter
+ * either way, so a wrong-prefix match still can't install the wrong asset).
+ */
+export async function fetchLatestReleaseForPrefix(
+  repo: string,
+  tagPrefix: string | undefined | null,
+  options: ReleaseFetchOptions = {}
+): Promise<ReleaseFetchResult> {
+  if (!tagPrefix) {
+    return fetchLatestRelease(repo, options);
+  }
+
+  const fetchFn = options.fetchFn ?? fetch;
+
+  try {
+    for (let page = 1; page <= RELEASES_MAX_PAGES; page++) {
+      const url = `${GITHUB_API_BASE}/repos/${repo}/releases?per_page=${RELEASES_PAGE_SIZE}&page=${page}`;
+      const response = await fetchFn(url, { headers: buildHeaders(options.token) });
+
+      if (!response.ok) {
+        return mapErrorResponse(response);
+      }
+
+      const releases = await response.json();
+      if (!Array.isArray(releases) || releases.length === 0) {
+        return { status: 'not-found' };
+      }
+
+      const match = releases.find(
+        (r: any) =>
+          !r?.draft && !r?.prerelease && typeof r?.tag_name === 'string' && r.tag_name.startsWith(tagPrefix)
+      );
+      if (match) {
+        return parseRelease(match);
+      }
+
+      if (releases.length < RELEASES_PAGE_SIZE) {
+        return { status: 'not-found' };
+      }
+    }
+
+    return { status: 'not-found' };
+  } catch (error: any) {
+    return { status: 'error', error: error?.message || String(error) };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Commit deltas (managed-repo updates: "what changed between old and new SHA")
 // ---------------------------------------------------------------------------

--- a/src/types/plugin-api.ts
+++ b/src/types/plugin-api.ts
@@ -89,6 +89,12 @@ export interface PluginManifest {
     assetPattern: string;
     /** True when `repo` requires a token (see GITHUB_PLUGINS_TOKEN). */
     private?: boolean;
+    /**
+     * Prefix of this plugin's release tags (e.g. `workflow-plugin-`) in a
+     * repo that publishes one GitHub Release per plugin (bead mea-ecp).
+     * Omit for repos that still cut one release per repo.
+     */
+    tagPrefix?: string;
   };
 
   /** UI integration points */


### PR DESCRIPTION
## Summary
- fictionlab-workflow now publishes one GitHub Release per plugin (`workflow-plugin-vX.Y.Z` / `kanban-plugin-vX.Y.Z` / `agent-factory-plugin-vX.Y.Z`, all in `RLRyals/fictionlab-workflow`). `checkPluginUpdate()` was hitting the repo-wide `GET /repos/{repo}/releases/latest`, so whichever plugin released most recently owned "latest" and the other plugins could never see their own update (and `normalizeVersion` degraded to a raw string compare on tags like `workflow-plugin-v1.2.0`, reporting garbage versions).
- Add `tagPrefix` to `PluginUpdateSource` (manifest-declared `updateSource.tagPrefix` and the `KNOWN_PLUGIN_UPDATE_SOURCES` map — `workflow-plugin-`, `kanban-plugin-`, and a new `fictionlab-agent-factory` entry with `agent-factory-plugin-`).
- Add `fetchLatestReleaseForPrefix(repo, tagPrefix, opts)` in `release-notes.ts`: walks the paginated `GET /repos/{repo}/releases` list for the first non-draft, non-prerelease release whose tag starts with the prefix; falls back to `fetchLatestRelease` (repo-wide `/releases/latest`) when no prefix is configured, for backward compat with single-plugin repos and already-installed manifests.
- `normalizeVersion` now strips `tagPrefix` before the leading `v`, so `workflow-plugin-v1.2.0` compares as semver `1.2.0`.
- Asset-pattern matching is unchanged (per the bead, no re-release needed on the fictionlab-workflow side).

## Test plan
- [x] `npx jest src/main/__tests__/plugin-github-updater.test.ts src/main/__tests__/release-notes.test.ts` — 57 passing, including new coverage for mixed-plugin release lists, draft/prerelease skipping, pagination, and prefix-stripped version compare.
- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean.
- [x] Full `npx jest` run — same 4 pre-existing failures as on `develop` (repository-manager/build-orchestrator git+network tests, provider-manager, ProviderSelector a11y), none touching the changed files.

Closes bead: mea-ecp