### PR TITLE
fix(plugin-context): add outline-server port mapping

### DIFF
--- a/src/main/plugin-context.ts
+++ b/src/main/plugin-context.ts
@@ -295,6 +295,7 @@ function createMCPConnectionManager(
         'review': 3007,
         'reporting': 3008,
         'author': 3009,
+        'outline': 3013,
         'kanban': 3015,
       };
 


### PR DESCRIPTION
## Summary
- `serverPorts` in `src/main/plugin-context.ts` hardcodes the canon-server port map (3001-3009 + workflow-manager 3012 + kanban 3015) but had no entry for `outline-server`, so a spawned outline-server was unreachable from `plugin context.services.mcp.callTool`.
- Adds `'outline': 3013`, matching the mws-side port (docker-compose.yml `3013:3013` and `single-server-runner.js`'s `outline` mapping on the `fix/mws-bpu-outline-server-orchestrator-spawn` branch of MCP-Writing-Servers, which spawns outline-server in the orchestrator).

## Test plan
- [x] `npm run build` — green
- [x] `npx tsc -p tsconfig.main.json --noEmit` — clean
- [x] `npx jest` full suite — same pre-existing failure count (4 unrelated `repository-manager.test.ts` failures, reproduced identically on `develop` without this change) as baseline; no regressions from this change
- [ ] Live verification against a real build pending MCP-Writing-Servers PR (mws-bpu) merging outline-server orchestrator spawn support

Closes bead: mea-006