### PR TITLE
feat(dashboard): plugin dashboard-widget contribution API + pluginless empty state

### DIFF
--- a/src/renderer/components/dashboard/DashboardWidgetSlot.tsx
+++ b/src/renderer/components/dashboard/DashboardWidgetSlot.tsx
@@ -1,0 +1,42 @@
+/**
+ * DashboardWidgetSlot
+ * Mounts one plugin-contributed dashboard widget class (loaded by
+ * dashboardWidgetLoader.ts) into a container div, mirroring how ViewRouter
+ * mounts a full View instance -- just scoped to a widget-sized slot instead
+ * of the whole page.
+ */
+
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
+import type { DashboardWidgetClass } from '../../services/dashboardWidgetLoader.js';
+
+export interface DashboardWidgetSlotProps {
+  WidgetClass: DashboardWidgetClass;
+  pluginId: string;
+}
+
+export const DashboardWidgetSlot: React.FC<DashboardWidgetSlotProps> = ({ WidgetClass, pluginId }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const widget = new WidgetClass();
+    let cancelled = false;
+    widget.mount(container).catch((error) => {
+      if (!cancelled) {
+        console.error(`[DashboardWidgetSlot] Failed to mount widget from plugin ${pluginId}:`, error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      widget.unmount?.();
+    };
+  }, [WidgetClass, pluginId]);
+
+  return <div ref={containerRef} className="dashboard-widget-slot" data-plugin-id={pluginId} />;
+};
+
+export default DashboardWidgetSlot;

--- a/src/renderer/components/dashboard/NoPluginsEmptyState.tsx
+++ b/src/renderer/components/dashboard/NoPluginsEmptyState.tsx
@@ -1,0 +1,71 @@
+/**
+ * NoPluginsEmptyState
+ * The Dashboard's pluginless empty state (bead mea-cjl.1 / epic mea-cjl):
+ * with zero plugins installed the core app is just service management, so
+ * the cockpit's Running/Next/Blocked columns (which only ever show
+ * plugin-gated placeholders anyway -- see PluginPlaceholder.tsx) are
+ * replaced entirely by this affordance instead of three empty dashed boxes.
+ */
+
+import * as React from 'react';
+
+export const NoPluginsEmptyState: React.FC = () => {
+  const handleInstallClick = () => {
+    (window as any).__viewRouter__?.navigateTo?.('plugins');
+  };
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: '48px 24px',
+    gap: '8px',
+  };
+
+  const iconStyle: React.CSSProperties = {
+    fontSize: '32px',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '15px',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+  };
+
+  const bodyStyle: React.CSSProperties = {
+    fontSize: '13px',
+    color: 'var(--color-text-tertiary)',
+    maxWidth: '360px',
+    margin: 0,
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    marginTop: '8px',
+    padding: '8px 16px',
+    fontSize: '13px',
+    fontWeight: 600,
+    cursor: 'pointer',
+    background: 'var(--color-bg-tertiary)',
+    color: 'var(--color-text-primary)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '6px',
+  };
+
+  return (
+    <div style={containerStyle} className="dashboard-no-plugins-empty-state">
+      <div style={iconStyle}>🧩</div>
+      <div style={titleStyle}>No plugins installed</div>
+      <p style={bodyStyle}>
+        This is the FictionLab core: service management for the MCP writing servers. Install a
+        plugin to add workflows, boards, and agents to this dashboard.
+      </p>
+      <button type="button" style={buttonStyle} onClick={handleInstallClick}>
+        Install plugins
+      </button>
+    </div>
+  );
+};
+
+export default NoPluginsEmptyState;

--- a/src/renderer/components/dashboard/__tests__/DashboardWidgetSlot.test.tsx
+++ b/src/renderer/components/dashboard/__tests__/DashboardWidgetSlot.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * DashboardWidgetSlot mount/unmount test (bead mea-cjl.1).
+ */
+
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { DashboardWidgetSlot } from '../DashboardWidgetSlot';
+import type { DashboardWidget, DashboardWidgetClass } from '../../../services/dashboardWidgetLoader';
+
+class FakeWidget implements DashboardWidget {
+  static mountCalls: HTMLElement[] = [];
+  static unmountCallCount = 0;
+
+  async mount(container: HTMLElement): Promise<void> {
+    FakeWidget.mountCalls.push(container);
+    container.textContent = 'fake widget content';
+  }
+
+  async unmount(): Promise<void> {
+    FakeWidget.unmountCallCount += 1;
+  }
+}
+
+beforeEach(() => {
+  FakeWidget.mountCalls = [];
+  FakeWidget.unmountCallCount = 0;
+});
+
+describe('DashboardWidgetSlot', () => {
+  it('instantiates the widget class and mounts it into the slot container', async () => {
+    const { container } = render(
+      <DashboardWidgetSlot WidgetClass={FakeWidget as DashboardWidgetClass} pluginId="fictionlab-workflow" />
+    );
+
+    await waitFor(() => expect(FakeWidget.mountCalls).toHaveLength(1));
+    expect(container.querySelector('.dashboard-widget-slot')).toHaveTextContent('fake widget content');
+    expect(container.querySelector('[data-plugin-id="fictionlab-workflow"]')).not.toBeNull();
+  });
+
+  it('calls unmount() on the widget when the slot unmounts', async () => {
+    const { unmount } = render(
+      <DashboardWidgetSlot WidgetClass={FakeWidget as DashboardWidgetClass} pluginId="fictionlab-workflow" />
+    );
+    await waitFor(() => expect(FakeWidget.mountCalls).toHaveLength(1));
+
+    unmount();
+
+    await waitFor(() => expect(FakeWidget.unmountCallCount).toBe(1));
+  });
+
+  it('logs rather than throws when mount() rejects', async () => {
+    class ThrowingWidget implements DashboardWidget {
+      async mount(): Promise<void> {
+        throw new Error('boom');
+      }
+    }
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<DashboardWidgetSlot WidgetClass={ThrowingWidget as DashboardWidgetClass} pluginId="broken-plugin" />);
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    errorSpy.mockRestore();
+  });
+});

--- a/src/renderer/components/dashboard/__tests__/NoPluginsEmptyState.test.tsx
+++ b/src/renderer/components/dashboard/__tests__/NoPluginsEmptyState.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * NoPluginsEmptyState render + affordance test (bead mea-cjl.1).
+ */
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NoPluginsEmptyState } from '../NoPluginsEmptyState';
+
+afterEach(() => {
+  delete (window as any).__viewRouter__;
+});
+
+describe('NoPluginsEmptyState', () => {
+  it('renders the pluginless empty-state copy', () => {
+    render(<NoPluginsEmptyState />);
+    expect(screen.getByText('No plugins installed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Install plugins' })).toBeInTheDocument();
+  });
+
+  it('clicking "Install plugins" navigates to the plugins view', async () => {
+    const navigateTo = jest.fn();
+    (window as any).__viewRouter__ = { navigateTo };
+
+    render(<NoPluginsEmptyState />);
+    await userEvent.click(screen.getByRole('button', { name: 'Install plugins' }));
+
+    expect(navigateTo).toHaveBeenCalledWith('plugins');
+  });
+
+  it('does not throw when __viewRouter__ is unavailable', async () => {
+    render(<NoPluginsEmptyState />);
+    await userEvent.click(screen.getByRole('button', { name: 'Install plugins' }));
+    // No assertion beyond "didn't throw" -- the click handler optionally chains.
+  });
+});

--- a/src/renderer/services/__tests__/dashboardWidgetLoader.test.ts
+++ b/src/renderer/services/__tests__/dashboardWidgetLoader.test.ts
@@ -1,0 +1,170 @@
+/**
+ * dashboardWidgetLoader tests (bead mea-cjl.1).
+ *
+ * Covers the descriptor-filtering logic (the pure business rule: which
+ * active plugins actually contribute a dashboard widget) plus the graceful-
+ * degradation branches -- no electronAPI, list() throws, non-array result.
+ * The dynamic-import success path (importing a real bundle's named
+ * `dashboardWidget` export) is intentionally left untested here, mirroring
+ * pluginViewLoader.ts's own equivalent gap: there is no fixture bundle to
+ * import in a jsdom test environment, only mockable IPC surfaces.
+ */
+
+import { listDashboardWidgetDescriptors, loadActiveDashboardWidgets } from '../dashboardWidgetLoader';
+
+function installElectronAPI(overrides: Partial<any> = {}) {
+  (window as any).electronAPI = {
+    plugins: {
+      list: jest.fn().mockResolvedValue([]),
+      getRendererUrl: jest.fn(),
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  delete (window as any).electronAPI;
+  jest.restoreAllMocks();
+});
+
+describe('listDashboardWidgetDescriptors', () => {
+  it('returns [] when electronAPI.plugins.list is unavailable', async () => {
+    (window as any).electronAPI = {};
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('returns [] when plugins.list() throws', async () => {
+    installElectronAPI({
+      plugins: { list: jest.fn().mockRejectedValue(new Error('ipc down')) },
+    });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('returns [] when plugins.list() resolves to a non-array', async () => {
+    installElectronAPI({ plugins: { list: jest.fn().mockResolvedValue(null) } });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('skips inactive plugins', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'inactive',
+            manifest: { version: '1.0.0', ui: { dashboardWidget: 'workflow-widget' }, entry: { renderer: 'dist-renderer/index.js' } },
+          },
+        ]),
+      },
+    });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('skips active plugins with no ui.dashboardWidget', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: { version: '1.0.0', ui: {}, entry: { renderer: 'dist-renderer/index.js' } },
+          },
+        ]),
+      },
+    });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('skips active plugins with a dashboardWidget id but no entry.renderer', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: { version: '1.0.0', ui: { dashboardWidget: 'workflow-widget' }, entry: {} },
+          },
+        ]),
+      },
+    });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([]);
+  });
+
+  it('includes an active plugin that declares both ui.dashboardWidget and entry.renderer', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: {
+              version: '2.1.0',
+              ui: { dashboardWidget: 'workflow-widget' },
+              entry: { renderer: 'dist-renderer/index.js' },
+            },
+          },
+        ]),
+      },
+    });
+    await expect(listDashboardWidgetDescriptors()).resolves.toEqual([
+      { pluginId: 'fictionlab-workflow', pluginVersion: '2.1.0', widgetId: 'workflow-widget' },
+    ]);
+  });
+
+  it('defaults pluginVersion to 0.0.0 when the manifest omits version', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: { ui: { dashboardWidget: 'workflow-widget' }, entry: { renderer: 'dist-renderer/index.js' } },
+          },
+        ]),
+      },
+    });
+    const descriptors = await listDashboardWidgetDescriptors();
+    expect(descriptors[0].pluginVersion).toBe('0.0.0');
+  });
+});
+
+describe('loadActiveDashboardWidgets', () => {
+  it('returns [] and never calls getRendererUrl when no plugin contributes a widget', async () => {
+    const getRendererUrl = jest.fn();
+    installElectronAPI({ plugins: { list: jest.fn().mockResolvedValue([]), getRendererUrl } });
+    await expect(loadActiveDashboardWidgets()).resolves.toEqual([]);
+    expect(getRendererUrl).not.toHaveBeenCalled();
+  });
+
+  it('skips a descriptor when plugins.getRendererUrl is unavailable', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: { version: '1.0.0', ui: { dashboardWidget: 'workflow-widget' }, entry: { renderer: 'dist-renderer/index.js' } },
+          },
+        ]),
+        // getRendererUrl deliberately omitted
+      },
+    });
+    await expect(loadActiveDashboardWidgets()).resolves.toEqual([]);
+  });
+
+  it('skips a descriptor when getRendererUrl rejects', async () => {
+    installElectronAPI({
+      plugins: {
+        list: jest.fn().mockResolvedValue([
+          {
+            id: 'fictionlab-workflow',
+            status: 'active',
+            manifest: { version: '1.0.0', ui: { dashboardWidget: 'workflow-widget' }, entry: { renderer: 'dist-renderer/index.js' } },
+          },
+        ]),
+        getRendererUrl: jest.fn().mockRejectedValue(new Error('not found')),
+      },
+    });
+    await expect(loadActiveDashboardWidgets()).resolves.toEqual([]);
+  });
+});

--- a/src/renderer/services/dashboardWidgetLoader.ts
+++ b/src/renderer/services/dashboardWidgetLoader.ts
@@ -1,0 +1,131 @@
+/**
+ * Plugin dashboard-widget contribution API (bead mea-cjl.1).
+ *
+ * Mirrors pluginViewLoader.ts's mainView mechanism but for a smaller
+ * contribution point: any installed, ACTIVE plugin whose manifest declares
+ * BOTH
+ *   - `entry.renderer`     (the same self-contained browser ES module used
+ *     for its main view; see plugin-api.ts), and
+ *   - `ui.dashboardWidget` (the widget id)
+ * gets that bundle's NAMED export `dashboardWidget` (not the default
+ * export, which is reserved for `ui.mainView`) dynamically imported and
+ * duck-typed against the DashboardWidget contract below. The Dashboard
+ * mounts one instance per loaded widget (see DashboardWidgetSlot.tsx).
+ *
+ * Failure behavior mirrors pluginViewLoader.ts: a missing bundle, an import
+ * error, or a bundle that doesn't export a mountable widget class is logged
+ * and simply skipped -- no slot is rendered for it.
+ *
+ * Unlike pluginViewLoader.ts, this has no persistent registry to reconcile:
+ * the Dashboard is a single React tree that re-mounts/unmounts widgets
+ * itself as its own widget list changes, so callers just re-invoke
+ * loadActiveDashboardWidgets() (e.g. on 'plugin-state-changed') and re-render.
+ */
+
+export interface DashboardWidget {
+  mount(container: HTMLElement): Promise<void>;
+  unmount?(): Promise<void>;
+}
+
+export interface DashboardWidgetClass {
+  new (): DashboardWidget;
+}
+
+export interface DashboardWidgetDescriptor {
+  pluginId: string;
+  pluginVersion: string;
+  widgetId: string;
+}
+
+export interface LoadedDashboardWidget extends DashboardWidgetDescriptor {
+  WidgetClass: DashboardWidgetClass;
+}
+
+/**
+ * Read the descriptors of every active plugin that declares a renderer
+ * bundle + dashboard widget id, straight from the manifests the main
+ * process already exposes over `plugin:list`.
+ */
+export async function listDashboardWidgetDescriptors(): Promise<DashboardWidgetDescriptor[]> {
+  const electronAPI = (window as any).electronAPI;
+  if (!electronAPI?.plugins?.list) return [];
+
+  let plugins: any[];
+  try {
+    plugins = await electronAPI.plugins.list();
+  } catch (error) {
+    console.error('[DashboardWidgetLoader] Failed to list plugins:', error);
+    return [];
+  }
+  if (!Array.isArray(plugins)) return [];
+
+  const descriptors: DashboardWidgetDescriptor[] = [];
+  for (const plugin of plugins) {
+    const manifest = plugin?.manifest;
+    const widgetId = manifest?.ui?.dashboardWidget;
+    if (plugin?.status !== 'active' || !widgetId || !manifest?.entry?.renderer) continue;
+    descriptors.push({
+      pluginId: plugin.id,
+      pluginVersion: manifest.version || '0.0.0',
+      widgetId,
+    });
+  }
+  return descriptors;
+}
+
+/**
+ * Import a plugin's renderer bundle and return its named-exported
+ * `dashboardWidget` class, or null when anything about it is unusable
+ * (logged, never thrown).
+ */
+async function importDashboardWidgetClass(
+  descriptor: DashboardWidgetDescriptor
+): Promise<DashboardWidgetClass | null> {
+  const electronAPI = (window as any).electronAPI;
+  if (!electronAPI?.plugins?.getRendererUrl) {
+    console.error('[DashboardWidgetLoader] plugins.getRendererUrl API not available');
+    return null;
+  }
+
+  try {
+    // Main process resolves manifest entry.renderer against the plugin's
+    // install directory, enforces the bundle stays inside it, and verifies
+    // it exists -- see `plugin:get-renderer-url` in src/main/index.ts. This
+    // is the exact same bundle pluginViewLoader.ts imports for the mainView.
+    const { url } = await electronAPI.plugins.getRendererUrl(descriptor.pluginId);
+
+    // Version query defeats the ES module cache across plugin updates.
+    const moduleUrl = `${url}?v=${encodeURIComponent(descriptor.pluginVersion)}`;
+    const module = await import(/* webpackIgnore: true */ moduleUrl);
+
+    const WidgetClass = module?.dashboardWidget;
+    if (typeof WidgetClass !== 'function' || typeof WidgetClass.prototype?.mount !== 'function') {
+      console.error(
+        `[DashboardWidgetLoader] Plugin ${descriptor.pluginId} renderer bundle has no named 'dashboardWidget' export with a mount() method`
+      );
+      return null;
+    }
+    return WidgetClass as DashboardWidgetClass;
+  } catch (error) {
+    console.error(
+      `[DashboardWidgetLoader] Failed to load dashboard widget bundle for plugin ${descriptor.pluginId}:`,
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Load the dashboard widget classes contributed by every currently-active
+ * plugin. Call on mount and again on 'plugin-state-changed'.
+ */
+export async function loadActiveDashboardWidgets(): Promise<LoadedDashboardWidget[]> {
+  const descriptors = await listDashboardWidgetDescriptors();
+  const loaded: LoadedDashboardWidget[] = [];
+  for (const descriptor of descriptors) {
+    const WidgetClass = await importDashboardWidgetClass(descriptor);
+    if (!WidgetClass) continue;
+    loaded.push({ ...descriptor, WidgetClass });
+  }
+  return loaded;
+}

--- a/src/renderer/views/DashboardViewReact.tsx
+++ b/src/renderer/views/DashboardViewReact.tsx
@@ -24,6 +24,8 @@ import { RunningPanel } from '../components/dashboard/RunningPanel.js';
 import { NextPanel } from '../components/dashboard/NextPanel.js';
 import { BlockedPanel } from '../components/dashboard/BlockedPanel.js';
 import { SystemStrip } from '../components/dashboard/SystemStrip.js';
+import { NoPluginsEmptyState } from '../components/dashboard/NoPluginsEmptyState.js';
+import { DashboardWidgetSlot } from '../components/dashboard/DashboardWidgetSlot.js';
 import {
   KANBAN_PLUGIN_ID,
   WORKFLOW_PLUGIN_ID,
@@ -31,6 +33,8 @@ import {
   isPluginActive,
 } from '../components/dashboard/types.js';
 import type { KanbanCard } from '../components/dashboard/types.js';
+import { loadActiveDashboardWidgets } from '../services/dashboardWidgetLoader.js';
+import type { LoadedDashboardWidget } from '../services/dashboardWidgetLoader.js';
 
 const KANBAN_PLUGIN_PREFIX = `plugin:${KANBAN_PLUGIN_ID}:`;
 
@@ -54,6 +58,10 @@ export const DashboardApp: React.FC = () => {
   const [kanbanPluginActive, setKanbanPluginActive] = useState(false);
   const [workflowsLoading, setWorkflowsLoading] = useState(true);
   const [kanbanLoading, setKanbanLoading] = useState(true);
+  // null = not yet checked (default to the "plugins installed" layout until
+  // resolved, so nothing flashes empty on first paint).
+  const [installedPluginCount, setInstalledPluginCount] = useState<number | null>(null);
+  const [dashboardWidgets, setDashboardWidgets] = useState<LoadedDashboardWidget[]>([]);
   const [isWide, setIsWide] = useState(() =>
     typeof window.matchMedia === 'function' ? window.matchMedia(WIDE_LAYOUT_QUERY).matches : true
   );
@@ -73,14 +81,42 @@ export const DashboardApp: React.FC = () => {
     setKanbanPluginActive(kbActive);
   }, []);
 
+  // ---- Widget-slot API (bead mea-cjl.1): pluginless empty state + any
+  // plugin-contributed dashboard widgets ---------------------------------
+  const checkInstalledPlugins = useCallback(async () => {
+    const electronAPI = (window as any).electronAPI;
+    if (!electronAPI?.plugins?.list) {
+      setInstalledPluginCount(0);
+      return;
+    }
+    try {
+      const plugins = await electronAPI.plugins.list();
+      setInstalledPluginCount(Array.isArray(plugins) ? plugins.length : 0);
+    } catch (error) {
+      console.error('[DashboardApp] Failed to list installed plugins:', error);
+      setInstalledPluginCount(0);
+    }
+  }, []);
+
+  const loadWidgets = useCallback(async () => {
+    const widgets = await loadActiveDashboardWidgets();
+    setDashboardWidgets(widgets);
+  }, []);
+
   useEffect(() => {
     checkPlugins();
+    checkInstalledPlugins();
+    loadWidgets();
     const electronAPI = (window as any).electronAPI;
     if (!electronAPI?.on || !electronAPI?.off) return;
-    const handlePluginStateChanged = () => checkPlugins();
+    const handlePluginStateChanged = () => {
+      checkPlugins();
+      checkInstalledPlugins();
+      loadWidgets();
+    };
     electronAPI.on('plugin-state-changed', handlePluginStateChanged);
     return () => electronAPI.off('plugin-state-changed', handlePluginStateChanged);
-  }, [checkPlugins]);
+  }, [checkPlugins, checkInstalledPlugins, loadWidgets]);
 
   // ---- Workflow list (RUNNING + BLOCKED-failed) -----------------------
   const loadWorkflows = useCallback(async () => {
@@ -337,14 +373,41 @@ export const DashboardApp: React.FC = () => {
     </div>
   );
 
+  // No plugins installed at all -> collapse to the health strip + an
+  // install-plugins affordance (epic mea-cjl target: pluginless core).
+  // installedPluginCount === null means "not checked yet"; default to the
+  // panel grid below rather than flashing the empty state.
+  const noPluginsInstalled = installedPluginCount === 0;
+
+  const widgetsContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    padding: '16px',
+  };
+
   return (
     <div style={containerStyle}>
       <SystemStrip />
-      <div style={panelsContainerStyle} className="dashboard-cockpit-panels">
-        {runningColumn}
-        {nextColumn}
-        {blockedColumn}
-      </div>
+      {noPluginsInstalled ? (
+        <NoPluginsEmptyState />
+      ) : dashboardWidgets.length > 0 ? (
+        <div style={widgetsContainerStyle} className="dashboard-widgets">
+          {dashboardWidgets.map((widget) => (
+            <DashboardWidgetSlot
+              key={`${widget.pluginId}:${widget.widgetId}`}
+              WidgetClass={widget.WidgetClass}
+              pluginId={widget.pluginId}
+            />
+          ))}
+        </div>
+      ) : (
+        <div style={panelsContainerStyle} className="dashboard-cockpit-panels">
+          {runningColumn}
+          {nextColumn}
+          {blockedColumn}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/views/__tests__/DashboardViewReact.pluginSlots.test.tsx
+++ b/src/renderer/views/__tests__/DashboardViewReact.pluginSlots.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * DashboardApp pluginless empty state + widget-slot rendering (bead
+ * mea-cjl.1). Separate from DashboardViewReact.test.tsx (which locks the
+ * card deep-link contract with one plugin active) because these tests vary
+ * the installed-plugin COUNT itself, the new gating signal.
+ */
+
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DashboardApp } from '../DashboardViewReact';
+
+jest.mock('../../services/dashboardWidgetLoader', () => ({
+  loadActiveDashboardWidgets: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { loadActiveDashboardWidgets } = require('../../services/dashboardWidgetLoader');
+
+class FakeWorkflowWidget {
+  async mount(container: HTMLElement): Promise<void> {
+    container.textContent = 'RUNNING / NEXT / BLOCKED';
+  }
+  async unmount(): Promise<void> {}
+}
+
+function installMocks(pluginList: any[]) {
+  (window as any).electronAPI = {
+    invoke: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+    off: jest.fn(),
+    removeAllListeners: jest.fn(),
+    plugins: {
+      list: jest.fn().mockResolvedValue(pluginList),
+      getRendererUrl: jest.fn(),
+    },
+    mcpSystem: {
+      getDetailedStatus: jest.fn().mockResolvedValue({
+        overall: { running: true, healthy: true, ready: true, message: 'ok' },
+        services: [],
+        timestamp: new Date(),
+      }),
+      start: jest.fn(),
+      stop: jest.fn(),
+      restart: jest.fn(),
+      onProgress: jest.fn(),
+      removeProgressListener: jest.fn(),
+    },
+    clientSelection: {
+      getSelection: jest.fn().mockResolvedValue({ clients: [], selectedAt: new Date().toISOString() }),
+    },
+  };
+  const navigateTo = jest.fn();
+  (window as any).__viewRouter__ = { navigateTo };
+  return { navigateTo };
+}
+
+afterEach(() => {
+  delete (window as any).__viewRouter__;
+  delete (window as any).electronAPI;
+  jest.clearAllMocks();
+});
+
+describe('DashboardApp pluginless empty state (bead mea-cjl.1)', () => {
+  it('with zero plugins installed, shows the health strip + install-plugins affordance, no cockpit columns', async () => {
+    loadActiveDashboardWidgets.mockResolvedValue([]);
+    const { navigateTo } = installMocks([]);
+
+    render(<DashboardApp />);
+
+    expect(await screen.findByText('No plugins installed')).toBeInTheDocument();
+    expect(screen.queryByText(/^Running \(/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Next \(/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Blocked \(/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Install plugins' }));
+    expect(navigateTo).toHaveBeenCalledWith('plugins');
+  });
+
+  it('with a plugin installed but no dashboard widget contributed, falls back to the cockpit columns', async () => {
+    loadActiveDashboardWidgets.mockResolvedValue([]);
+    installMocks([{ id: 'fictionlab-kanban', status: 'active' }]);
+
+    render(<DashboardApp />);
+
+    expect(await screen.findByText(/^Running \(/)).toBeInTheDocument();
+    expect(screen.queryByText('No plugins installed')).not.toBeInTheDocument();
+  });
+
+  it('with a plugin contributing a dashboard widget, renders the widget slot instead of the cockpit columns', async () => {
+    loadActiveDashboardWidgets.mockResolvedValue([
+      { pluginId: 'fictionlab-workflow', pluginVersion: '1.0.0', widgetId: 'workflow-widget', WidgetClass: FakeWorkflowWidget },
+    ]);
+    installMocks([{ id: 'fictionlab-workflow', status: 'active' }]);
+
+    render(<DashboardApp />);
+
+    await waitFor(() => expect(screen.getByText('RUNNING / NEXT / BLOCKED')).toBeInTheDocument());
+    expect(screen.queryByText('No plugins installed')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Running \(/)).not.toBeInTheDocument();
+  });
+});

--- a/src/types/plugin-api.ts
+++ b/src/types/plugin-api.ts
@@ -184,6 +184,17 @@ export interface PluginUIConfig {
   /** Sidebar widget component */
   sidebarWidget?: string;
 
+  /**
+   * Dashboard widget component identifier (bead mea-cjl.1). When the
+   * manifest also declares `entry.renderer`, the host dynamically imports
+   * that SAME bundle and looks for a NAMED export `dashboardWidget` (the
+   * `entry.renderer` doc comment above reserves the default export for
+   * `ui.mainView`) — a widget class implementing `{ mount(container),
+   * unmount?() }` — and mounts one instance into the Dashboard under this
+   * id. Omit if the plugin contributes no dashboard widget.
+   */
+  dashboardWidget?: string;
+
   /** Settings panel component */
   settingsPanel?: string;
 


### PR DESCRIPTION
## Summary
- Adds a host-side plugin dashboard-widget contribution API: `ui.dashboardWidget` manifest field + `src/renderer/services/dashboardWidgetLoader.ts`, mirroring `pluginViewLoader.ts`'s `mainView`/`entry.renderer` duck-typed default-export pattern, but looking for a named export `dashboardWidget` on the same bundle (the default export stays reserved for `ui.mainView`).
- With **zero plugins installed**, the Dashboard now renders only `SystemStrip` (service health) plus a new `NoPluginsEmptyState` affordance ("Install plugins" → navigates to the Plugins view) instead of the Running/Next/Blocked columns full of plugin-required placeholders.
- With plugins installed, existing behavior is preserved: if no active plugin yet contributes a dashboard widget (true today — no plugin implements the new field yet), the cockpit falls back to the current Running/Next/Blocked panel grid. If a plugin does contribute a widget, it's mounted into a `DashboardWidgetSlot`.
- Part of epic `mea-cjl` (extract all workflow UI into the workflow plugin; dashboard becomes plugin-composed). This slice is host-side only — the actual RUNNING/NEXT/BLOCKED widget moving into the workflow plugin is slice D (`mea-cjl.4`), which depends on this.

## Test plan
- [x] `npx tsc -p tsconfig.renderer.json --noEmit` — clean
- [x] New unit tests: `dashboardWidgetLoader.test.ts`, `NoPluginsEmptyState.test.tsx`, `DashboardWidgetSlot.test.tsx`, `DashboardViewReact.pluginSlots.test.tsx` (zero plugins → empty state; plugin installed w/ no widget → existing columns; plugin contributing a widget → widget slot)
- [x] Existing `DashboardViewReact.test.tsx` (card deep-link regression) still passes unchanged
- [x] Full `npx jest --config jest.config.cjs` run — only pre-existing, unrelated failures in `tests/main/build-orchestrator.test.ts` / `tests/main/repository-manager.test.ts` (network/git timeouts, confirmed present on `develop` before this change via `git stash`)

Closes bead: mea-cjl.1