### PR TITLE
fix(dashboard): top-bar status stuck on Unknown + silent Refresh button

### DIFF
--- a/src/renderer/components/TopBar.ts
+++ b/src/renderer/components/TopBar.ts
@@ -38,6 +38,11 @@ export class TopBar {
   private container: HTMLElement;
   private currentConfig: TopBarConfig = {};
   private listeners: Map<string, Set<Function>> = new Map();
+  // Last aggregate status pushed via updateEnvironmentStatus() (bead
+  // mea-lj0). null = never pushed yet (e.g. Dashboard/SystemStrip hasn't
+  // mounted this session) -- rendered as a neutral "Status Unknown", not a
+  // false "error", so a real error can't be confused with "not checked yet".
+  private environmentStatus: { status: 'healthy' | 'warning' | 'error'; text: string } | null = null;
 
   constructor(options: TopBarOptions) {
     this.container = options.container;
@@ -293,37 +298,20 @@ export class TopBar {
    * Render environment indicator
    */
   private renderEnvironmentIndicator(): string {
-    // Get actual system status from DOM (updated by dashboard handlers)
-    const statusTextElement = document.getElementById('dashboard-status-text');
-    const statusIndicator = document.getElementById('dashboard-status-indicator');
-
-    let status: 'healthy' | 'warning' | 'error' = 'error';
-    let statusText = 'Status Unknown';
-
-    if (statusTextElement && statusIndicator) {
-      const currentStatusText = statusTextElement.textContent || '';
-
-      // Map dashboard status to environment indicator status
-      if (currentStatusText === 'System Ready') {
-        status = 'healthy';
-        statusText = 'All Systems Operational';
-      } else if (currentStatusText === 'System Starting' || currentStatusText === 'System Degraded') {
-        status = 'warning';
-        statusText = currentStatusText;
-      } else if (currentStatusText === 'System Offline') {
-        status = 'error';
-        statusText = 'System Offline';
-      } else {
-        // Unknown status
-        status = 'error';
-        statusText = currentStatusText || 'Status Unknown';
-      }
-    }
+    // Driven by updateEnvironmentStatus() (bead mea-lj0) -- SystemStrip
+    // pushes the live aggregate here on every status fetch. Previously this
+    // read `#dashboard-status-text` / `#dashboard-status-indicator`, DOM
+    // elements the old Dashboard markup owned; issue #214's cockpit redesign
+    // deleted that markup without replacing what fed this indicator, so it
+    // was permanently stuck reporting "Status Unknown" regardless of real
+    // health (verified 2026-07-17 -- neither id exists anywhere in the tree).
+    const statusClass = this.environmentStatus?.status ?? '';
+    const statusText = this.environmentStatus?.text ?? 'Status Unknown';
 
     return `
       <div class="environment-indicator">
-        <span class="environment-dot ${status}"></span>
-        <span class="environment-text">${statusText}</span>
+        <span class="environment-dot ${statusClass}"></span>
+        <span class="environment-text">${this.escapeHtml(statusText)}</span>
       </div>
     `;
   }
@@ -749,6 +737,12 @@ export class TopBar {
    * This method is called by the dashboard handlers when status changes
    */
   public updateEnvironmentStatus(status: 'healthy' | 'warning' | 'error', text?: string): void {
+    // Persist so the NEXT full render() (e.g. navigating to another view,
+    // which rebuilds this markup from scratch via setContext -> render())
+    // still reflects the last known status instead of resetting to "Status
+    // Unknown" (bead mea-lj0) -- see renderEnvironmentIndicator().
+    this.environmentStatus = { status, text: text ?? this.environmentStatus?.text ?? 'Status Unknown' };
+
     const indicator = this.container.querySelector('.environment-indicator');
     if (indicator) {
       const dot = indicator.querySelector('.environment-dot');
@@ -761,8 +755,8 @@ export class TopBar {
         dot.classList.add(status);
       }
 
-      if (textEl && text) {
-        textEl.textContent = text;
+      if (textEl) {
+        textEl.textContent = this.environmentStatus.text;
       }
     }
   }

--- a/src/renderer/components/__tests__/TopBar.environmentIndicator.test.ts
+++ b/src/renderer/components/__tests__/TopBar.environmentIndicator.test.ts
@@ -1,0 +1,92 @@
+/**
+ * TopBar environment indicator regression tests (bead mea-lj0).
+ *
+ * The bug: renderEnvironmentIndicator() read status from `#dashboard-
+ * status-text` / `#dashboard-status-indicator` DOM elements that issue
+ * #214's cockpit redesign deleted along with the old Dashboard markup.
+ * Nothing has driven the indicator since, so it was permanently stuck on
+ * "Status Unknown" (rendered as an 'error'-colored dot) regardless of real
+ * service health. The fix: SystemStrip now pushes the live aggregate via
+ * `updateEnvironmentStatus()`, and the indicator renders from that pushed
+ * state (persisted on the TopBar instance) instead of a stale DOM read.
+ */
+
+import { TopBar } from '../TopBar';
+
+function setupTopBar(): { topBar: TopBar; container: HTMLElement } {
+  document.body.innerHTML = '<div id="top-bar"></div>';
+  const container = document.getElementById('top-bar')!;
+  const topBar = new TopBar({ container });
+  topBar.initialize();
+  topBar.setContext('dashboard', {
+    title: 'Dashboard',
+    global: { environmentIndicator: true },
+  });
+  return { topBar, container };
+}
+
+describe('TopBar environment indicator', () => {
+  it('renders a neutral "Status Unknown" (no health class) before anything ever pushes a status', () => {
+    const { container } = setupTopBar();
+
+    const text = container.querySelector('.environment-text');
+    const dot = container.querySelector('.environment-dot');
+
+    expect(text?.textContent).toBe('Status Unknown');
+    expect(dot?.classList.contains('error')).toBe(false);
+    expect(dot?.classList.contains('healthy')).toBe(false);
+    expect(dot?.classList.contains('warning')).toBe(false);
+  });
+
+  it('reflects a healthy push immediately (patches the live DOM, not just state)', () => {
+    const { topBar, container } = setupTopBar();
+
+    topBar.updateEnvironmentStatus('healthy', 'All Systems Operational');
+
+    const text = container.querySelector('.environment-text');
+    const dot = container.querySelector('.environment-dot');
+    expect(text?.textContent).toBe('All Systems Operational');
+    expect(dot?.classList.contains('healthy')).toBe(true);
+  });
+
+  it('degrades to warning/error text+class on subsequent pushes (never stuck on the first status)', () => {
+    const { topBar, container } = setupTopBar();
+
+    topBar.updateEnvironmentStatus('healthy', 'All Systems Operational');
+    topBar.updateEnvironmentStatus('warning', 'MCP Writing Servers starting');
+
+    const dot = container.querySelector('.environment-dot');
+    const text = container.querySelector('.environment-text');
+    expect(dot?.classList.contains('warning')).toBe(true);
+    expect(dot?.classList.contains('healthy')).toBe(false);
+    expect(text?.textContent).toBe('MCP Writing Servers starting');
+  });
+
+  it('survives a full re-render (view navigation) instead of resetting to Status Unknown', () => {
+    const { topBar, container } = setupTopBar();
+
+    topBar.updateEnvironmentStatus('healthy', 'All Systems Operational');
+    // setContext triggers a full render() -- rebuilds the markup from
+    // scratch, the exact path that used to lose the pushed status because
+    // the old implementation re-read a DOM element instead of stored state.
+    topBar.setContext('settings-services', {
+      title: 'Services',
+      global: { environmentIndicator: true },
+    });
+
+    const text = container.querySelector('.environment-text');
+    const dot = container.querySelector('.environment-dot');
+    expect(text?.textContent).toBe('All Systems Operational');
+    expect(dot?.classList.contains('healthy')).toBe(true);
+  });
+
+  it('escapes text content (defense in depth -- overall.message ultimately comes from service data)', () => {
+    const { topBar, container } = setupTopBar();
+
+    topBar.updateEnvironmentStatus('error', '<img src=x onerror=alert(1)>');
+
+    const text = container.querySelector('.environment-text');
+    expect(text?.innerHTML).not.toContain('<img');
+    expect(text?.textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+});

--- a/src/renderer/components/dashboard/SystemStrip.tsx
+++ b/src/renderer/components/dashboard/SystemStrip.tsx
@@ -80,6 +80,49 @@ function dotColor(status: DetailedServiceStatus['status']): string {
   }
 }
 
+export interface AggregateStatus {
+  status: 'healthy' | 'warning' | 'error';
+  text: string;
+}
+
+/**
+ * Derive the TopBar's aggregate health text/color from the same `overall`
+ * summary the health dots already use (bead mea-lj0). Exported for direct
+ * unit coverage of the derivation rule, independent of the fetch/render
+ * plumbing around it.
+ */
+export function deriveAggregateStatus(overall: DetailedSystemStatus['overall'] | undefined): AggregateStatus {
+  if (!overall) {
+    return { status: 'error', text: 'Status Unknown' };
+  }
+  if (overall.healthy) {
+    return { status: 'healthy', text: 'All Systems Operational' };
+  }
+  if (overall.running) {
+    return { status: 'warning', text: overall.message || 'System Degraded' };
+  }
+  return { status: 'error', text: overall.message || 'System Offline' };
+}
+
+/**
+ * Push the derived aggregate to the TopBar's environment indicator (bead
+ * mea-lj0). The indicator used to read its status from `#dashboard-status-
+ * text` / `#dashboard-status-indicator` DOM elements that issue #214's
+ * cockpit redesign deleted along with the old Dashboard markup -- nothing
+ * has driven it since, so it was permanently stuck on its "Status Unknown"
+ * default regardless of real health. SystemStrip is the strip that already
+ * owns the live health fetch, so it's the natural (and only, today) source
+ * to drive it from, via the same `window.topBar` global renderer.ts exposes
+ * (mirrors the guarded-call convention WorkflowsViewReact.tsx already uses
+ * for topBar.refreshProjectSelector()).
+ */
+function notifyTopBarOfStatus(overall: DetailedSystemStatus['overall'] | undefined): void {
+  const topBar = (window as any).topBar;
+  if (!topBar || typeof topBar.updateEnvironmentStatus !== 'function') return;
+  const aggregate = deriveAggregateStatus(overall);
+  topBar.updateEnvironmentStatus(aggregate.status, aggregate.text);
+}
+
 /**
  * There's no dedicated "Docker daemon" IPC channel exposed to the renderer
  * (checkDockerRunning() in src/main/prerequisites.ts is main-process-only --
@@ -100,6 +143,8 @@ export const SystemStrip: React.FC = () => {
   const [detailed, setDetailed] = useState<DetailedSystemStatus | null>(null);
   const [actionInProgress, setActionInProgress] = useState<SystemAction | null>(null);
   const [progressText, setProgressText] = useState('');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastChecked, setLastChecked] = useState<Date | null>(null);
   const actionInProgressRef = useRef<SystemAction | null>(null);
 
   const fetchStatus = useCallback(async () => {
@@ -108,6 +153,8 @@ export const SystemStrip: React.FC = () => {
       if (!electronAPI?.mcpSystem?.getDetailedStatus) return;
       const result: DetailedSystemStatus = await electronAPI.mcpSystem.getDetailedStatus();
       setDetailed(result);
+      setLastChecked(new Date());
+      notifyTopBarOfStatus(result?.overall);
     } catch (error) {
       console.error('[SystemStrip] Failed to fetch detailed status:', error);
     }
@@ -116,7 +163,19 @@ export const SystemStrip: React.FC = () => {
   useEffect(() => {
     fetchStatus();
     const pollInterval = setInterval(fetchStatus, POLL_INTERVAL_MS);
-    const handleRefresh = () => fetchStatus();
+    // The Refresh top-bar action (DashboardView's handleAction('refresh'))
+    // dispatches this event. Unlike the silent poll above, a manual refresh
+    // needs VISIBLE feedback (bead mea-lj0) -- the health dots update either
+    // way, but with nothing already unhealthy, that update is invisible, so
+    // clicking Refresh looked like it did nothing.
+    const handleRefresh = async () => {
+      setIsRefreshing(true);
+      try {
+        await fetchStatus();
+      } finally {
+        setIsRefreshing(false);
+      }
+    };
     window.addEventListener('dashboard-refresh', handleRefresh);
     return () => {
       clearInterval(pollInterval);
@@ -227,6 +286,18 @@ export const SystemStrip: React.FC = () => {
     color: 'var(--color-text-tertiary)',
   };
 
+  // Manual-refresh feedback (bead mea-lj0): "Checking…" while in flight,
+  // then a last-checked timestamp -- takes priority over nothing so the
+  // Refresh button visibly does something even when no dot changes color.
+  // Falls back to any Start/Stop/Restart progress text when one is running.
+  const statusLineText = progressText
+    ? progressText
+    : isRefreshing
+    ? 'Checking…'
+    : lastChecked
+    ? `Checked ${lastChecked.toLocaleTimeString()}`
+    : '';
+
   const services = detailed?.services || [];
   // "Writing Srv" / "Connector" per the design supplement's ASCII layout --
   // getDetailedServiceStatus() names them "MCP Writing Servers" / "MCP Connector".
@@ -253,7 +324,11 @@ export const SystemStrip: React.FC = () => {
       </div>
 
       <div style={actionsContainerStyle}>
-        {progressText && <span style={progressTextStyle}>{progressText}</span>}
+        {statusLineText && (
+          <span style={progressTextStyle} aria-live="polite">
+            {statusLineText}
+          </span>
+        )}
         <div style={buttonGroupStyle} role="group" aria-label="System controls">
           {(['start', 'stop', 'restart'] as SystemAction[]).map((action) => (
             <button

--- a/src/renderer/components/dashboard/__tests__/SystemStrip.test.tsx
+++ b/src/renderer/components/dashboard/__tests__/SystemStrip.test.tsx
@@ -12,7 +12,7 @@
 import * as React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SystemStrip } from '../SystemStrip';
+import { SystemStrip, deriveAggregateStatus } from '../SystemStrip';
 
 function installElectronAPI(overrides: Partial<any> = {}) {
   const api = {
@@ -84,5 +84,85 @@ describe('SystemStrip', () => {
 
     expect(api.mcpSystem.start).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(api.mcpSystem.getDetailedStatus).toHaveBeenCalled());
+  });
+});
+
+describe('deriveAggregateStatus (bead mea-lj0)', () => {
+  it('reports healthy when overall.healthy is true', () => {
+    expect(deriveAggregateStatus({ running: true, healthy: true, ready: true, message: 'ok' })).toEqual({
+      status: 'healthy',
+      text: 'All Systems Operational',
+    });
+  });
+
+  it('reports warning with the service message when running but not yet healthy', () => {
+    expect(
+      deriveAggregateStatus({ running: true, healthy: false, ready: false, message: 'Starting Postgres...' })
+    ).toEqual({ status: 'warning', text: 'Starting Postgres...' });
+  });
+
+  it('falls back to a generic warning message when running-but-unhealthy has no message', () => {
+    expect(deriveAggregateStatus({ running: true, healthy: false, ready: false, message: '' })).toEqual({
+      status: 'warning',
+      text: 'System Degraded',
+    });
+  });
+
+  it('reports error when not running, using the service message', () => {
+    expect(
+      deriveAggregateStatus({ running: false, healthy: false, ready: false, message: 'Docker not detected' })
+    ).toEqual({ status: 'error', text: 'Docker not detected' });
+  });
+
+  it('reports error with "System Offline" when not running and no message', () => {
+    expect(deriveAggregateStatus({ running: false, healthy: false, ready: false, message: '' })).toEqual({
+      status: 'error',
+      text: 'System Offline',
+    });
+  });
+
+  it('reports "Status Unknown" when overall is undefined (status not fetched yet)', () => {
+    expect(deriveAggregateStatus(undefined)).toEqual({ status: 'error', text: 'Status Unknown' });
+  });
+});
+
+describe('SystemStrip -> TopBar aggregate push (bead mea-lj0)', () => {
+  it('pushes the derived healthy aggregate to window.topBar.updateEnvironmentStatus on fetch', async () => {
+    installElectronAPI();
+    const updateEnvironmentStatus = jest.fn();
+    (window as any).topBar = { updateEnvironmentStatus };
+
+    render(<SystemStrip />);
+
+    await waitFor(() =>
+      expect(updateEnvironmentStatus).toHaveBeenCalledWith('healthy', 'All Systems Operational')
+    );
+
+    delete (window as any).topBar;
+  });
+
+  it('does not throw when window.topBar is unavailable', async () => {
+    installElectronAPI();
+    delete (window as any).topBar;
+
+    render(<SystemStrip />);
+    await screen.findByText('Postgres');
+    // No assertion beyond "didn't throw".
+  });
+
+  it('shows "Checking…" then a last-checked timestamp after a manual dashboard-refresh', async () => {
+    installElectronAPI();
+    render(<SystemStrip />);
+    await screen.findByText('Postgres');
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('dashboard-refresh'));
+    });
+
+    // The refresh resolves near-instantly with mocked IPC, but the
+    // "Checking…"/"Checked <time>" text is the visible-feedback contract
+    // under test -- assert the end state landed rather than racing the
+    // synchronous flip back to false.
+    await waitFor(() => expect(screen.getByText(/^Checked /)).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary
- Root cause of both symptoms: `TopBar.renderEnvironmentIndicator()` read status from `#dashboard-status-text` / `#dashboard-status-indicator` DOM elements that issue #214's Dashboard-cockpit redesign deleted along with the old Dashboard markup (verified by grep — neither id exists anywhere in the tree anymore). Nothing has driven it since, so it always fell through to the "Status Unknown" / error-colored default, regardless of real per-service health, and Refresh's re-fetch had no visible effect on it.
- `SystemStrip` now derives an aggregate (`healthy`/`warning`/`error`) from the same `overall` summary its own health dots already use (new exported `deriveAggregateStatus()`), and pushes it to `window.topBar.updateEnvironmentStatus()` on every status fetch (15s poll, manual refresh, and after start/stop/restart) — mirroring the existing guarded `window.topBar` call convention already used in `WorkflowsViewReact.tsx`.
- `TopBar` now persists the pushed status on the instance and renders from it, so it survives a full re-render (e.g. navigating to another view, which rebuilds the top-bar markup from scratch via `setContext` → `render()`) instead of resetting to "Status Unknown".
- The Refresh button now shows "Checking…" while a manual refresh is in flight, then a "Checked HH:MM:SS" timestamp — visible feedback even when no dot changes color (previously a healthy system's Refresh click looked like a no-op).

## Test plan
- [x] `npx tsc -p tsconfig.renderer.json --noEmit` — clean
- [x] New tests: `TopBar.environmentIndicator.test.ts` (neutral pre-push state, healthy/warning/error pushes, survives full re-render, HTML-escapes pushed text) and additions to `SystemStrip.test.tsx` (`deriveAggregateStatus` unit coverage for all branches + the undefined/no-status-yet case, the TopBar push on fetch, graceful no-op when `window.topBar` is absent, and the Checking→Checked refresh-feedback text)
- [x] Existing `SystemStrip.test.tsx` cases still pass unchanged
- [x] Full `npx jest --config jest.config.cjs` — only pre-existing, unrelated failures in `tests/main/build-orchestrator.test.ts` / `tests/main/repository-manager.test.ts` (confirmed present on `develop` before this change)

Closes bead: mea-lj0