### PR TITLE
feat(dashboard): drop workflow columns from core, composite with plugin widgets (mea-cjl.4)

### DIFF
--- a/src/renderer/components/dashboard/BlockedPanel.tsx
+++ b/src/renderer/components/dashboard/BlockedPanel.tsx
@@ -1,14 +1,16 @@
 /**
  * BlockedPanel ("what needs a human decision")
- * Kanban blocked cards + review cards with review_policy === 'review-required',
- * plus failed workflow runs. This is the "what do you need from me" list --
+ * Kanban blocked cards + review cards with review_policy === 'review-required'.
+ * Failed workflow runs used to appear here too until the workflow plugin
+ * grew its own dashboard widget for that (bead mea-cjl.4) — see
+ * DashboardViewReact.tsx for how the widget and this now-kanban-only panel
+ * grid render together. This is the "what do you need from me" list --
  * every entry says what it's waiting on and deep-links into the Board view
  * (v1 scope: navigateTo('kanban') only, per the design supplement -- no
  * plugin-side card-drawer opening in this PR).
  */
 
 import * as React from 'react';
-import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
 import { KanbanCardRow } from './KanbanCardRow.js';
 import { PluginPlaceholder } from './PluginPlaceholder.js';
 import type { KanbanCard } from './types.js';
@@ -16,13 +18,9 @@ import type { KanbanCard } from './types.js';
 export interface BlockedPanelProps {
   /** Already filtered to status === 'blocked' OR (status === 'review' AND review_policy === 'review-required'). */
   kanbanCards: KanbanCard[];
-  /** Already filtered to status === 'failed'. */
-  failedWorkflows: ActiveWorkflowInstance[];
   kanbanPluginActive: boolean;
-  workflowPluginActive: boolean;
   loading: boolean;
   onCardClick: (card: KanbanCard) => void;
-  onWorkflowClick: (workflow: ActiveWorkflowInstance) => void;
 }
 
 function waitingOnLabel(card: KanbanCard): string {
@@ -33,51 +31,17 @@ function waitingOnLabel(card: KanbanCard): string {
 
 export const BlockedPanel: React.FC<BlockedPanelProps> = ({
   kanbanCards,
-  failedWorkflows,
   kanbanPluginActive,
-  workflowPluginActive,
   loading,
   onCardClick,
-  onWorkflowClick,
 }) => {
-  // Same "don't claim empty when every source is gated off" rule as
-  // RunningPanel -- see its comment.
-  const anyActive = kanbanPluginActive || workflowPluginActive;
-  const isEmpty =
-    !loading &&
-    anyActive &&
-    (!kanbanPluginActive || kanbanCards.length === 0) &&
-    (!workflowPluginActive || failedWorkflows.length === 0);
+  const isEmpty = !loading && kanbanPluginActive && kanbanCards.length === 0;
 
   const emptyStyle: React.CSSProperties = {
     padding: '16px 4px',
     fontSize: '12px',
     color: 'var(--color-text-tertiary)',
     textAlign: 'center',
-  };
-
-  const failedRowStyle: React.CSSProperties = {
-    background: 'var(--color-bg-tertiary)',
-    border: '1px solid var(--status-error)',
-    borderLeft: '3px solid var(--status-error)',
-    borderRadius: '6px',
-    padding: '8px 10px',
-    marginBottom: '6px',
-    cursor: 'pointer',
-  };
-
-  const failedTitleStyle: React.CSSProperties = {
-    fontSize: '13px',
-    color: 'var(--color-text-primary)',
-    marginBottom: '4px',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  };
-
-  const failedMetaStyle: React.CSSProperties = {
-    fontSize: '11px',
-    color: 'var(--status-error)',
   };
 
   return (
@@ -93,34 +57,6 @@ export const BlockedPanel: React.FC<BlockedPanelProps> = ({
         ))
       ) : (
         <PluginPlaceholder label="Enable the kanban plugin to see blocked work items." />
-      )}
-
-      {workflowPluginActive ? (
-        failedWorkflows.map((workflow) => (
-          <div
-            key={workflow.id}
-            style={failedRowStyle}
-            onClick={() => onWorkflowClick(workflow)}
-            role="button"
-            tabIndex={0}
-            title={workflow.workflowName}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onWorkflowClick(workflow);
-              }
-            }}
-          >
-            <div style={failedTitleStyle}>{workflow.workflowName}</div>
-            <div style={failedMetaStyle}>Workflow failed — needs attention</div>
-            {/* TODO: no workflow retry/restart-run IPC exists yet (checked
-                workflow-handlers.ts: only pause/resume/cancel/jump-to-node).
-                Add a Retry button here once one ships -- do not invent one
-                in this PR (issue #214 hard constraint). */}
-          </div>
-        ))
-      ) : (
-        <PluginPlaceholder label="Enable the fictionlab-workflow plugin to see failed workflow runs." />
       )}
 
       {isEmpty && <div style={emptyStyle}>Nothing blocked 🎉</div>}

--- a/src/renderer/components/dashboard/RunningPanel.tsx
+++ b/src/renderer/components/dashboard/RunningPanel.tsx
@@ -1,53 +1,32 @@
 /**
  * RunningPanel ("what's running now")
- * Composes ActiveWorkflowCard (reused, not reinvented -- issue #214 hard
- * constraint) for live workflow runs with in_progress/claimed kanban cards.
- * A kanban card whose workflow_registry_id matches an already-shown run is
- * suppressed (dedupe rule) so the same piece of work never appears twice.
+ * In-progress/claimed kanban cards. Running/blocked workflow runs used to
+ * appear here too (reusing ActiveWorkflowCard) until the workflow plugin
+ * grew its own dashboard widget for that (bead mea-cjl.4) — see
+ * DashboardViewReact.tsx for how the widget and this now-kanban-only panel
+ * grid render together.
  */
 
 import * as React from 'react';
-import type { ActiveWorkflowInstance } from '../../../types/workflow.js';
-import { ActiveWorkflowCard } from '../ActiveWorkflowCard.js';
 import { KanbanCardRow } from './KanbanCardRow.js';
 import { PluginPlaceholder } from './PluginPlaceholder.js';
 import type { KanbanCard } from './types.js';
 
 export interface RunningPanelProps {
-  /** Already filtered to status running/paused. */
-  workflows: ActiveWorkflowInstance[];
-  /** Already filtered to status in_progress/claimed AND deduped against `workflows`. */
+  /** Already filtered to status in_progress/claimed. */
   kanbanCards: KanbanCard[];
-  workflowPluginActive: boolean;
   kanbanPluginActive: boolean;
   loading: boolean;
-  onPause: (id: string) => void;
-  onResume: (id: string) => void;
-  onCancel: (id: string) => void;
   onCardClick: (card: KanbanCard) => void;
 }
 
 export const RunningPanel: React.FC<RunningPanelProps> = ({
-  workflows,
   kanbanCards,
-  workflowPluginActive,
   kanbanPluginActive,
   loading,
-  onPause,
-  onResume,
-  onCancel,
   onCardClick,
 }) => {
-  // Only claim "Nothing running" once at least one data source is actually
-  // active and confirmed empty -- when every source is plugin-gated off,
-  // the placeholders already explain the empty panel; showing "Nothing
-  // running" on top of them would be misleading (nothing was checked).
-  const anyActive = workflowPluginActive || kanbanPluginActive;
-  const isEmpty =
-    !loading &&
-    anyActive &&
-    (!workflowPluginActive || workflows.length === 0) &&
-    (!kanbanPluginActive || kanbanCards.length === 0);
+  const isEmpty = !loading && kanbanPluginActive && kanbanCards.length === 0;
 
   const emptyStyle: React.CSSProperties = {
     padding: '16px 4px',
@@ -58,20 +37,6 @@ export const RunningPanel: React.FC<RunningPanelProps> = ({
 
   return (
     <div className="dashboard-panel dashboard-panel-running">
-      {workflowPluginActive ? (
-        workflows.map((workflow) => (
-          <ActiveWorkflowCard
-            key={workflow.id}
-            workflow={workflow}
-            onPause={onPause}
-            onResume={onResume}
-            onCancel={onCancel}
-          />
-        ))
-      ) : (
-        <PluginPlaceholder label="Enable the fictionlab-workflow plugin to see running workflows." />
-      )}
-
       {kanbanPluginActive ? (
         kanbanCards.map((card) => (
           <KanbanCardRow key={card.id} card={card} onClick={() => onCardClick(card)} />

--- a/src/renderer/components/dashboard/__tests__/BlockedPanel.test.tsx
+++ b/src/renderer/components/dashboard/__tests__/BlockedPanel.test.tsx
@@ -1,40 +1,19 @@
 /**
- * Render tests for BlockedPanel (issue #214): populated (blocked kanban
- * card + failed workflow run, each captioned with what it's waiting on),
- * empty, and plugin-missing states.
+ * Render tests for BlockedPanel (issue #214, kanban-only since bead
+ * mea-cjl.4 moved failed-workflow rendering to the workflow plugin's own
+ * dashboard widget): populated (blocked/review-required kanban cards, each
+ * captioned with what it's waiting on), empty, and plugin-missing states.
  */
 
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { BlockedPanel } from '../BlockedPanel';
-import type { ActiveWorkflowInstance } from '../../../../types/workflow';
 import type { KanbanCard } from '../types';
 
 const noop = () => {};
 
-function makeFailedWorkflow(overrides: Partial<ActiveWorkflowInstance> = {}): ActiveWorkflowInstance {
-  return {
-    id: 'wf-registry-9',
-    workflowId: 'wf-def-9',
-    workflowName: 'Cover Generation Pipeline',
-    source: 'fictionlab_ui',
-    projectFolder: '/projects/book-2',
-    projectName: 'Book Two',
-    currentNodeId: 'node-3',
-    currentNodeName: 'Generate Cover',
-    status: 'failed',
-    progressPercent: 60,
-    totalNodes: 5,
-    completedNodes: 3,
-    startedAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    availableNodes: [],
-    ...overrides,
-  };
-}
-
 describe('BlockedPanel', () => {
-  it('renders blocked/review-required kanban cards with a waiting-on caption and failed workflow runs', () => {
+  it('renders blocked/review-required kanban cards with a waiting-on caption', () => {
     const cards: KanbanCard[] = [
       { id: 1, title: 'Decide on title', status: 'blocked' },
       { id: 2, title: 'Approve final draft', status: 'review', review_policy: 'review-required' },
@@ -43,12 +22,9 @@ describe('BlockedPanel', () => {
     render(
       <BlockedPanel
         kanbanCards={cards}
-        failedWorkflows={[makeFailedWorkflow()]}
         kanbanPluginActive
-        workflowPluginActive
         loading={false}
         onCardClick={noop}
-        onWorkflowClick={noop}
       />
     );
 
@@ -56,41 +32,32 @@ describe('BlockedPanel', () => {
     expect(screen.getByText('Blocked — needs a decision')).toBeInTheDocument();
     expect(screen.getByText('Approve final draft')).toBeInTheDocument();
     expect(screen.getByText('In review — needs approval')).toBeInTheDocument();
-    expect(screen.getByText('Cover Generation Pipeline')).toBeInTheDocument();
-    expect(screen.getByText('Workflow failed — needs attention')).toBeInTheDocument();
   });
 
-  it('shows the "nothing blocked" empty state when both sources are active and clear', () => {
+  it('shows the "nothing blocked" empty state when active and clear', () => {
     render(
       <BlockedPanel
         kanbanCards={[]}
-        failedWorkflows={[]}
         kanbanPluginActive
-        workflowPluginActive
         loading={false}
         onCardClick={noop}
-        onWorkflowClick={noop}
       />
     );
 
     expect(screen.getByText('Nothing blocked 🎉')).toBeInTheDocument();
   });
 
-  it('shows plugin-missing placeholders when both plugins are inactive', () => {
+  it('shows a plugin-missing placeholder when kanban is inactive', () => {
     render(
       <BlockedPanel
         kanbanCards={[]}
-        failedWorkflows={[]}
         kanbanPluginActive={false}
-        workflowPluginActive={false}
         loading={false}
         onCardClick={noop}
-        onWorkflowClick={noop}
       />
     );
 
     expect(screen.getByText(/Enable the kanban plugin/)).toBeInTheDocument();
-    expect(screen.getByText(/Enable the fictionlab-workflow plugin/)).toBeInTheDocument();
     expect(screen.queryByText('Nothing blocked 🎉')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/dashboard/__tests__/RunningPanel.test.tsx
+++ b/src/renderer/components/dashboard/__tests__/RunningPanel.test.tsx
@@ -1,34 +1,13 @@
 /**
- * Render tests for RunningPanel (issue #214): populated, empty, and
- * plugin-missing states for both its workflow half and its kanban half.
+ * Render tests for RunningPanel (issue #214, kanban-only since bead
+ * mea-cjl.4 moved the workflow half to the workflow plugin's own dashboard
+ * widget): populated, empty, and plugin-missing states.
  */
 
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RunningPanel } from '../RunningPanel';
-import type { ActiveWorkflowInstance } from '../../../../types/workflow';
 import type { KanbanCard } from '../types';
-
-function makeWorkflow(overrides: Partial<ActiveWorkflowInstance> = {}): ActiveWorkflowInstance {
-  return {
-    id: 'wf-registry-1',
-    workflowId: 'wf-def-1',
-    workflowName: 'Chapter Drafting Pipeline',
-    source: 'claude_code',
-    projectFolder: '/projects/book-1',
-    projectName: 'Book One',
-    currentNodeId: 'node-2',
-    currentNodeName: 'Draft Chapter',
-    status: 'running',
-    progressPercent: 40,
-    totalNodes: 5,
-    completedNodes: 2,
-    startedAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    availableNodes: [],
-    ...overrides,
-  };
-}
 
 function makeCard(overrides: Partial<KanbanCard> = {}): KanbanCard {
   return {
@@ -42,36 +21,25 @@ function makeCard(overrides: Partial<KanbanCard> = {}): KanbanCard {
 const noop = () => {};
 
 describe('RunningPanel', () => {
-  it('renders an ActiveWorkflowCard per running workflow and a row per non-deduped kanban card', () => {
+  it('renders a row per kanban card', () => {
     render(
       <RunningPanel
-        workflows={[makeWorkflow()]}
         kanbanCards={[makeCard({ id: 'card-2', title: 'Fix cover art' })]}
-        workflowPluginActive
         kanbanPluginActive
         loading={false}
-        onPause={noop}
-        onResume={noop}
-        onCancel={noop}
         onCardClick={noop}
       />
     );
 
-    expect(screen.getByText('Chapter Drafting Pipeline')).toBeInTheDocument();
     expect(screen.getByText('Fix cover art')).toBeInTheDocument();
   });
 
-  it('shows the empty state when both sources are active but have nothing running', () => {
+  it('shows the empty state when active but nothing running', () => {
     render(
       <RunningPanel
-        workflows={[]}
         kanbanCards={[]}
-        workflowPluginActive
         kanbanPluginActive
         loading={false}
-        onPause={noop}
-        onResume={noop}
-        onCancel={noop}
         onCardClick={noop}
       />
     );
@@ -79,25 +47,19 @@ describe('RunningPanel', () => {
     expect(screen.getByText('Nothing running')).toBeInTheDocument();
   });
 
-  it('shows plugin-missing placeholders for each half when its plugin is inactive', () => {
+  it('shows a plugin-missing placeholder when kanban is inactive', () => {
     render(
       <RunningPanel
-        workflows={[]}
         kanbanCards={[]}
-        workflowPluginActive={false}
         kanbanPluginActive={false}
         loading={false}
-        onPause={noop}
-        onResume={noop}
-        onCancel={noop}
         onCardClick={noop}
       />
     );
 
-    expect(screen.getByText(/Enable the fictionlab-workflow plugin/)).toBeInTheDocument();
     expect(screen.getByText(/Enable the kanban plugin/)).toBeInTheDocument();
-    // Both halves are gated off, so there's nothing left to call "empty" --
-    // the placeholders already explain why nothing is showing.
+    // Gated off, so there's nothing left to call "empty" -- the placeholder
+    // already explains why nothing is showing.
     expect(screen.queryByText('Nothing running')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/dashboard/types.ts
+++ b/src/renderer/components/dashboard/types.ts
@@ -30,7 +30,7 @@ export interface KanbanCard {
   due_at?: string | null;
   /** e.g. 'review-required' -- gates whether a review-column card counts as Blocked. */
   review_policy?: string | null;
-  /** Set when a workflow run is attached to this card (join key for the dedupe rule). */
+  /** Set when a workflow run is attached to this card. */
   workflow_registry_id?: string | null;
   workflow_phase?: string | null;
   workflow_progress_percent?: number | null;
@@ -59,7 +59,6 @@ export const PRIORITY_LABELS: Record<string, string> = {
 };
 
 export const KANBAN_PLUGIN_ID = 'fictionlab-kanban';
-export const WORKFLOW_PLUGIN_ID = 'fictionlab-workflow';
 
 /**
  * Board scope (design supplement item 5): the cockpit should follow the

--- a/src/renderer/views/DashboardViewReact.tsx
+++ b/src/renderer/views/DashboardViewReact.tsx
@@ -5,58 +5,44 @@
  * (status bar, quick actions grid, database management, hardcoded service
  * cards, an unfed Recent Activity list).
  *
- * Follows the WorkflowsViewReact host-bundled React view idiom, but data
- * fetching for workflows + kanban cards is centralized here (rather than
- * duplicated per panel) because the dedupe rule (a kanban card is
- * suppressed if its workflow_registry_id matches an already-shown run)
- * needs both lists computed together, and Running/Blocked both need
- * different slices of the *same* workflow list.
+ * The panel grid is now kanban-only: running/blocked workflow runs used to
+ * be centralized here too (deduped against kanban cards sharing a
+ * workflow_registry_id), until the workflow plugin grew its own dashboard
+ * widget for that (bead mea-cjl.4, packages/workflow-plugin/src/renderer/
+ * dashboard-widget.tsx in fictionlab-workflow). That cross-plugin dedupe
+ * has no home anymore -- it needed both lists in one place, and the
+ * workflow plugin can't reach into kanban's data without coupling to its
+ * IPC contract. A kanban card mirroring a running workflow may now appear
+ * in both the kanban panel grid below and the workflow widget above.
  *
- * Plugin containment: this file lives in the host and aggregates host +
- * plugin data purely over IPC (`plugin:fictionlab-kanban:*` channels via
- * electronAPI.invoke/on) -- it never imports plugin code.
+ * Plugin containment: this file lives in the host and renders kanban data
+ * purely over IPC (`plugin:fictionlab-kanban:*` channels via
+ * electronAPI.invoke/on) -- it never imports plugin code. Any
+ * plugin-contributed dashboard widgets (workflow's Running/Blocked cards,
+ * and future ones) render above this grid rather than replacing it, since
+ * kanban's content isn't covered by any widget yet.
  */
 
 import * as React from 'react';
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import type { ActiveWorkflowInstance, WorkflowUpdate } from '../../types/workflow.js';
 import { RunningPanel } from '../components/dashboard/RunningPanel.js';
 import { NextPanel } from '../components/dashboard/NextPanel.js';
 import { BlockedPanel } from '../components/dashboard/BlockedPanel.js';
 import { SystemStrip } from '../components/dashboard/SystemStrip.js';
 import { NoPluginsEmptyState } from '../components/dashboard/NoPluginsEmptyState.js';
 import { DashboardWidgetSlot } from '../components/dashboard/DashboardWidgetSlot.js';
-import {
-  KANBAN_PLUGIN_ID,
-  WORKFLOW_PLUGIN_ID,
-  DEFAULT_BOARD_KEY,
-  isPluginActive,
-} from '../components/dashboard/types.js';
+import { KANBAN_PLUGIN_ID, DEFAULT_BOARD_KEY, isPluginActive } from '../components/dashboard/types.js';
 import type { KanbanCard } from '../components/dashboard/types.js';
 import { loadActiveDashboardWidgets } from '../services/dashboardWidgetLoader.js';
 import type { LoadedDashboardWidget } from '../services/dashboardWidgetLoader.js';
 
 const KANBAN_PLUGIN_PREFIX = `plugin:${KANBAN_PLUGIN_ID}:`;
 
-// Workflow list poll interval. Design supplement item 6 only mandates a 15s
-// poll backstop for the strip, but WorkflowManagerPanel.tsx already
-// established (and documented, see its loadActiveWorkflows() effect) that
-// workflow:instance-updated alone isn't enough: a workflow driven by an
-// external Claude Code session never goes through the IPC handlers that
-// call broadcastWorkflowUpdate(), so the push channel never fires for it
-// (see also WorkflowsViewReact.tsx's identical poll-fallback comment,
-// issue #178). Reusing that exact 5s poll here for the same IPC channel
-// avoids reintroducing that already-fixed-elsewhere bug in the cockpit.
-const WORKFLOW_POLL_INTERVAL_MS = 5000;
-
 const WIDE_LAYOUT_QUERY = '(min-width: 1100px)';
 
 export const DashboardApp: React.FC = () => {
-  const [workflows, setWorkflows] = useState<ActiveWorkflowInstance[]>([]);
   const [kanbanCards, setKanbanCards] = useState<KanbanCard[]>([]);
-  const [workflowPluginActive, setWorkflowPluginActive] = useState(false);
   const [kanbanPluginActive, setKanbanPluginActive] = useState(false);
-  const [workflowsLoading, setWorkflowsLoading] = useState(true);
   const [kanbanLoading, setKanbanLoading] = useState(true);
   // null = not yet checked (default to the "plugins installed" layout until
   // resolved, so nothing flashes empty on first paint).
@@ -66,19 +52,12 @@ export const DashboardApp: React.FC = () => {
     typeof window.matchMedia === 'function' ? window.matchMedia(WIDE_LAYOUT_QUERY).matches : true
   );
 
-  const workflowPluginActiveRef = useRef(workflowPluginActive);
   const kanbanPluginActiveRef = useRef(kanbanPluginActive);
-  workflowPluginActiveRef.current = workflowPluginActive;
   kanbanPluginActiveRef.current = kanbanPluginActive;
 
   // ---- Plugin gating -------------------------------------------------
   const checkPlugins = useCallback(async () => {
-    const [wfActive, kbActive] = await Promise.all([
-      isPluginActive(WORKFLOW_PLUGIN_ID),
-      isPluginActive(KANBAN_PLUGIN_ID),
-    ]);
-    setWorkflowPluginActive(wfActive);
-    setKanbanPluginActive(kbActive);
+    setKanbanPluginActive(await isPluginActive(KANBAN_PLUGIN_ID));
   }, []);
 
   // ---- Widget-slot API (bead mea-cjl.1): pluginless empty state + any
@@ -117,50 +96,6 @@ export const DashboardApp: React.FC = () => {
     electronAPI.on('plugin-state-changed', handlePluginStateChanged);
     return () => electronAPI.off('plugin-state-changed', handlePluginStateChanged);
   }, [checkPlugins, checkInstalledPlugins, loadWidgets]);
-
-  // ---- Workflow list (RUNNING + BLOCKED-failed) -----------------------
-  const loadWorkflows = useCallback(async () => {
-    if (!workflowPluginActiveRef.current) return;
-    try {
-      const electronAPI = (window as any).electronAPI;
-      if (!electronAPI?.invoke) return;
-      const result = await electronAPI.invoke('workflow:list-active');
-      if (Array.isArray(result)) {
-        setWorkflows(result);
-      }
-    } catch (error) {
-      console.error('[DashboardApp] Failed to load active workflows:', error);
-    } finally {
-      setWorkflowsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!workflowPluginActive) {
-      setWorkflows([]);
-      setWorkflowsLoading(false);
-      return;
-    }
-
-    setWorkflowsLoading(true);
-    loadWorkflows();
-
-    const electronAPI = (window as any).electronAPI;
-    if (!electronAPI?.on || !electronAPI?.off) return;
-
-    const handleUpdate = (_update: WorkflowUpdate) => loadWorkflows();
-    electronAPI.on('workflow:instance-updated', handleUpdate);
-
-    const pollInterval = setInterval(loadWorkflows, WORKFLOW_POLL_INTERVAL_MS);
-    const handleDashboardRefresh = () => loadWorkflows();
-    window.addEventListener('dashboard-refresh', handleDashboardRefresh);
-
-    return () => {
-      electronAPI.off('workflow:instance-updated', handleUpdate);
-      clearInterval(pollInterval);
-      window.removeEventListener('dashboard-refresh', handleDashboardRefresh);
-    };
-  }, [workflowPluginActive, loadWorkflows]);
 
   // ---- Kanban cards (RUNNING in_progress/claimed, NEXT ready, BLOCKED) --
   const loadKanbanCards = useCallback(async () => {
@@ -228,28 +163,9 @@ export const DashboardApp: React.FC = () => {
   }, []);
 
   // ---- Derived slices ---------------------------------------------------
-  const runningWorkflows = useMemo(
-    () => workflows.filter((w) => w.status === 'running' || w.status === 'paused'),
-    [workflows]
-  );
-  const failedWorkflows = useMemo(() => workflows.filter((w) => w.status === 'failed'), [workflows]);
-
-  // Dedupe rule: a kanban card whose workflow_registry_id matches an
-  // already-shown running/paused workflow is suppressed from the Running
-  // panel's card list -- the ActiveWorkflowCard already represents it.
-  const runningRegistryIds = useMemo(
-    () => new Set(runningWorkflows.map((w) => w.id)),
-    [runningWorkflows]
-  );
-
   const runningKanbanCards = useMemo(
-    () =>
-      kanbanCards.filter(
-        (c) =>
-          (c.status === 'in_progress' || c.status === 'claimed') &&
-          !(c.workflow_registry_id && runningRegistryIds.has(c.workflow_registry_id))
-      ),
-    [kanbanCards, runningRegistryIds]
+    () => kanbanCards.filter((c) => c.status === 'in_progress' || c.status === 'claimed'),
+    [kanbanCards]
   );
 
   const nextKanbanCards = useMemo(() => kanbanCards.filter((c) => c.status === 'ready'), [kanbanCards]);
@@ -262,27 +178,9 @@ export const DashboardApp: React.FC = () => {
     [kanbanCards]
   );
 
-  const blockedHasItems =
-    (kanbanPluginActive && blockedKanbanCards.length > 0) || (workflowPluginActive && failedWorkflows.length > 0);
+  const blockedHasItems = kanbanPluginActive && blockedKanbanCards.length > 0;
 
   // ---- Actions -----------------------------------------------------------
-  const invokeWorkflowAction = useCallback(
-    async (channel: string, registryId: string) => {
-      try {
-        const electronAPI = (window as any).electronAPI;
-        await electronAPI.invoke(channel, registryId);
-        loadWorkflows();
-      } catch (error) {
-        console.error(`[DashboardApp] Failed to invoke ${channel}:`, error);
-      }
-    },
-    [loadWorkflows]
-  );
-
-  const handlePause = useCallback((id: string) => invokeWorkflowAction('workflow:pause', id), [invokeWorkflowAction]);
-  const handleResume = useCallback((id: string) => invokeWorkflowAction('workflow:resume', id), [invokeWorkflowAction]);
-  const handleCancel = useCallback((id: string) => invokeWorkflowAction('workflow:cancel', id), [invokeWorkflowAction]);
-
   // Card deep-link (bead mea-5bq): navigate to the Board view AND tell it
   // which card to open. The card id crosses the app->plugin boundary via
   // ViewRouter's existing `navigateTo(viewId, params)` -> `view.mount(container,
@@ -291,10 +189,6 @@ export const DashboardApp: React.FC = () => {
   // versions ignore the extra param and just show the board (previous behavior).
   const handleCardClick = useCallback((card: KanbanCard) => {
     (window as any).__viewRouter__?.navigateTo?.('kanban', { cardId: card.id });
-  }, []);
-
-  const handleWorkflowClick = useCallback((_workflow: ActiveWorkflowInstance) => {
-    (window as any).__viewRouter__?.navigateTo?.('workflows');
   }, []);
 
   // ---- Layout -------------------------------------------------------------
@@ -331,16 +225,11 @@ export const DashboardApp: React.FC = () => {
 
   const runningColumn = (
     <div style={{ ...columnStyle, order: !isWide ? (blockedHasItems ? 1 : 0) : undefined }} key="running">
-      <div style={headingStyle}>Running ({runningWorkflows.length + runningKanbanCards.length})</div>
+      <div style={headingStyle}>Running ({runningKanbanCards.length})</div>
       <RunningPanel
-        workflows={runningWorkflows}
         kanbanCards={runningKanbanCards}
-        workflowPluginActive={workflowPluginActive}
         kanbanPluginActive={kanbanPluginActive}
-        loading={workflowsLoading || kanbanLoading}
-        onPause={handlePause}
-        onResume={handleResume}
-        onCancel={handleCancel}
+        loading={kanbanLoading}
         onCardClick={handleCardClick}
       />
     </div>
@@ -360,15 +249,12 @@ export const DashboardApp: React.FC = () => {
 
   const blockedColumn = (
     <div style={{ ...columnStyle, order: !isWide ? (blockedHasItems ? 0 : 2) : undefined }} key="blocked">
-      <div style={headingStyle}>Blocked ({blockedKanbanCards.length + failedWorkflows.length})</div>
+      <div style={headingStyle}>Blocked ({blockedKanbanCards.length})</div>
       <BlockedPanel
         kanbanCards={blockedKanbanCards}
-        failedWorkflows={failedWorkflows}
         kanbanPluginActive={kanbanPluginActive}
-        workflowPluginActive={workflowPluginActive}
-        loading={workflowsLoading || kanbanLoading}
+        loading={kanbanLoading}
         onCardClick={handleCardClick}
-        onWorkflowClick={handleWorkflowClick}
       />
     </div>
   );
@@ -391,22 +277,25 @@ export const DashboardApp: React.FC = () => {
       <SystemStrip />
       {noPluginsInstalled ? (
         <NoPluginsEmptyState />
-      ) : dashboardWidgets.length > 0 ? (
-        <div style={widgetsContainerStyle} className="dashboard-widgets">
-          {dashboardWidgets.map((widget) => (
-            <DashboardWidgetSlot
-              key={`${widget.pluginId}:${widget.widgetId}`}
-              WidgetClass={widget.WidgetClass}
-              pluginId={widget.pluginId}
-            />
-          ))}
-        </div>
       ) : (
-        <div style={panelsContainerStyle} className="dashboard-cockpit-panels">
-          {runningColumn}
-          {nextColumn}
-          {blockedColumn}
-        </div>
+        <>
+          {dashboardWidgets.length > 0 && (
+            <div style={widgetsContainerStyle} className="dashboard-widgets">
+              {dashboardWidgets.map((widget) => (
+                <DashboardWidgetSlot
+                  key={`${widget.pluginId}:${widget.widgetId}`}
+                  WidgetClass={widget.WidgetClass}
+                  pluginId={widget.pluginId}
+                />
+              ))}
+            </div>
+          )}
+          <div style={panelsContainerStyle} className="dashboard-cockpit-panels">
+            {runningColumn}
+            {nextColumn}
+            {blockedColumn}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/renderer/views/__tests__/DashboardViewReact.pluginSlots.test.tsx
+++ b/src/renderer/views/__tests__/DashboardViewReact.pluginSlots.test.tsx
@@ -87,9 +87,14 @@ describe('DashboardApp pluginless empty state (bead mea-cjl.1)', () => {
     expect(screen.queryByText('No plugins installed')).not.toBeInTheDocument();
   });
 
-  it('with a plugin contributing a dashboard widget, renders the widget slot instead of the cockpit columns', async () => {
+  it('with a plugin contributing a dashboard widget, renders the widget slot ALONGSIDE the (kanban) cockpit columns', async () => {
+    // Widgets and the panel grid are composited, not exclusive -- the grid
+    // is kanban-only since bead mea-cjl.4 moved the workflow columns into
+    // the workflow plugin's own widget, so it still needs to render even
+    // when a widget is present (kanban's content isn't covered by any
+    // widget yet, see DashboardViewReact.tsx's module doc comment).
     loadActiveDashboardWidgets.mockResolvedValue([
-      { pluginId: 'fictionlab-workflow', pluginVersion: '1.0.0', widgetId: 'workflow-widget', WidgetClass: FakeWorkflowWidget },
+      { pluginId: 'fictionlab-workflow', pluginVersion: '1.0.0', widgetId: 'workflow-status', WidgetClass: FakeWorkflowWidget },
     ]);
     installMocks([{ id: 'fictionlab-workflow', status: 'active' }]);
 
@@ -97,6 +102,6 @@ describe('DashboardApp pluginless empty state (bead mea-cjl.1)', () => {
 
     await waitFor(() => expect(screen.getByText('RUNNING / NEXT / BLOCKED')).toBeInTheDocument());
     expect(screen.queryByText('No plugins installed')).not.toBeInTheDocument();
-    expect(screen.queryByText(/^Running \(/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/^Running \(/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- `RunningPanel.tsx`/`BlockedPanel.tsx` become kanban-only: the running/blocked workflow halves (`ActiveWorkflowCard` rendering, workflow IPC fetch/poll, pause/resume/cancel, and the cross-plugin dedupe against kanban cards) move to the workflow plugin's own dashboard widget — sibling PR RLRyals/fictionlab-workflow#39 (stacked on #38, mea-cjl.2), `packages/workflow-plugin/src/renderer/dashboard-widget.tsx`.
- `DashboardViewReact.tsx`: removed all workflow state/fetching/actions; `RunningPanel`/`BlockedPanel` now take kanban-only props; heading counts drop the workflow half; `WORKFLOW_PLUGIN_ID` removed from `components/dashboard/types.ts` (now unused in this repo).
- **Behavior fix, not just a move**: `DashboardViewReact.tsx`'s widget/grid rendering changes from mutually exclusive (`dashboardWidgets.length > 0 ? <widgets> : <grid>`) to composited (widgets render above the grid when present, grid always renders unless zero plugins are installed). The old exclusive-or was written before any real dashboard widget existed (bead mea-cjl.1); shipping the workflow plugin's widget without this fix would have hidden kanban's still-core-hosted Next/Blocked cards entirely for anyone with both plugins installed, the moment the workflow plugin updated. Updated the `DashboardViewReact.pluginSlots.test.tsx` case that had locked in the old exclusive-or behavior.

## Known gap (documented, not fixed here)
The dedupe rule (a kanban card sharing a `workflow_registry_id` with a running workflow was suppressed from the Running panel) has no home anymore — it needed both lists in one place, and the workflow plugin can't reach into kanban's data without coupling to its IPC contract. A kanban card mirroring a running workflow may now appear in both the kanban panel grid and the workflow widget. Flagged as a possible follow-up if it turns out to matter in practice.

## Test plan
- [x] `npx tsc --noEmit` — no new errors (4 pre-existing unrelated failing suites confirmed present on baseline via stash: `provider-manager.test.ts`, `ProviderSelector.a11y.test.tsx`, `build-orchestrator.test.ts`, `repository-manager.test.ts`)
- [x] All 9 dashboard-related test suites pass (38 tests): `RunningPanel`, `BlockedPanel`, `NextPanel`, `DashboardWidgetSlot`, `NoPluginsEmptyState`, `SystemStrip`, `DashboardView`, `DashboardViewReact`, `DashboardViewReact.pluginSlots`
- [ ] Manual smoke test in the actual Electron app (both plugins installed, verify the workflow widget shows alongside kanban's Next column) — not done this session

Closes bead: mea-cjl.4