### PR TITLE
feat(workflows): wire ContextVariablesTab into NodeConfigDialog

### DIFF
--- a/src/renderer/components/WorkflowCanvas.tsx
+++ b/src/renderer/components/WorkflowCanvas.tsx
@@ -36,6 +36,7 @@ import { DocumentEditDialog } from './dialogs/DocumentEditDialog.js';
 import type { WorkflowNode } from '../../types/workflow-nodes.js';
 import type { LLMProviderConfig } from '../../types/llm-providers.js';
 import type { NodeStatusInfo } from '../../types/workflow.js';
+import type { VariableReference } from '../../types/workflow-context.js';
 
 // Simple debounce utility
 function debounce<T extends (...args: any[]) => void>(
@@ -370,6 +371,38 @@ export const WorkflowCanvas: React.FC<WorkflowCanvasProps> = React.memo(({
     }
   }, [graphData.nodes, availableProviders]);
 
+  // Variables available to the node currently being edited: every ancestor
+  // reachable by walking incoming edges backward through the graph. This is
+  // resolved statically from the graph shape, not from execution results.
+  const editingNodeAvailableVariables = useMemo((): VariableReference[] => {
+    if (!editingNode) return [];
+
+    const nodesById = new Map(graphData.nodes.map(n => [String(n.id), n]));
+    const visited = new Set<string>();
+    const queue: string[] = [editingNode.id];
+
+    while (queue.length > 0) {
+      const currentId = queue.shift()!;
+      for (const edge of graphData.edges) {
+        if (String(edge.target) === currentId && !visited.has(String(edge.source))) {
+          const sourceId = String(edge.source);
+          visited.add(sourceId);
+          queue.push(sourceId);
+        }
+      }
+    }
+
+    return Array.from(visited)
+      .map(id => nodesById.get(id))
+      .filter((n): n is NonNullable<typeof n> => !!n)
+      .map(n => ({
+        nodeId: String(n.id),
+        nodeName: n.name || 'Unnamed',
+        nodeType: n.type,
+        path: `$.${n.id}.output`,
+        type: 'object',
+      }));
+  }, [editingNode, graphData.nodes, graphData.edges]);
 
   // Handle save edited node (new NodeConfigDialog)
   const handleSaveNode = useCallback(async (updatedNode: WorkflowNode) => {
@@ -1140,6 +1173,7 @@ export const WorkflowCanvas: React.FC<WorkflowCanvasProps> = React.memo(({
           onSave={handleSaveNode}
           onCancel={() => setEditingNode(null)}
           availableWorkflows={availableWorkflows}
+          availableVariables={editingNodeAvailableVariables}
         />
       )}
 

--- a/src/renderer/components/dialogs/ContextVariablesTab.tsx
+++ b/src/renderer/components/dialogs/ContextVariablesTab.tsx
@@ -21,8 +21,12 @@ import { VariableReference } from '../../../types/workflow-context';
 export interface ContextVariablesTabProps {
   node: WorkflowNode;
   onChange: (updates: Partial<WorkflowNode>) => void;
-  availableVariables: VariableReference[]; // From previous nodes
+  availableVariables: VariableReference[]; // Resolved from upstream nodes in the workflow graph
   errors: Record<string, string>;
+  /** Whether this node type has a prompt field that variables can be inserted into */
+  canInsertIntoPrompt: boolean;
+  /** Insert {{nodeId}} into the node's prompt field (Configuration tab) */
+  onInsertIntoPrompt: (nodeId: string) => void;
 }
 
 export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
@@ -30,29 +34,23 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
   onChange,
   availableVariables,
   errors,
+  canInsertIntoPrompt,
+  onInsertIntoPrompt,
 }) => {
-  const [mode, setMode] = useState<'simple' | 'advanced'>(node.contextConfig.mode);
+  // Mode is owned by the parent dialog (toggle buttons live there); this tab just renders for it.
+  const mode = node.contextConfig.mode;
   const [inputMappings, setInputMappings] = useState<ContextMapping[]>(
     node.contextConfig.inputs || []
   );
   const [outputMappings, setOutputMappings] = useState<ContextMapping[]>(
     node.contextConfig.outputs || []
   );
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [showVariableBrowser, setShowVariableBrowser] = useState(true);
-  const [activeField, setActiveField] = useState<'input' | 'output' | null>(null);
-
-  // Handle mode toggle
-  const handleModeToggle = () => {
-    const newMode = mode === 'simple' ? 'advanced' : 'simple';
-    setMode(newMode);
-    onChange({
-      contextConfig: {
-        ...node.contextConfig,
-        mode: newMode,
-      },
-    });
-  };
+  // Which mapping row's source field was last focused - clicking a variable
+  // fills that field; with nothing focused it falls back to prompt insertion.
+  const [focusedMappingField, setFocusedMappingField] = useState<
+    { type: 'input' | 'output'; index: number } | null
+  >(null);
 
   // Add input mapping
   const handleAddInputMapping = () => {
@@ -62,8 +60,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
     };
     const updated = [...inputMappings, newMapping];
     setInputMappings(updated);
-    setEditingIndex(updated.length - 1);
-    setActiveField('input');
+    setFocusedMappingField({ type: 'input', index: updated.length - 1 });
     updateNodeContext({ inputs: updated });
   };
 
@@ -79,7 +76,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
   const handleDeleteInputMapping = (index: number) => {
     const updated = inputMappings.filter((_, i) => i !== index);
     setInputMappings(updated);
-    setEditingIndex(null);
+    setFocusedMappingField(null);
     updateNodeContext({ inputs: updated });
   };
 
@@ -91,8 +88,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
     };
     const updated = [...outputMappings, newMapping];
     setOutputMappings(updated);
-    setEditingIndex(updated.length - 1);
-    setActiveField('output');
+    setFocusedMappingField({ type: 'output', index: updated.length - 1 });
     updateNodeContext({ outputs: updated });
   };
 
@@ -108,7 +104,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
   const handleDeleteOutputMapping = (index: number) => {
     const updated = outputMappings.filter((_, i) => i !== index);
     setOutputMappings(updated);
-    setEditingIndex(null);
+    setFocusedMappingField(null);
     updateNodeContext({ outputs: updated });
   };
 
@@ -122,11 +118,22 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
     });
   };
 
-  // Insert variable into active field
-  const handleInsertVariable = (path: string) => {
-    // This would insert the variable path into the currently focused field
-    // For now, we'll just show the path
-    console.log('Insert variable:', path);
+  // Insert a variable into whichever mapping field was last focused; with no
+  // field focused (or in Simple mode, where there are no mapping fields),
+  // insert it into the node's prompt instead.
+  const handleInsertVariable = (variable: VariableReference) => {
+    if (focusedMappingField) {
+      const { type, index } = focusedMappingField;
+      if (type === 'input') {
+        handleUpdateInputMapping(index, 'source', variable.path);
+      } else {
+        handleUpdateOutputMapping(index, 'source', variable.path);
+      }
+      return;
+    }
+    if (canInsertIntoPrompt) {
+      onInsertIntoPrompt(variable.nodeId);
+    }
   };
 
   // Validate JSONPath or variable reference
@@ -147,30 +154,6 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
 
   return (
     <div style={styles.container}>
-      {/* Mode Toggle */}
-      <div style={styles.modeToggleContainer}>
-        <div style={styles.modeToggleLabel}>Variable Mode</div>
-        <button
-          style={styles.modeToggle}
-          onClick={handleModeToggle}
-          aria-pressed={mode === 'advanced'}
-          title={`Switch to ${mode === 'simple' ? 'Advanced' : 'Simple'} Mode`}
-        >
-          <div
-            style={{
-              ...styles.modeToggleSlider,
-              left: mode === 'advanced' ? '50%' : '0',
-            }}
-          />
-          <span style={mode === 'simple' ? styles.modeToggleOptionActive : styles.modeToggleOption}>
-            Simple
-          </span>
-          <span style={mode === 'advanced' ? styles.modeToggleOptionActive : styles.modeToggleOption}>
-            Advanced
-          </span>
-        </button>
-      </div>
-
       {/* Simple Mode Display */}
       {mode === 'simple' && (
         <div style={styles.simpleModeContainer}>
@@ -185,11 +168,40 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
           </div>
 
           <div style={styles.availableSection}>
-            <h3 style={styles.sectionTitle}>What's Available to This Node</h3>
+            <h3 style={styles.sectionTitle}>Inherited From Upstream Nodes</h3>
+            {availableVariables.length === 0 ? (
+              <div style={styles.emptyState}>
+                No upstream nodes yet. Connect a node before this one in the graph to see its outputs here.
+              </div>
+            ) : (
+              <ul style={styles.availableList}>
+                {availableVariables.map((variable) => (
+                  <li key={`${variable.nodeId}-${variable.path}`} style={styles.availableItem}>
+                    <div>
+                      <strong>{variable.nodeName}</strong>{' '}
+                      <span style={styles.variableSource}>({variable.nodeType})</span>
+                      <div>
+                        <code style={styles.code}>{variable.path}</code>
+                      </div>
+                    </div>
+                    {canInsertIntoPrompt && (
+                      <button
+                        type="button"
+                        style={styles.insertIntoPromptButton}
+                        onClick={() => onInsertIntoPrompt(variable.nodeId)}
+                        aria-label={`Insert {{${variable.nodeId}}} into prompt`}
+                        title={`Insert {{${variable.nodeId}}} into prompt`}
+                      >
+                        {'{{'}
+                        {variable.nodeId}
+                        {'}}'} → Prompt
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
             <ul style={styles.availableList}>
-              <li style={styles.availableItem}>
-                <strong>Previous Node Outputs:</strong> All outputs from nodes executed before this one
-              </li>
               <li style={styles.availableItem}>
                 <strong>Global Variables:</strong> Variables set during workflow execution
               </li>
@@ -257,6 +269,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
                               }
                               value={mapping.source || ''}
                               onChange={(e) => handleUpdateInputMapping(index, 'source', e.target.value)}
+                              onFocus={() => setFocusedMappingField({ type: 'input', index })}
                               placeholder="$.previousNode.field or {{variable}}"
                               aria-label="Source JSONPath"
                               aria-invalid={!validateSource(mapping.source || '')}
@@ -393,6 +406,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
                               }
                               value={mapping.source || ''}
                               onChange={(e) => handleUpdateOutputMapping(index, 'source', e.target.value)}
+                              onFocus={() => setFocusedMappingField({ type: 'output', index })}
                               placeholder="$.output.field"
                               aria-label="Source JSONPath"
                               aria-invalid={!validateSource(mapping.source || '')}
@@ -497,10 +511,15 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
                 <button
                   style={styles.sidebarToggle}
                   onClick={() => setShowVariableBrowser(false)}
+                  aria-label="Hide variable browser"
                   title="Hide variable browser"
                 >
                   ✕
                 </button>
+              </div>
+
+              <div style={styles.helperBox}>
+                Click a variable to fill the focused source field above{canInsertIntoPrompt ? ', or insert it into the prompt if no field is focused' : ''}.
               </div>
 
               <div style={styles.variableList}>
@@ -508,10 +527,11 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
                   <div style={styles.emptyState}>No variables available yet</div>
                 ) : (
                   availableVariables.map((variable, index) => (
-                    <div
+                    <button
                       key={index}
+                      type="button"
                       style={styles.variableItem}
-                      onClick={() => handleInsertVariable(variable.path)}
+                      onClick={() => handleInsertVariable(variable)}
                       title={`Click to insert: ${variable.path}`}
                     >
                       <div style={styles.variableName}>{variable.path}</div>
@@ -528,7 +548,7 @@ export const ContextVariablesTab: React.FC<ContextVariablesTabProps> = ({
                             : String(variable.value).substring(0, 50)}
                         </div>
                       )}
-                    </div>
+                    </button>
                   ))
                 )}
               </div>
@@ -557,62 +577,6 @@ const styles: Record<string, React.CSSProperties> = {
     flexDirection: 'column',
     gap: '20px',
     height: '100%',
-  },
-
-  // Mode Toggle
-  modeToggleContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '16px',
-  },
-  modeToggleLabel: {
-    fontSize: '14px',
-    fontWeight: 600,
-    color: '#374151',
-  },
-  modeToggle: {
-    position: 'relative',
-    display: 'flex',
-    width: '200px',
-    height: '40px',
-    background: '#f3f4f6',
-    border: '1px solid #d1d5db',
-    borderRadius: '8px',
-    cursor: 'pointer',
-    padding: '4px',
-    transition: 'all 0.3s',
-  },
-  modeToggleSlider: {
-    position: 'absolute',
-    top: '4px',
-    width: '50%',
-    height: 'calc(100% - 8px)',
-    background: 'var(--status-running)',
-    borderRadius: '6px',
-    transition: 'left 0.3s',
-    zIndex: 1,
-  },
-  modeToggleOption: {
-    flex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '14px',
-    fontWeight: 600,
-    color: 'var(--status-neutral)',
-    zIndex: 2,
-    transition: 'color 0.3s',
-  },
-  modeToggleOptionActive: {
-    flex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '14px',
-    fontWeight: 600,
-    color: 'white',
-    zIndex: 2,
-    transition: 'color 0.3s',
   },
 
   // Simple Mode
@@ -660,6 +624,22 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '14px',
     color: '#374151',
     lineHeight: '1.5',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  insertIntoPromptButton: {
+    flexShrink: 0,
+    padding: '4px 10px',
+    fontSize: '12px',
+    fontWeight: 600,
+    fontFamily: 'monospace',
+    color: 'var(--status-running)',
+    background: 'white',
+    border: '1px solid var(--status-running)',
+    borderRadius: '6px',
+    cursor: 'pointer',
   },
   hint: {
     padding: '12px 16px',
@@ -891,6 +871,9 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '8px',
   },
   variableItem: {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
     padding: '12px',
     background: 'white',
     border: '1px solid #e5e7eb',
@@ -898,6 +881,7 @@ const styles: Record<string, React.CSSProperties> = {
     marginBottom: '8px',
     cursor: 'pointer',
     transition: 'all 0.2s',
+    font: 'inherit',
   },
   variableName: {
     fontSize: '13px',

--- a/src/renderer/components/dialogs/NodeConfigDialog.tsx
+++ b/src/renderer/components/dialogs/NodeConfigDialog.tsx
@@ -32,6 +32,8 @@ import { CreateAgentDialog } from './CreateAgentDialog.js';
 import { CreateSkillDialog } from './CreateSkillDialog.js';
 import { DocumentEditDialog } from './DocumentEditDialog.js';
 import { SubWorkflowNodeConfig } from './config-panels/SubWorkflowNodeConfig.js';
+import { ContextVariablesTab } from './ContextVariablesTab.js';
+import type { VariableReference } from '../../../types/workflow-context';
 
 // ============================================================================
 // Types & Interfaces
@@ -48,6 +50,8 @@ export interface NodeConfigDialogProps {
     description?: string;
     versions?: Array<{ version: string; createdAt: string }>;
   }>;
+  /** Upstream node outputs available to `node`, resolved from the workflow graph */
+  availableVariables?: VariableReference[];
 }
 
 type TabId = 'basic' | 'config' | 'provider' | 'context' | 'advanced';
@@ -92,6 +96,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
   onSave,
   onCancel,
   availableWorkflows = [],
+  availableVariables = [],
 }) => {
   // ============================================================================
   // State Management
@@ -123,6 +128,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
   const lastFocusableRef = useRef<HTMLButtonElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const errorAnnouncerRef = useRef<HTMLDivElement>(null);
+  const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   // ============================================================================
   // Tab Configuration
@@ -159,7 +165,12 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
   // Initialize form data when node changes
   useEffect(() => {
     if (node) {
-      setFormData(node);
+      // Legacy/pre-existing nodes may predate contextConfig; default it so
+      // downstream tabs (Context & Variables, Sub-Workflow) never read undefined.
+      setFormData({
+        ...node,
+        contextConfig: node.contextConfig || { mode: 'simple' },
+      });
       setContextMode(node.contextConfig?.mode || 'simple');
       setIsDirty(false);
       setErrors([]);
@@ -246,6 +257,38 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
     // Clear errors for this field
     setErrors(prev => prev.filter(err => err.field !== field));
   }, []); // Remove formData dependency - we use prev parameter instead
+
+  const handleContextModeChange = useCallback((mode: 'simple' | 'advanced') => {
+    setContextMode(mode);
+    setFormData(prev => {
+      if (!prev) return prev;
+      return { ...prev, contextConfig: { ...(prev.contextConfig || {}), mode } };
+    });
+    setIsDirty(true);
+  }, []);
+
+  // Insert {{nodeId}} into the node's prompt field (Configuration tab),
+  // reachable from the Context & Variables tab regardless of which tab is
+  // currently showing. Only agent-type nodes have a prompt field.
+  const insertVariableIntoPrompt = useCallback((nodeId: string) => {
+    const variableSyntax = `{{${nodeId}}}`;
+    setFormData(prev => {
+      if (!prev || !isAgentNode(prev)) return prev;
+      const current = (prev as any).prompt || '';
+      const textarea = promptTextareaRef.current;
+      let updated: string;
+      if (textarea && document.activeElement === textarea) {
+        const start = textarea.selectionStart ?? current.length;
+        const end = textarea.selectionEnd ?? current.length;
+        updated = current.slice(0, start) + variableSyntax + current.slice(end);
+      } else {
+        updated = current && !/\s$/.test(current) ? `${current} ${variableSyntax}` : `${current}${variableSyntax}`;
+      }
+      return { ...prev, prompt: updated };
+    });
+    setIsDirty(true);
+    setErrors(prev => prev.filter(err => err.field !== 'prompt'));
+  }, []);
 
   const handleTabChange = useCallback((tabId: TabId) => {
     setActiveTab(tabId);
@@ -1012,6 +1055,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
                 </div>
                 <textarea
                   id="config-prompt"
+                  ref={promptTextareaRef}
                   style={{ ...styles.input, minHeight: '200px', fontFamily: 'monospace', fontSize: '13px' }}
                   value={(formData as any).prompt || ''}
                   onChange={(e) => {
@@ -2023,6 +2067,12 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
   };
 
   const renderContextTab = () => {
+    if (!formData) return null;
+    const nodeForContext = {
+      ...formData,
+      contextConfig: formData.contextConfig || { mode: 'simple' as const },
+    };
+
     return (
       <div role="tabpanel" id="panel-context" aria-labelledby="tab-context">
         <div style={styles.field}>
@@ -2031,7 +2081,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
             <button
               type="button"
               style={contextMode === 'simple' ? { ...styles.modeButton, ...styles.modeButtonActive } : styles.modeButton}
-              onClick={() => setContextMode('simple')}
+              onClick={() => handleContextModeChange('simple')}
               aria-pressed={contextMode === 'simple'}
             >
               Simple
@@ -2039,7 +2089,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
             <button
               type="button"
               style={contextMode === 'advanced' ? { ...styles.modeButton, ...styles.modeButtonActive } : styles.modeButton}
-              onClick={() => setContextMode('advanced')}
+              onClick={() => handleContextModeChange('advanced')}
               aria-pressed={contextMode === 'advanced'}
             >
               Advanced
@@ -2047,39 +2097,18 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
           </div>
         </div>
 
-        <div style={styles.placeholderPanel}>
-          <div style={styles.placeholderIcon}>🔗</div>
-          <h3 style={styles.placeholderTitle}>
-            Context & Variables - {contextMode === 'simple' ? 'Simple' : 'Advanced'} Mode
-          </h3>
-          <p style={styles.placeholderText}>
-            This panel will be populated by a separate component for managing context and variables.
-          </p>
-          {contextMode === 'simple' ? (
-            <>
-              <p style={styles.placeholderText}>
-                <strong>Simple Mode:</strong> Automatically inherits all context from previous nodes.
-              </p>
-              <ul style={styles.placeholderList}>
-                <li>No manual configuration needed</li>
-                <li>All previous node outputs available</li>
-                <li>Suitable for most workflows</li>
-              </ul>
-            </>
-          ) : (
-            <>
-              <p style={styles.placeholderText}>
-                <strong>Advanced Mode:</strong> Explicit input/output mapping with transformations.
-              </p>
-              <ul style={styles.placeholderList}>
-                <li>Input mapping (JSONPath expressions)</li>
-                <li>Output mapping (extract specific fields)</li>
-                <li>Variable transformations (JavaScript)</li>
-                <li>Fine-grained control over data flow</li>
-              </ul>
-            </>
-          )}
-        </div>
+        <ContextVariablesTab
+          node={nodeForContext}
+          onChange={(updates) => {
+            if (updates.contextConfig) {
+              handleFieldChange('contextConfig', updates.contextConfig);
+            }
+          }}
+          availableVariables={availableVariables}
+          errors={errors.reduce((acc, e) => ({ ...acc, [e.field]: e.message }), {} as Record<string, string>)}
+          canInsertIntoPrompt={isAgentNode(formData)}
+          onInsertIntoPrompt={insertVariableIntoPrompt}
+        />
       </div>
     );
   };
@@ -2734,43 +2763,6 @@ const styles: Record<string, React.CSSProperties> = {
     background: '#eff6ff',
     borderColor: 'var(--status-running)',
     fontWeight: 600,
-  },
-
-  // Placeholder Panel
-  placeholderPanel: {
-    padding: '32px',
-    textAlign: 'center',
-    background: '#f9fafb',
-    borderRadius: '8px',
-    border: '2px dashed #d1d5db',
-  },
-
-  placeholderIcon: {
-    fontSize: '48px',
-    marginBottom: '16px',
-  },
-
-  placeholderTitle: {
-    margin: '0 0 12px 0',
-    fontSize: '18px',
-    fontWeight: 600,
-    color: '#374151',
-  },
-
-  placeholderText: {
-    margin: '0 0 12px 0',
-    fontSize: '14px',
-    color: 'var(--status-neutral)',
-    lineHeight: 1.6,
-  },
-
-  placeholderList: {
-    textAlign: 'left',
-    margin: '16px auto',
-    maxWidth: '500px',
-    fontSize: '14px',
-    color: 'var(--status-neutral)',
-    lineHeight: 1.8,
   },
 
   infoBox: {


### PR DESCRIPTION
## Summary
- Wires the already-built `ContextVariablesTab` component into `NodeConfigDialog`'s Context & Variables tab, replacing the permanent "This panel will be populated by a separate component..." placeholder text.
- Simple mode now shows the node's actual upstream outputs (name, type, JSONPath) resolved by walking the workflow graph's edges backward from the node being edited, instead of only asserting generic prose ("inherits all context").
- `{{nodeId}}` insertion into the agent prompt field now works from both Simple and Advanced mode variable lists — inserts at the prompt textarea's cursor when it's focused, appends otherwise.
- Advanced mode's variable-browser click now actually fills the focused mapping row's source field (previously a `console.log` stub that did nothing).
- Fixed a latent crash: nodes created before `contextConfig` existed on the type would throw when their Context tab was opened (`node.contextConfig.mode` on `undefined`). Now defaulted to `{ mode: 'simple' }`.

## Advanced mode scope note (per bead)
Advanced mode's input/output JSONPath mapping table is UI-only, same as before this PR — no workflow runtime code reads `contextConfig.inputs`/`outputs` today. This PR does not add new runtime semantics for it (out of scope per the bead); it only makes the existing mapping UI and variable-insertion UI actually functional. If/when the runtime engine is built to consume these mappings, that's separate follow-up work.

## Test plan
- [x] `npx tsc -p tsconfig.renderer.json --noEmit` — clean
- [x] `NodeConfigDialog.a11y.test.tsx` — 46/46 passing (mode-toggle aria-pressed tests still pass unchanged, since the dialog's existing tested toggle buttons were kept and just wired to also persist `contextConfig.mode`)
- [x] Full renderer test suite — 348/350 passing; the 2 failures are in `ProviderSelector.a11y.test.tsx` (slider/number-input keyboard nav), pre-existing and unrelated to this change (no `ProviderSelector` files touched)

Closes bead: mea-5ol