### PR TITLE
fix(workflows): always offer general-purpose in the Agent dropdown

### DIFF
--- a/src/renderer/components/dialogs/NodeConfigDialog.tsx
+++ b/src/renderer/components/dialogs/NodeConfigDialog.tsx
@@ -23,7 +23,7 @@
  * ```
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import type { WorkflowNode, SubWorkflowNode } from '../../../types/workflow-nodes';
 import type { LLMProviderConfig } from '../../../types/llm-providers';
 import { AgentSkillSelector } from '../AgentSkillSelector.js';
@@ -82,6 +82,12 @@ const NODE_TYPE_CONFIGS = [
   { value: 'swarm', label: 'Swarm Exploration', icon: '🐝' },
 ] as const;
 
+// Claude Code agent types that are always available for --agent, independent
+// of whatever custom agent .md files happen to exist in ~/.claude/agents/.
+// Not installable/editable as a file (no "Edit" action) - the CLI resolves
+// them natively.
+const BUILT_IN_AGENTS = ['general-purpose'] as const;
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -113,6 +119,15 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
   const [creatingAgent, setCreatingAgent] = useState(false);
   const [creatingSkill, setCreatingSkill] = useState(false);
   const [creatingOutputStyle, setCreatingOutputStyle] = useState(false);
+
+  // Agent dropdown options: built-ins first, then whatever custom agent .md
+  // files are installed (deduped, in case a file happens to share a built-in's
+  // name). The "Agent" field's Edit button still checks against
+  // `installedAgents` alone, so built-ins correctly show as non-editable.
+  const agentSelectOptions = useMemo(
+    () => [...BUILT_IN_AGENTS, ...installedAgents.filter(a => !(BUILT_IN_AGENTS as readonly string[]).includes(a))],
+    [installedAgents]
+  );
 
   // ============================================================================
   // Refs for Focus Management
@@ -927,7 +942,7 @@ export const NodeConfigDialog: React.FC<NodeConfigDialogProps> = ({
                       setIsDirty(true);
                       setErrors(errors.filter(err => err.field !== 'agent'));
                     }}
-                    installedOptions={installedAgents}
+                    installedOptions={agentSelectOptions}
                     error={agentError?.message}
                     required={true}
                   />

--- a/src/renderer/components/dialogs/__tests__/NodeConfigDialog.a11y.test.tsx
+++ b/src/renderer/components/dialogs/__tests__/NodeConfigDialog.a11y.test.tsx
@@ -713,3 +713,41 @@ describe('NodeConfigDialog - Advanced Tab Accessibility', () => {
     expect(timeoutInput).toHaveAttribute('min', '0');
   });
 });
+
+// ============================================================================
+// Built-in Agent Option (mea-2bj)
+// ============================================================================
+
+describe('NodeConfigDialog - Built-in Agent Option', () => {
+  it('always offers general-purpose in the Agent dropdown, even with no installed agent files', async () => {
+    renderDialog();
+    const user = userEvent.setup();
+
+    const configTab = screen.getByRole('tab', { name: /Configuration/i });
+    await user.click(configTab);
+
+    const agentSelect = screen.getByLabelText('Select Agent') as HTMLSelectElement;
+    const optionValues = within(agentSelect)
+      .getAllByRole('option')
+      .map((o) => (o as HTMLOptionElement).value);
+    expect(optionValues).toContain('general-purpose');
+  });
+
+  it('defaults a freshly agent-ified node to general-purpose, and that value is actually selected (not silently dropped)', async () => {
+    // mockUserInputNode has no `agent` field; switching its type to an agent
+    // type is what triggers the 'general-purpose' default (NodeConfigDialog
+    // handleFieldChange). Before this fix, that default referenced an agent
+    // absent from the dropdown's option list.
+    renderDialog({ node: mockUserInputNode });
+    const user = userEvent.setup();
+
+    const typeSelect = screen.getByLabelText('Node type');
+    await user.selectOptions(typeSelect, 'writing');
+
+    const configTab = screen.getByRole('tab', { name: /Configuration/i });
+    await user.click(configTab);
+
+    const agentSelect = screen.getByLabelText('Select Agent') as HTMLSelectElement;
+    expect(agentSelect.value).toBe('general-purpose');
+  });
+});


### PR DESCRIPTION
## Summary
- The Agent selector in Configure Node → Configuration only listed custom agent `.md` files scanned from `~/.claude/agents/`. On a fresh install, or any machine without the book-specialist agent files (`series-architect-agent`, `chapter-planner`, etc.), there was no general-purpose option for non-book workflows — and the dropdown could even be entirely disabled ("No agents installed").
- This was also a latent bug: switching a node to an agent type (planning/writing/gate) already defaults `agentNode.agent` to `'general-purpose'` (`NodeConfigDialog.tsx` `handleFieldChange`), but that name never appeared in the dropdown's option list, which was built from `installedAgents` alone — a fresh agent node silently pointed at a value the UI couldn't display or reselect.
- Fix: the Agent select's option list now always includes `'general-purpose'` (a `BUILT_IN_AGENTS` constant), merged ahead of whatever custom agent files are installed, deduped against them. The Edit button's enabled/disabled state still checks `installedAgents` alone, so `general-purpose` correctly shows as non-editable — there's no file to edit, since the Claude Code CLI resolves this agent type natively via `--agent general-purpose` (confirmed by tracing `claude-code-executor.ts`, which just forwards the agent name string to the CLI's `--agent` flag; no `~/.claude/agents/general-purpose.md` file is required for it to work at execution time).

## "Duplicate an existing agent" — already implemented
The bead also asked for a way to duplicate an existing agent as a starting point for a new specialist. That already exists: `CreateAgentDialog`'s "Copy from Existing..." template option loads an installed agent's content via `electronAPI.document.readAgent`, lets you edit it inline, then save under a new name via `electronAPI.document.writeAgent` (auto-selecting it on the node afterward). Traced the full IPC wiring (`document:read-agent`/`document:write-agent` handlers in `workflow-handlers.ts`) to confirm it's functional end-to-end. No changes made there — it just wasn't very discoverable (a secondary option inside the "Create" button's dialog).

## Test plan
- [x] `npx tsc -p tsconfig.renderer.json --noEmit` — clean
- [x] Added two tests to `NodeConfigDialog.a11y.test.tsx`: general-purpose always present in the Agent dropdown even with zero installed agent files, and a freshly agent-ified node's default agent value is actually selected in the dropdown (not silently dropped)
- [x] Full renderer test suite — 350/352 passing; the 2 failures are in `ProviderSelector.a11y.test.tsx` (slider/number-input keyboard nav), pre-existing and unrelated (no `ProviderSelector` files touched)

Closes bead: mea-2bj