### PR TITLE
fix(spellcheck): wire suggested-corrections into right-click context menu

### DIFF
--- a/src/main/__tests__/spellcheck-context-menu.test.ts
+++ b/src/main/__tests__/spellcheck-context-menu.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for mea-qpg: Electron underlines misspelled words natively but does
+ * not populate the right-click context menu with suggestions on its own --
+ * attachSpellCheckContextMenu wires the 'context-menu' event to build one
+ * (suggestions + Add to Dictionary + the normal edit items), matching the
+ * bead's acceptance criteria.
+ */
+
+import { Menu } from 'electron';
+
+import { attachSpellCheckContextMenu } from '../spellcheck-context-menu';
+
+function createMockWebContents() {
+  let contextMenuHandler: ((event: unknown, params: any) => void) | undefined;
+
+  return {
+    on: jest.fn((event: string, handler: (event: unknown, params: any) => void) => {
+      if (event === 'context-menu') {
+        contextMenuHandler = handler;
+      }
+    }),
+    replaceMisspelling: jest.fn(),
+    session: {
+      addWordToSpellCheckerDictionary: jest.fn(),
+    },
+    triggerContextMenu(params: any) {
+      contextMenuHandler?.(undefined, params);
+    },
+  };
+}
+
+function baseParams(overrides: Record<string, unknown> = {}) {
+  return {
+    misspelledWord: '',
+    dictionarySuggestions: [],
+    isEditable: false,
+    selectionText: '',
+    editFlags: {
+      canCut: false,
+      canCopy: false,
+      canPaste: false,
+      canSelectAll: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('attachSpellCheckContextMenu', () => {
+  beforeEach(() => {
+    (Menu.buildFromTemplate as jest.Mock).mockClear();
+  });
+
+  it('registers a context-menu listener on the given webContents', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+    expect(webContents.on).toHaveBeenCalledWith('context-menu', expect.any(Function));
+  });
+
+  it('lists dictionary suggestions on a misspelled word and replaces on click', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(
+      baseParams({
+        misspelledWord: 'teh',
+        dictionarySuggestions: ['the', 'tea'],
+        isEditable: true,
+        editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+      })
+    );
+
+    const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+    const suggestionItems = template.filter((item: any) => item.label === 'the' || item.label === 'tea');
+    expect(suggestionItems).toHaveLength(2);
+
+    suggestionItems[0].click();
+    expect(webContents.replaceMisspelling).toHaveBeenCalledWith('the');
+  });
+
+  it('includes an "Add to Dictionary" entry that adds the misspelled word', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(
+      baseParams({
+        misspelledWord: 'fictionlab',
+        dictionarySuggestions: ['fiction lab'],
+        isEditable: true,
+        editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+      })
+    );
+
+    const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+    const addToDictionary = template.find((item: any) => item.label === 'Add to Dictionary');
+    expect(addToDictionary).toBeDefined();
+
+    addToDictionary.click();
+    expect(webContents.session.addWordToSpellCheckerDictionary).toHaveBeenCalledWith('fictionlab');
+  });
+
+  it('shows a disabled placeholder when there are no dictionary suggestions', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(
+      baseParams({
+        misspelledWord: 'asdfqwerty',
+        dictionarySuggestions: [],
+        isEditable: true,
+        editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+      })
+    );
+
+    const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+    const placeholder = template.find((item: any) => item.label === 'No suggestions');
+    expect(placeholder).toEqual(expect.objectContaining({ enabled: false }));
+  });
+
+  it('shows the normal edit menu (cut/copy/paste/select all) on non-misspelled editable text', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(
+      baseParams({
+        isEditable: true,
+        editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+      })
+    );
+
+    const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+    const labels = template.map((item: any) => item.label);
+    expect(labels).toEqual(['Cut', 'Copy', 'Paste', undefined, 'Select All']);
+    expect(template.every((item: any) => item.label !== 'Add to Dictionary')).toBe(true);
+  });
+
+  it('shows only Copy on a plain text selection outside an editable field', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(
+      baseParams({
+        selectionText: 'some selected text',
+        editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: false },
+      })
+    );
+
+    const template = (Menu.buildFromTemplate as jest.Mock).mock.calls[0][0];
+    expect(template).toEqual([{ label: 'Copy', role: 'copy', enabled: true }]);
+  });
+
+  it('does not open a menu when there is nothing to show', () => {
+    const webContents = createMockWebContents();
+    attachSpellCheckContextMenu(webContents as any);
+
+    webContents.triggerContextMenu(baseParams());
+
+    expect(Menu.buildFromTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,7 @@ import {
   registerMediaProtocolHandler,
 } from './media-protocol';
 import type { LLMProviderConfig } from '../types/llm-providers';
+import { attachSpellCheckContextMenu } from './spellcheck-context-menu';
 import type {
   RepositoryCloneRequest,
   RepositoryCloneResponse,
@@ -300,6 +301,8 @@ function createWizardWindow(): void {
     show: false, // Don't show until ready
   });
 
+  attachSpellCheckContextMenu(mainWindow.webContents);
+
   // Load the setup wizard HTML file
   const wizardPath = path.join(__dirname, '../renderer/setup-wizard.html');
   mainWindow.loadFile(wizardPath);
@@ -345,6 +348,8 @@ function createMigrationWizardWindow(): void {
     },
     show: false, // Don't show until ready
   });
+
+  attachSpellCheckContextMenu(mainWindow.webContents);
 
   // Load the migration wizard HTML file
   const migrationWizardPath = path.join(__dirname, '../renderer/migration-wizard.html');
@@ -400,6 +405,17 @@ function createWindow(): void {
       backgroundThrottling: false,
     },
     show: false, // Don't show until ready
+  });
+
+  attachSpellCheckContextMenu(mainWindow.webContents);
+
+  // Plugin UI (e.g. the kanban board) renders inside a <webview> tag
+  // (src/renderer/components/PluginContainer.ts), which gets its own
+  // WebContents distinct from the host window's -- wire the same
+  // suggestion menu onto every guest view as it attaches so right-click
+  // works inside plugin content too.
+  mainWindow.webContents.on('did-attach-webview', (_event, guestWebContents) => {
+    attachSpellCheckContextMenu(guestWebContents);
   });
 
   // Load the index.html file

--- a/src/main/plugin-views.ts
+++ b/src/main/plugin-views.ts
@@ -7,6 +7,7 @@
 import { BrowserWindow } from 'electron';
 import path from 'path';
 import { logWithCategory, LogCategory } from './logger';
+import { attachSpellCheckContextMenu } from './spellcheck-context-menu';
 
 export interface PluginViewInfo {
   pluginId: string;
@@ -64,6 +65,8 @@ class PluginViewManager {
           sandbox: false,
         },
       });
+
+      attachSpellCheckContextMenu(window.webContents);
 
       // Open DevTools in development mode only
       if (!require('electron').app.isPackaged) {

--- a/src/main/spellcheck-context-menu.ts
+++ b/src/main/spellcheck-context-menu.ts
@@ -1,0 +1,56 @@
+/**
+ * Wires Chromium's spellchecker suggestions into the native right-click
+ * context menu. Electron underlines misspelled words automatically, but it
+ * does NOT populate the context menu with suggestions/corrections on its
+ * own -- that requires listening for 'context-menu' and reading
+ * params.misspelledWord / params.dictionarySuggestions ourselves
+ * (mea-qpg).
+ */
+
+import { Menu, MenuItemConstructorOptions, WebContents } from 'electron';
+
+export function attachSpellCheckContextMenu(webContents: WebContents): void {
+  webContents.on('context-menu', (_event, params) => {
+    const menuItems: MenuItemConstructorOptions[] = [];
+
+    if (params.misspelledWord) {
+      if (params.dictionarySuggestions.length > 0) {
+        for (const suggestion of params.dictionarySuggestions) {
+          menuItems.push({
+            label: suggestion,
+            click: () => webContents.replaceMisspelling(suggestion),
+          });
+        }
+      } else {
+        menuItems.push({ label: 'No suggestions', enabled: false });
+      }
+
+      menuItems.push(
+        { type: 'separator' },
+        {
+          label: 'Add to Dictionary',
+          click: () => webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord),
+        },
+        { type: 'separator' }
+      );
+    }
+
+    if (params.isEditable) {
+      menuItems.push(
+        { label: 'Cut', role: 'cut', enabled: params.editFlags.canCut },
+        { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy },
+        { label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste },
+        { type: 'separator' },
+        { label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll }
+      );
+    } else if (params.selectionText) {
+      menuItems.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
+    }
+
+    if (menuItems.length === 0) {
+      return;
+    }
+
+    Menu.buildFromTemplate(menuItems).popup();
+  });
+}


### PR DESCRIPTION
## Summary
- Electron's Chromium spellchecker underlines misspelled words automatically, but it does not populate the native right-click context menu with suggestions on its own -- that requires the app to explicitly listen for `context-menu` and read `params.misspelledWord` / `params.dictionarySuggestions`.
- Adds `attachSpellCheckContextMenu()` in `src/main/spellcheck-context-menu.ts`: on a misspelled word, lists `dictionarySuggestions` (each replacing via `webContents.replaceMisspelling`) plus an "Add to Dictionary" entry (`session.addWordToSpellCheckerDictionary`); otherwise falls back to the normal cut/copy/paste/select-all edit menu (or just Copy on a plain selection).
- Wired onto every webContents that can hold text: the main window, setup wizard window, migration wizard window (`src/main/index.ts`), plugin windows (`src/main/plugin-views.ts`), and -- via `did-attach-webview` on the main window -- the kanban plugin's embedded `<webview>` (`src/renderer/components/PluginContainer.ts`), which is where the reported symptom (dev-backlog card cb5cdfea) actually lives.

## Test plan
- [x] `npx jest --config jest.config.cjs src/main/__tests__/spellcheck-context-menu.test.ts` -- new unit tests cover: listener registration, suggestion list + replace-on-click, Add to Dictionary, no-suggestions placeholder, normal edit menu on non-misspelled editable text, Copy-only on a plain selection, and no menu when there's nothing to show.
- [x] `npx tsc -p tsconfig.main.json --noEmit` -- clean.
- [x] `npx jest --config jest.config.cjs --selectProjects main` -- passes except 3 pre-existing failures unrelated to this change (`repository-manager.test.ts`, `build-orchestrator.test.ts`, `provider-manager.test.ts` -- git/network-dependent tests, untouched by this diff).
- [ ] Manual verification in a running app build (right-click a misspelled word -> suggestions appear and replace; Add to Dictionary clears the underline; right-click normal text -> cut/copy/paste) -- this ships via an installed app release per the bead, so hands-on verification happens there.

Closes bead: mea-qpg