### PR TITLE
feat(terminal): host-side PTY spawn + IPC surface for embedded Claude Code terminal

### DIFF
--- a/e2e/terminal-pty.spec.ts
+++ b/e2e/terminal-pty.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Terminal PTY end-to-end test (mea-bkr).
+ *
+ * Exercises the real host-side PTY surface (terminal:spawn/write/resize/kill
+ * + the terminal:data/terminal:exit push events) end to end through the
+ * ACTUAL running app via Playwright's Electron support, the same harness
+ * smoke.spec.ts / pluginless.spec.ts already use. This is the disclosed
+ * "manual GUI verification pass" for this PR's slice of mea-bkr: it proves
+ * a real ConPTY-backed child process is spawned, streams output back over
+ * IPC, accepts written keystrokes, resizes, and is fully reaped (no
+ * orphaned process) on kill.
+ *
+ * Deliberately spawns a plain `cmd.exe` shell via a throwaway profile
+ * written directly to the isolated --user-data-dir's terminal-profiles.json
+ * BEFORE launch (exercising the real profile-loading path), not the real
+ * `claude` CLI: launching an actual interactive Claude Code session as a
+ * child of an unattended dispatched agent session would itself start a new,
+ * separately-billed session -- out of scope for an automated CI-safe check.
+ * The terminal-plugin renderer view (xterm.js UI) does not exist yet (it
+ * lives in the fictionlab-workflow monorepo, tracked as follow-up), so this
+ * drives the IPC contract directly via window.electronAPI rather than
+ * clicking through a terminal UI -- see this PR's description for what
+ * remains before the full mea-bkr acceptance criteria (UI-driven profile
+ * launch, resize, ctrl-C) are met.
+ */
+import { test, expect, _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+const APP_ROOT = path.resolve(__dirname, '..');
+const SESSION_ID = 'e2e-terminal-session';
+const MARKER = 'E2E_PTY_MARKER_9f3ac1';
+
+function launchEnv(): NodeJS.ProcessEnv {
+  // See smoke.spec.ts: strip ELECTRON_RUN_AS_NODE, force smoke mode.
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  env.FICTIONLAB_E2E_SMOKE = '1';
+  return env;
+}
+
+let electronApp: ElectronApplication;
+let window: Page;
+let closed = false;
+let userDataDir: string;
+
+test.describe.configure({ mode: 'serial' });
+
+test.skip(process.platform !== 'win32', 'This profile spawns cmd.exe; ConPTY is Windows-only per the mea-bkr spec.');
+
+test.beforeAll(async () => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fictionlab-e2e-terminal-'));
+
+  // Seed a throwaway profile through the real load path (profiles.ts reads
+  // {userData}/terminal-profiles.json) instead of adding a test-only IPC
+  // surface just to override the spawned command.
+  fs.writeFileSync(
+    path.join(userDataDir, 'terminal-profiles.json'),
+    JSON.stringify([
+      {
+        id: 'e2e-shell',
+        name: 'E2E Shell',
+        cwd: os.tmpdir(),
+        command: 'cmd.exe',
+        args: [],
+      },
+    ]),
+    'utf-8'
+  );
+
+  electronApp = await electron.launch({
+    args: ['.', `--user-data-dir=${userDataDir}`],
+    cwd: APP_ROOT,
+    env: launchEnv(),
+  });
+
+  window = await electronApp.firstWindow({ timeout: 30_000 });
+  await window.waitForLoadState('domcontentloaded');
+
+  // Collect pushed terminal:data / terminal:exit events on the page itself
+  // so we can poll for them from the Node side.
+  await window.evaluate(() => {
+    (window as any).__e2eTerminalData = [];
+    (window as any).__e2eTerminalExit = [];
+    (window as any).electronAPI.on('terminal:data', (payload: any) => {
+      (window as any).__e2eTerminalData.push(payload);
+    });
+    (window as any).electronAPI.on('terminal:exit', (payload: any) => {
+      (window as any).__e2eTerminalExit.push(payload);
+    });
+  });
+});
+
+test.afterAll(async () => {
+  if (electronApp && !closed) {
+    await electronApp.close();
+    closed = true;
+  }
+  if (userDataDir) {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test('terminal:list-profiles picks up the seeded e2e-shell profile', async () => {
+  const profiles = await window.evaluate(() => (window as any).electronAPI.invoke('terminal:list-profiles'));
+  expect(profiles.map((p: any) => p.id)).toContain('e2e-shell');
+});
+
+test('terminal:spawn starts a real ConPTY-backed cmd.exe process', async () => {
+  const result = await window.evaluate(
+    ({ sessionId }) =>
+      (window as any).electronAPI.invoke('terminal:spawn', { sessionId, profileId: 'e2e-shell', cols: 80, rows: 24 }),
+    { sessionId: SESSION_ID }
+  );
+  expect(result.success).toBe(true);
+  expect(result.profile.id).toBe('e2e-shell');
+});
+
+test('keystrokes written through terminal:write reach the real shell and its output streams back', async () => {
+  await window.evaluate(
+    ({ sessionId, marker }) =>
+      (window as any).electronAPI.invoke('terminal:write', { sessionId, data: `echo ${marker}\r` }),
+    { sessionId: SESSION_ID, marker: MARKER }
+  );
+
+  await window.waitForFunction(
+    (marker) => (window as any).__e2eTerminalData.some((e: any) => e.data.includes(marker)),
+    MARKER,
+    { timeout: 15_000 }
+  );
+});
+
+test('terminal:resize succeeds against the live session', async () => {
+  const result = await window.evaluate(
+    ({ sessionId }) => (window as any).electronAPI.invoke('terminal:resize', { sessionId, cols: 120, rows: 40 }),
+    { sessionId: SESSION_ID }
+  );
+  expect(result.success).toBe(true);
+});
+
+test('terminal:kill terminates the process and a terminal:exit event confirms it was reaped (no orphan)', async () => {
+  const result = await window.evaluate(
+    ({ sessionId }) => (window as any).electronAPI.invoke('terminal:kill', { sessionId }),
+    { sessionId: SESSION_ID }
+  );
+  expect(result.success).toBe(true);
+
+  await window.waitForFunction(
+    (sessionId) => (window as any).__e2eTerminalExit.some((e: any) => e.sessionId === sessionId),
+    SESSION_ID,
+    { timeout: 15_000 }
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "../fictionlab-workflow/packages/types": {
@@ -7252,6 +7255,24 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.27",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "simple-git": "^3.21.0",
     "vm2": "^3.10.0"
   },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
+  },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/main/handlers/__tests__/terminal-handlers.test.ts
+++ b/src/main/handlers/__tests__/terminal-handlers.test.ts
@@ -1,0 +1,109 @@
+const sendMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn() },
+  app: { getPath: jest.fn(() => '/fake/userData') },
+  BrowserWindow: {
+    getAllWindows: jest.fn(() => [{ webContents: { send: sendMock } }]),
+  },
+}));
+
+jest.mock('../../logger', () => ({
+  LogCategory: { TERMINAL: 'TERMINAL' },
+  logWithCategory: jest.fn(),
+}));
+
+const managerInstance = {
+  spawn: jest.fn(),
+  write: jest.fn(),
+  resize: jest.fn(),
+  kill: jest.fn(),
+  killAll: jest.fn(),
+  has: jest.fn(),
+};
+
+jest.mock('../../terminal/pty-manager', () => ({
+  PtyManager: jest.fn(() => managerInstance),
+}));
+
+const FAKE_PROFILE = { id: 'default', name: 'Claude Code', cwd: '/home', command: 'claude' };
+
+jest.mock('../../terminal/profiles', () => ({
+  loadProfiles: jest.fn(async () => [FAKE_PROFILE]),
+  DEFAULT_PROFILES: [FAKE_PROFILE],
+}));
+
+import { ipcMain } from 'electron';
+import { registerTerminalHandlers, killAllTerminals } from '../terminal-handlers';
+
+function getHandler(channel: string) {
+  const call = (ipcMain.handle as jest.Mock).mock.calls.find((c) => c[0] === channel);
+  if (!call) throw new Error(`handler not registered for ${channel}`);
+  return call[1] as (event: any, ...args: any[]) => any;
+}
+
+describe('terminal IPC handlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registerTerminalHandlers();
+  });
+
+  it('registers every terminal:* channel', () => {
+    const channels = (ipcMain.handle as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(channels).toEqual(
+      expect.arrayContaining(['terminal:list-profiles', 'terminal:spawn', 'terminal:write', 'terminal:resize', 'terminal:kill'])
+    );
+  });
+
+  it('terminal:list-profiles resolves the loaded profiles', async () => {
+    const result = await getHandler('terminal:list-profiles')({});
+    expect(result).toEqual([FAKE_PROFILE]);
+  });
+
+  it('terminal:spawn rejects a missing sessionId without calling the manager', async () => {
+    await expect(getHandler('terminal:spawn')({}, { sessionId: '' })).rejects.toThrow(/sessionId is required/i);
+    expect(managerInstance.spawn).not.toHaveBeenCalled();
+  });
+
+  it('terminal:spawn resolves the default profile and calls PtyManager.spawn', async () => {
+    const result = await getHandler('terminal:spawn')({}, { sessionId: 'sess-1' });
+    expect(result).toEqual({ success: true, profile: FAKE_PROFILE });
+    expect(managerInstance.spawn).toHaveBeenCalledWith(
+      'sess-1',
+      FAKE_PROFILE,
+      80,
+      24,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('terminal:spawn broadcasts PTY output to every open window via the onData callback', async () => {
+    await getHandler('terminal:spawn')({}, { sessionId: 'sess-2' });
+    const onData = managerInstance.spawn.mock.calls[0][4];
+    onData('sess-2', 'hello');
+    expect(sendMock).toHaveBeenCalledWith('terminal:data', { sessionId: 'sess-2', data: 'hello' });
+  });
+
+  it('terminal:spawn broadcasts exit events via the onExit callback', async () => {
+    await getHandler('terminal:spawn')({}, { sessionId: 'sess-3' });
+    const onExit = managerInstance.spawn.mock.calls[0][5];
+    onExit('sess-3', 0, undefined);
+    expect(sendMock).toHaveBeenCalledWith('terminal:exit', { sessionId: 'sess-3', exitCode: 0, signal: undefined });
+  });
+
+  it('terminal:write/terminal:resize/terminal:kill delegate to the manager', async () => {
+    await getHandler('terminal:write')({}, { sessionId: 's', data: 'x' });
+    await getHandler('terminal:resize')({}, { sessionId: 's', cols: 10, rows: 5 });
+    await getHandler('terminal:kill')({}, { sessionId: 's' });
+
+    expect(managerInstance.write).toHaveBeenCalledWith('s', 'x');
+    expect(managerInstance.resize).toHaveBeenCalledWith('s', 10, 5);
+    expect(managerInstance.kill).toHaveBeenCalledWith('s');
+  });
+
+  it('killAllTerminals() delegates to PtyManager.killAll()', () => {
+    killAllTerminals();
+    expect(managerInstance.killAll).toHaveBeenCalled();
+  });
+});

--- a/src/main/handlers/terminal-handlers.ts
+++ b/src/main/handlers/terminal-handlers.ts
@@ -1,0 +1,119 @@
+/**
+ * Terminal IPC handlers (mea-bkr).
+ *
+ * Exposes host-side PTY spawning to any renderer/plugin via the same
+ * registerHandler + electronAPI.invoke pattern workflow-handlers.ts uses for
+ * workflow:* channels (see workflow-handlers.ts:117) -- terminal-plugin (the
+ * renderer/xterm.js view; lives in the fictionlab-workflow monorepo, not
+ * this repo) calls these directly through window.electronAPI.invoke/on.
+ *
+ * Channel contract:
+ *   terminal:list-profiles()                              -> TerminalProfile[]
+ *   terminal:spawn({sessionId, profileId?, cols?, rows?})  -> { success, profile }
+ *   terminal:write({sessionId, data})                      -> { success }
+ *   terminal:resize({sessionId, cols, rows})                -> { success }
+ *   terminal:kill({sessionId})                             -> { success }
+ *   'terminal:data' (pushed)  { sessionId, data }
+ *   'terminal:exit' (pushed)  { sessionId, exitCode, signal }
+ */
+import { app, BrowserWindow } from 'electron';
+import { registerHandler } from '../ipc-registry';
+import { logWithCategory, LogCategory } from '../logger';
+import { PtyManager } from '../terminal/pty-manager';
+import { loadProfiles, DEFAULT_PROFILES } from '../terminal/profiles';
+import type {
+  SpawnTerminalParams,
+  WriteTerminalParams,
+  ResizeTerminalParams,
+  KillTerminalParams,
+  TerminalDataEvent,
+  TerminalExitEvent,
+} from '../terminal/types';
+
+const ptyManager = new PtyManager();
+
+function broadcast(channel: string, payload: TerminalDataEvent | TerminalExitEvent) {
+  BrowserWindow.getAllWindows().forEach((win) => {
+    win.webContents.send(channel, payload);
+  });
+}
+
+export function registerTerminalHandlers() {
+  registerHandler('terminal:list-profiles', 'List available terminal launch profiles', async () => {
+    try {
+      return await loadProfiles(app.getPath('userData'));
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.TERMINAL, 'IPC: terminal:list-profiles failed', { error: error.message });
+      return DEFAULT_PROFILES;
+    }
+  });
+
+  registerHandler('terminal:spawn', 'Spawn a PTY-backed terminal session', async (_event, params: SpawnTerminalParams) => {
+    const { sessionId, profileId, cols = 80, rows = 24 } = params || ({} as SpawnTerminalParams);
+    logWithCategory('info', LogCategory.TERMINAL, `IPC: terminal:spawn ${sessionId} (profile ${profileId || 'default'})`);
+    try {
+      if (!sessionId) {
+        throw new Error('sessionId is required');
+      }
+      const profiles = await loadProfiles(app.getPath('userData'));
+      const profile = (profileId && profiles.find((p) => p.id === profileId)) || profiles[0];
+      if (!profile) {
+        throw new Error('No terminal profiles configured');
+      }
+
+      ptyManager.spawn(
+        sessionId,
+        profile,
+        cols,
+        rows,
+        (id, data) => broadcast('terminal:data', { sessionId: id, data }),
+        (id, exitCode, signal) => broadcast('terminal:exit', { sessionId: id, exitCode, signal })
+      );
+
+      return { success: true, profile };
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.TERMINAL, 'IPC: terminal:spawn failed', { error: error.message, stack: error.stack });
+      throw error;
+    }
+  });
+
+  registerHandler('terminal:write', 'Write keystrokes to a terminal session', async (_event, params: WriteTerminalParams) => {
+    try {
+      ptyManager.write(params.sessionId, params.data);
+      return { success: true };
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.TERMINAL, 'IPC: terminal:write failed', { error: error.message });
+      throw error;
+    }
+  });
+
+  registerHandler('terminal:resize', 'Resize a terminal session', async (_event, params: ResizeTerminalParams) => {
+    try {
+      ptyManager.resize(params.sessionId, params.cols, params.rows);
+      return { success: true };
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.TERMINAL, 'IPC: terminal:resize failed', { error: error.message });
+      throw error;
+    }
+  });
+
+  registerHandler('terminal:kill', 'Kill a terminal session', async (_event, params: KillTerminalParams) => {
+    try {
+      ptyManager.kill(params.sessionId);
+      return { success: true };
+    } catch (error: any) {
+      logWithCategory('error', LogCategory.TERMINAL, 'IPC: terminal:kill failed', { error: error.message });
+      throw error;
+    }
+  });
+
+  logWithCategory('info', LogCategory.TERMINAL, 'Terminal IPC handlers registered');
+}
+
+/**
+ * Kill every live PTY session. Called from app 'before-quit' so closing the
+ * app never leaves an orphaned claude/shell process behind.
+ */
+export function killAllTerminals(): void {
+  ptyManager.killAll();
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -462,6 +462,7 @@ import { registerPluginUpdateHandlers } from './handlers/plugin-update-handlers'
 import { registerPluginGithubUpdateHandlers } from './handlers/plugin-github-update-handlers';
 import { registerGenrePackHandlers } from './handlers/genre-pack-handlers';
 import { registerLinkHandlers } from './handlers/link-handlers';
+import { registerTerminalHandlers, killAllTerminals } from './handlers/terminal-handlers';
 
 /**
  * Build the README.md dropped into a newly-initialized project root
@@ -536,6 +537,9 @@ function setupIPC(): void {
   // Register app:open-external / app:reveal-in-folder (issue #198 --
   // Kanban card links, issue_ref, and body URLs)
   registerLinkHandlers();
+
+  // Register embedded terminal (Casey cockpit) handlers (mea-bkr)
+  registerTerminalHandlers();
 
   // Example IPC handler - ping/pong
   registerHandler('ping', "Health-check ping/pong", async () => {
@@ -3356,6 +3360,14 @@ app.on('before-quit', async (event) => {
   isQuitting = true;
 
   logger.info('App is quitting...');
+
+  // Kill any live terminal (Casey cockpit) PTY sessions before the app exits
+  // so closing FictionLab never leaves an orphaned claude/shell process running.
+  try {
+    killAllTerminals();
+  } catch (error) {
+    logWithCategory('error', LogCategory.SYSTEM, 'Error killing terminal sessions:', error);
+  }
 
   // Clean up plugin system
   try {

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -23,6 +23,7 @@ export enum LogCategory {
   ERROR = 'ERROR',
   CONFIG = 'CONFIG',
   WORKFLOW = "WORKFLOW",
+  TERMINAL = "TERMINAL",
 }
 
 /**

--- a/src/main/terminal/__tests__/profiles.test.ts
+++ b/src/main/terminal/__tests__/profiles.test.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { DEFAULT_PROFILES, getProfilesFilePath, loadProfiles, saveProfiles } from '../profiles';
+
+describe('terminal profiles', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'terminal-profiles-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('DEFAULT_PROFILES includes a Casey profile rooted at ~/.claude/casey', () => {
+    const casey = DEFAULT_PROFILES.find((p) => p.id === 'casey');
+    expect(casey).toBeDefined();
+    expect(casey!.cwd).toBe(path.join(os.homedir(), '.claude', 'casey'));
+    expect(casey!.command).toBe('claude');
+    expect(casey!.env?.ANTHROPIC_MODEL).toBeTruthy();
+  });
+
+  it('loadProfiles returns DEFAULT_PROFILES when no file exists yet', async () => {
+    const profiles = await loadProfiles(tmpDir);
+    expect(profiles).toEqual(DEFAULT_PROFILES);
+  });
+
+  it('saveProfiles then loadProfiles round-trips custom profiles', async () => {
+    const custom = [
+      { id: 'custom', name: 'Custom', cwd: tmpDir, command: 'bash' },
+    ];
+    await saveProfiles(tmpDir, custom);
+    const loaded = await loadProfiles(tmpDir);
+    expect(loaded).toEqual(custom);
+    expect(await fs.pathExists(getProfilesFilePath(tmpDir))).toBe(true);
+  });
+
+  it('falls back to DEFAULT_PROFILES when the saved file is corrupt JSON', async () => {
+    await fs.ensureDir(tmpDir);
+    await fs.writeFile(getProfilesFilePath(tmpDir), '{not valid json', 'utf-8');
+    const profiles = await loadProfiles(tmpDir);
+    expect(profiles).toEqual(DEFAULT_PROFILES);
+  });
+
+  it('falls back to DEFAULT_PROFILES when the saved file is an empty array', async () => {
+    await saveProfiles(tmpDir, []);
+    const profiles = await loadProfiles(tmpDir);
+    expect(profiles).toEqual(DEFAULT_PROFILES);
+  });
+});

--- a/src/main/terminal/__tests__/pty-manager.test.ts
+++ b/src/main/terminal/__tests__/pty-manager.test.ts
@@ -1,0 +1,173 @@
+jest.mock('../../logger', () => ({
+  LogCategory: { TERMINAL: 'TERMINAL' },
+  logWithCategory: jest.fn(),
+}));
+
+function makeFakePty() {
+  const listeners: { data?: (d: string) => void; exit?: (e: { exitCode: number; signal?: number }) => void } = {};
+  return {
+    pid: 4242,
+    onData: jest.fn((cb: (d: string) => void) => {
+      listeners.data = cb;
+    }),
+    onExit: jest.fn((cb: (e: { exitCode: number; signal?: number }) => void) => {
+      listeners.exit = cb;
+    }),
+    write: jest.fn(),
+    resize: jest.fn(),
+    kill: jest.fn(),
+    __listeners: listeners,
+  };
+}
+
+const spawnMock = jest.fn();
+
+jest.mock('node-pty', () => ({
+  spawn: (...args: any[]) => spawnMock(...args),
+}));
+
+import { PtyManager, buildSpawnEnv } from '../pty-manager';
+import type { TerminalProfile } from '../types';
+
+const profile: TerminalProfile = {
+  id: 'test-profile',
+  name: 'Test',
+  cwd: 'C:/somewhere',
+  command: 'claude',
+  env: { FOO: 'bar' },
+};
+
+describe('buildSpawnEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, ELECTRON_RUN_AS_NODE: '1', EXISTING: 'yes' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('strips ELECTRON_RUN_AS_NODE even when inherited', () => {
+    const env = buildSpawnEnv();
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    expect(env.EXISTING).toBe('yes');
+  });
+
+  it('merges profile env overrides on top of process env', () => {
+    const env = buildSpawnEnv({ FOO: 'bar', EXISTING: 'overridden' });
+    expect(env.FOO).toBe('bar');
+    expect(env.EXISTING).toBe('overridden');
+  });
+});
+
+describe('PtyManager', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('isSupported() is true when node-pty loads', () => {
+    const manager = new PtyManager();
+    expect(manager.isSupported()).toBe(true);
+  });
+
+  it('spawn() calls node-pty.spawn with the profile command/args/cwd/env', () => {
+    const fake = makeFakePty();
+    spawnMock.mockReturnValue(fake);
+    const manager = new PtyManager();
+
+    manager.spawn('session-1', profile, 80, 24, jest.fn(), jest.fn());
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnMock.mock.calls[0];
+    expect(command).toBe('claude');
+    expect(args).toEqual([]);
+    expect(options.cwd).toBe('C:/somewhere');
+    expect(options.cols).toBe(80);
+    expect(options.rows).toBe(24);
+    expect(options.env.FOO).toBe('bar');
+    expect(manager.has('session-1')).toBe(true);
+  });
+
+  it('throws when spawning a duplicate session id', () => {
+    spawnMock.mockReturnValue(makeFakePty());
+    const manager = new PtyManager();
+    manager.spawn('dup', profile, 80, 24, jest.fn(), jest.fn());
+    expect(() => manager.spawn('dup', profile, 80, 24, jest.fn(), jest.fn())).toThrow(/already exists/i);
+  });
+
+  it('routes PTY data to the onData callback with the session id', () => {
+    const fake = makeFakePty();
+    spawnMock.mockReturnValue(fake);
+    const manager = new PtyManager();
+    const onData = jest.fn();
+
+    manager.spawn('session-2', profile, 80, 24, onData, jest.fn());
+    fake.__listeners.data!('hello world');
+
+    expect(onData).toHaveBeenCalledWith('session-2', 'hello world');
+  });
+
+  it('removes the session and fires onExit when the PTY process exits', () => {
+    const fake = makeFakePty();
+    spawnMock.mockReturnValue(fake);
+    const manager = new PtyManager();
+    const onExit = jest.fn();
+
+    manager.spawn('session-3', profile, 80, 24, jest.fn(), onExit);
+    expect(manager.has('session-3')).toBe(true);
+
+    fake.__listeners.exit!({ exitCode: 0, signal: undefined });
+
+    expect(onExit).toHaveBeenCalledWith('session-3', 0, undefined);
+    expect(manager.has('session-3')).toBe(false);
+  });
+
+  it('write()/resize() delegate to the underlying PTY process', () => {
+    const fake = makeFakePty();
+    spawnMock.mockReturnValue(fake);
+    const manager = new PtyManager();
+    manager.spawn('session-4', profile, 80, 24, jest.fn(), jest.fn());
+
+    manager.write('session-4', 'ls\r');
+    manager.resize('session-4', 120, 40);
+
+    expect(fake.write).toHaveBeenCalledWith('ls\r');
+    expect(fake.resize).toHaveBeenCalledWith(120, 40);
+  });
+
+  it('write()/resize() throw for an unknown session id', () => {
+    const manager = new PtyManager();
+    expect(() => manager.write('missing', 'x')).toThrow(/no terminal session/i);
+    expect(() => manager.resize('missing', 10, 10)).toThrow(/no terminal session/i);
+  });
+
+  it('kill() terminates the process and removes the session; is a no-op for an unknown id', () => {
+    const fake = makeFakePty();
+    spawnMock.mockReturnValue(fake);
+    const manager = new PtyManager();
+    manager.spawn('session-5', profile, 80, 24, jest.fn(), jest.fn());
+
+    manager.kill('session-5');
+    expect(fake.kill).toHaveBeenCalled();
+    expect(manager.has('session-5')).toBe(false);
+
+    expect(() => manager.kill('never-spawned')).not.toThrow();
+  });
+
+  it('killAll() kills every live session, leaving none orphaned', () => {
+    const fakeA = makeFakePty();
+    const fakeB = makeFakePty();
+    spawnMock.mockReturnValueOnce(fakeA).mockReturnValueOnce(fakeB);
+    const manager = new PtyManager();
+
+    manager.spawn('a', profile, 80, 24, jest.fn(), jest.fn());
+    manager.spawn('b', profile, 80, 24, jest.fn(), jest.fn());
+    manager.killAll();
+
+    expect(fakeA.kill).toHaveBeenCalled();
+    expect(fakeB.kill).toHaveBeenCalled();
+    expect(manager.has('a')).toBe(false);
+    expect(manager.has('b')).toBe(false);
+  });
+});

--- a/src/main/terminal/profiles.ts
+++ b/src/main/terminal/profiles.ts
@@ -1,0 +1,60 @@
+/**
+ * Terminal launch profiles (mea-bkr).
+ *
+ * A profile is where a spawned terminal session runs (cwd), what it runs
+ * (command/args), and what environment overrides it gets (e.g. a pinned
+ * ANTHROPIC_MODEL). Profiles are persisted as JSON in the app's userData
+ * directory so they survive restarts and can be hand-edited; on first run
+ * (or if the file is missing/corrupt) DEFAULT_PROFILES seeds the list.
+ */
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import { TerminalProfile } from './types';
+
+const PROFILES_FILE_NAME = 'terminal-profiles.json';
+
+/**
+ * Casey pins claude-sonnet-5 by default -- the session model this app's own
+ * dispatched agents run under (see ~/.claude/CLAUDE.md). Editable per-profile
+ * via the persisted JSON file; not a hardcoded requirement.
+ */
+export const DEFAULT_PROFILES: TerminalProfile[] = [
+  {
+    id: 'default',
+    name: 'Claude Code',
+    cwd: os.homedir(),
+    command: 'claude',
+  },
+  {
+    id: 'casey',
+    name: 'Casey',
+    cwd: path.join(os.homedir(), '.claude', 'casey'),
+    command: 'claude',
+    env: { ANTHROPIC_MODEL: 'claude-sonnet-5' },
+  },
+];
+
+export function getProfilesFilePath(userDataDir: string): string {
+  return path.join(userDataDir, PROFILES_FILE_NAME);
+}
+
+export async function loadProfiles(userDataDir: string): Promise<TerminalProfile[]> {
+  const filePath = getProfilesFilePath(userDataDir);
+  if (await fs.pathExists(filePath)) {
+    try {
+      const raw = await fs.readJson(filePath);
+      if (Array.isArray(raw) && raw.length > 0) {
+        return raw;
+      }
+    } catch {
+      // Corrupt/unreadable file - fall through to defaults rather than crash.
+    }
+  }
+  return DEFAULT_PROFILES;
+}
+
+export async function saveProfiles(userDataDir: string, profiles: TerminalProfile[]): Promise<void> {
+  await fs.ensureDir(userDataDir);
+  await fs.writeJson(getProfilesFilePath(userDataDir), profiles, { spaces: 2 });
+}

--- a/src/main/terminal/pty-manager.ts
+++ b/src/main/terminal/pty-manager.ts
@@ -1,0 +1,154 @@
+/**
+ * Host-side PTY session manager (mea-bkr).
+ *
+ * Spawns real, interactive processes via node-pty (ConPTY on Windows) and
+ * tracks them by session id so IPC handlers can write keystrokes, resize,
+ * and kill them. node-pty is an optionalDependency (native module; its
+ * prebuilds don't cover every platform, and we don't want a failed native
+ * install to break `npm install`/CI elsewhere in the app) -- it is loaded
+ * lazily and defensively so a platform without it degrades to
+ * isSupported() === false instead of crashing at import time.
+ */
+import { logWithCategory, LogCategory } from '../logger';
+import type { TerminalProfile } from './types';
+
+// Lazily resolved: only imported for its types, never eagerly required.
+type PtyModule = typeof import('node-pty');
+type IPty = import('node-pty').IPty;
+
+let ptyModule: PtyModule | null = null;
+let ptyLoadError: Error | null = null;
+let ptyLoadAttempted = false;
+
+function loadPty(): PtyModule | null {
+  if (ptyLoadAttempted) {
+    return ptyModule;
+  }
+  ptyLoadAttempted = true;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    ptyModule = require('node-pty');
+  } catch (error: any) {
+    ptyLoadError = error;
+    logWithCategory('error', LogCategory.TERMINAL, 'node-pty unavailable on this platform', {
+      error: error?.message,
+    });
+  }
+  return ptyModule;
+}
+
+/**
+ * Build the child process environment: profile overrides on top of the
+ * current process env, with ELECTRON_RUN_AS_NODE always stripped.
+ *
+ * Binding gotcha (shared-store electron-gui-blocked-in-agent-sessions):
+ * Claude Code / agent sessions run with ELECTRON_RUN_AS_NODE=1. If a spawned
+ * `claude` (or any) child process inherits it, it starts in plain-Node mode
+ * with no real terminal semantics -- this must be stripped for every PTY
+ * spawn, not just for launching the whole Electron app.
+ */
+export function buildSpawnEnv(profileEnv?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  Object.assign(env, profileEnv || {});
+  delete env.ELECTRON_RUN_AS_NODE;
+  return env;
+}
+
+interface PtySession {
+  id: string;
+  ptyProcess: IPty;
+  profile: TerminalProfile;
+}
+
+export type TerminalDataListener = (sessionId: string, data: string) => void;
+export type TerminalExitListener = (sessionId: string, exitCode: number, signal?: number) => void;
+
+export class PtyManager {
+  private sessions = new Map<string, PtySession>();
+
+  isSupported(): boolean {
+    return loadPty() !== null;
+  }
+
+  getUnsupportedReason(): string | undefined {
+    return ptyLoadError?.message;
+  }
+
+  spawn(
+    sessionId: string,
+    profile: TerminalProfile,
+    cols: number,
+    rows: number,
+    onData: TerminalDataListener,
+    onExit: TerminalExitListener
+  ): void {
+    const pty = loadPty();
+    if (!pty) {
+      throw new Error(
+        `Terminal spawning is unavailable on this platform: ${ptyLoadError?.message || 'node-pty failed to load'}`
+      );
+    }
+    if (this.sessions.has(sessionId)) {
+      throw new Error(`Terminal session ${sessionId} already exists`);
+    }
+
+    const ptyProcess = pty.spawn(profile.command, profile.args || [], {
+      name: 'xterm-color',
+      cols,
+      rows,
+      cwd: profile.cwd,
+      env: buildSpawnEnv(profile.env),
+      useConpty: process.platform === 'win32',
+    });
+
+    this.sessions.set(sessionId, { id: sessionId, ptyProcess, profile });
+    logWithCategory('info', LogCategory.TERMINAL, `Spawned terminal ${sessionId} (profile ${profile.id}, pid ${ptyProcess.pid})`);
+
+    ptyProcess.onData((data) => onData(sessionId, data));
+    ptyProcess.onExit(({ exitCode, signal }) => {
+      this.sessions.delete(sessionId);
+      logWithCategory('info', LogCategory.TERMINAL, `Terminal ${sessionId} exited (code ${exitCode}, signal ${signal})`);
+      onExit(sessionId, exitCode, signal);
+    });
+  }
+
+  write(sessionId: string, data: string): void {
+    this.mustGet(sessionId).ptyProcess.write(data);
+  }
+
+  resize(sessionId: string, cols: number, rows: number): void {
+    this.mustGet(sessionId).ptyProcess.resize(cols, rows);
+  }
+
+  kill(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    session.ptyProcess.kill();
+    this.sessions.delete(sessionId);
+  }
+
+  killAll(): void {
+    for (const sessionId of Array.from(this.sessions.keys())) {
+      this.kill(sessionId);
+    }
+  }
+
+  has(sessionId: string): boolean {
+    return this.sessions.has(sessionId);
+  }
+
+  private mustGet(sessionId: string): PtySession {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No terminal session with id ${sessionId}`);
+    }
+    return session;
+  }
+}

--- a/src/main/terminal/types.ts
+++ b/src/main/terminal/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Terminal profile: describes what command a spawned PTY session should
+ * run, in which directory, and with which environment overrides.
+ *
+ * This shape (id/name/cwd/command/args/env) is the persisted config format
+ * loaded/saved by profiles.ts -- extend it, don't replace it, so existing
+ * saved profile files keep loading.
+ */
+export interface TerminalProfile {
+  id: string;
+  name: string;
+  cwd: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface SpawnTerminalParams {
+  sessionId: string;
+  profileId?: string;
+  cols?: number;
+  rows?: number;
+}
+
+export interface WriteTerminalParams {
+  sessionId: string;
+  data: string;
+}
+
+export interface ResizeTerminalParams {
+  sessionId: string;
+  cols: number;
+  rows: number;
+}
+
+export interface KillTerminalParams {
+  sessionId: string;
+}
+
+export interface TerminalDataEvent {
+  sessionId: string;
+  data: string;
+}
+
+export interface TerminalExitEvent {
+  sessionId: string;
+  exitCode: number;
+  signal?: number;
+}


### PR DESCRIPTION
## Summary

This is the **host-side foundation slice** of the "Casey cockpit" embedded terminal (bead mea-bkr) -- steps 1-2 of that bead's plan, done and tested. It does **not** close the bead; the renderer/UI slice (step 3) lives in a different repo and is called out below as remaining work.

- `src/main/terminal/pty-manager.ts` -- `PtyManager` spawns real child processes via `node-pty` (ConPTY on Windows), tracks sessions by id, and explicitly strips `ELECTRON_RUN_AS_NODE` from every spawn's env (the binding gotcha from shared-store `electron-gui-blocked-in-agent-sessions`). `node-pty` is loaded lazily/defensively so a platform without a prebuild degrades to "unsupported" instead of crashing.
- `src/main/terminal/profiles.ts` -- persisted profile config (`{userData}/terminal-profiles.json`), seeded with a default shell profile and a **Casey** profile (`cwd: ~/.claude/casey`, `ANTHROPIC_MODEL` pinned).
- `src/main/handlers/terminal-handlers.ts` -- `terminal:list-profiles` / `terminal:spawn` / `terminal:write` / `terminal:resize` / `terminal:kill` IPC channels registered via the existing `registerHandler` pattern (same shape as `workflow-handlers.ts`'s `workflow:*` channels), pushing `terminal:data` / `terminal:exit` events to renderer windows. Wired into `setupIPC()`; `killAllTerminals()` runs on `before-quit` so quitting the app never leaves an orphaned PTY process.
- `node-pty` added as an **optionalDependency** (not a hard dependency) -- its prebuilds don't cover every platform/arch, and a failed native install for an optional dep doesn't break `npm install`/CI on platforms this bead doesn't target.

## Verification (disclosed per the mea-bkr acceptance criteria)

No human GUI click-through was performed -- the terminal-plugin renderer view (xterm.js UI) doesn't exist yet (see "Remaining work"). Instead, `e2e/terminal-pty.spec.ts` drives the **real, running Electron app** via Playwright (same harness as `smoke.spec.ts`/`pluginless.spec.ts`) and calls the IPC contract directly through `window.electronAPI.invoke`:

1. Seeds a throwaway `cmd.exe` profile through the real `{userData}/terminal-profiles.json` load path (not a test-only IPC override).
2. `terminal:spawn` starts a real ConPTY-backed `cmd.exe` process.
3. `terminal:write` sends a marker string; the shell's real output streams back over `terminal:data` and is observed on the page.
4. `terminal:resize` succeeds against the live session.
5. `terminal:kill` terminates it, and a `terminal:exit` event confirms node-pty actually reaped the process (no orphan).

All 5 e2e assertions pass on Windows. Also added 24 jest unit tests (`pty-manager.test.ts`, `profiles.test.ts`, `terminal-handlers.test.ts`) covering env stripping, duplicate-session handling, data/exit routing, and IPC delegation. `npm run test:ci` (the blocking gate): 57/57 suites, 706/706 tests green. `npm test` (full suite): same 4 pre-existing red suites as `develop` (tracked in `docs/test-triage.md`), no new failures. `npm run build` clean.

Real `claude` was deliberately **not** spawned in the automated test -- launching an actual interactive Claude Code session as a child of this unattended dispatched session would itself start a new, separately-billed session, which is out of scope for a CI-safe automated check.

## Remaining work (bead mea-bkr stays in_progress)

- **Terminal view / `terminal-plugin` package** -- lives in the `fictionlab-workflow` monorepo (a separate GitHub repo from this one), per the bead's plugin-containment requirement. Wraps xterm.js, wired to the IPC contract this PR defines (`terminal:spawn/write/resize/kill/list-profiles`, `terminal:data`/`terminal:exit` events).
- **UI-driven Casey profile launch** -- once the plugin view exists, verify the Casey profile launches from the UI and a real interactive `claude` session runs inside it (prompt, streaming output, resize, ctrl-C).
- These are the two still-open mea-bkr acceptance criteria; everything host-side (PTY spawn, IPC surface, profile config, clean kill/no-orphan) is done and tested here.

Related to bead: mea-bkr