### PR TITLE
fix(plugins): stop phantom same-version update for Agent Factory (mea-4w7)

### DIFF
--- a/src/main/__tests__/plugin-github-updater.test.ts
+++ b/src/main/__tests__/plugin-github-updater.test.ts
@@ -73,14 +73,38 @@ describe('resolveUpdateSource', () => {
     expect(source).toEqual(KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban']);
   });
 
-  it('prefers a manifest-declared updateSource over the known-plugin map', () => {
+  it('prefers a manifest-declared updateSource over the known-plugin map, merging in the known tagPrefix when the manifest omits it (bead mea-4w7)', () => {
+    // Defect 1 (mea-4w7): a manifest that declares updateSource but omits
+    // tagPrefix used to short-circuit past KNOWN_PLUGIN_UPDATE_SOURCES
+    // entirely, yielding tagPrefix: undefined even for a plugin the table
+    // knows the correct prefix for. repo/assetPattern/private still come
+    // from the manifest (unchanged precedence) -- only tagPrefix merges.
     const manifest: any = {
       id: 'fictionlab-kanban',
       version: '1.0.0',
       updateSource: { repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false },
     };
     const source = resolveUpdateSource('fictionlab-kanban', manifest);
-    expect(source).toEqual({ repo: 'someone/fork', assetPattern: 'custom-*.zip', private: false, tagPrefix: undefined });
+    expect(source).toEqual({
+      repo: 'someone/fork',
+      assetPattern: 'custom-*.zip',
+      private: false,
+      tagPrefix: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'].tagPrefix,
+    });
+  });
+
+  it('resolves tagPrefix from the known-plugin table when the manifest declares updateSource without one, for a plugin present in the table (the production case, bead mea-4w7)', () => {
+    const manifest: any = {
+      id: 'fictionlab-agent-factory',
+      version: '0.1.1',
+      updateSource: {
+        repo: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].repo,
+        assetPattern: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].assetPattern,
+        private: true,
+      },
+    };
+    const source = resolveUpdateSource('fictionlab-agent-factory', manifest);
+    expect(source?.tagPrefix).toBe('agent-factory-plugin-');
   });
 
   it('carries a manifest-declared tagPrefix through (bead mea-ecp)', () => {
@@ -283,6 +307,76 @@ describe('checkPluginUpdate', () => {
     expect(result.status).toBe('update-available');
     expect(result.latestVersion).toBe('1.2.0');
     expect(result.asset?.id).toBe(2);
+  });
+
+  it('reports "up-to-date" (not a phantom update) when installed 0.1.1 and the latest release tag is the raw "agent-factory-plugin-v0.1.1", even when the installed manifest omits tagPrefix (bead mea-4w7, Rebecca\'s reported symptom)', async () => {
+    await writeInstalledPlugin('fictionlab-agent-factory', '0.1.1', {
+      updateSource: {
+        repo: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].repo,
+        assetPattern: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].assetPattern,
+        private: true,
+        // deliberately no tagPrefix -- the pre-mea-ecp installed-manifest shape
+      },
+    });
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse([{ tag_name: 'agent-factory-plugin-v0.1.1', assets: [{ name: 'fictionlab-agent-factory-0.1.1.zip', browser_download_url: 'x', id: 1 }] }])
+    );
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-agent-factory', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('up-to-date');
+    expect(result.latestVersion).toBe('0.1.1');
+  });
+
+  it('still detects a real upgrade for the same plugin/tagPrefix shape -- installed 0.1.1, release tag agent-factory-plugin-v0.2.0 -> update-available with a clean semver, never the raw tag (bead mea-4w7)', async () => {
+    await writeInstalledPlugin('fictionlab-agent-factory', '0.1.1', {
+      updateSource: {
+        repo: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].repo,
+        assetPattern: KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-agent-factory'].assetPattern,
+        private: true,
+      },
+    });
+    const fetchFn = jest.fn().mockResolvedValue(
+      okJsonResponse([{ tag_name: 'agent-factory-plugin-v0.2.0', assets: [{ name: 'fictionlab-agent-factory-0.2.0.zip', browser_download_url: 'x', id: 1 }] }])
+    );
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-agent-factory', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('0.2.0');
+    expect(result.latestVersion).not.toContain('agent-factory-plugin');
+  });
+
+  it('treats a double-digit patch bump as newer, not as a string-lexical regression -- installed 0.1.9, release tag ...-v0.1.10 -> update-available', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '0.1.9');
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'kanban-plugin-v0.1.10', assets: [SAMPLE_ASSET] }]));
+
+    const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+    expect(result.status).toBe('update-available');
+    expect(result.latestVersion).toBe('0.1.10');
+  });
+
+  it('fails safe (no update offered) and logs a warning naming the plugin/tag/normalized value when a version is unparseable on either side (bead mea-4w7)', async () => {
+    await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
+    // A tag whose prefix does not match the resolved tagPrefix normalizes to
+    // garbage that is not valid semver -- this must never be read as "newer".
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'totally-unparseable-garbage', assets: [SAMPLE_ASSET] }]));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const result = await checkPluginUpdate({ pluginId: 'fictionlab-kanban', pluginsDir, token: 't', fetchFn: fetchFn as any });
+
+      expect(result.status).toBe('up-to-date');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fictionlab-kanban')
+      );
+      const warnedMessage = warnSpy.mock.calls[0]?.[0] as string;
+      expect(warnedMessage).toContain('totally-unparseable-garbage');
+      expect(warnedMessage).toContain('1.0.0');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('never includes the token in a returned error message', async () => {

--- a/src/main/__tests__/plugin-github-updater.test.ts
+++ b/src/main/__tests__/plugin-github-updater.test.ts
@@ -359,9 +359,10 @@ describe('checkPluginUpdate', () => {
 
   it('fails safe (no update offered) and logs a warning naming the plugin/tag/normalized value when a version is unparseable on either side (bead mea-4w7)', async () => {
     await writeInstalledPlugin('fictionlab-kanban', '1.0.0');
-    // A tag whose prefix does not match the resolved tagPrefix normalizes to
-    // garbage that is not valid semver -- this must never be read as "newer".
-    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'totally-unparseable-garbage', assets: [SAMPLE_ASSET] }]));
+    // Prefix matches (so fetchLatestReleaseForPrefix's own prefix filter
+    // still selects this release), but what remains after stripping the
+    // prefix is not valid semver -- this must never be read as "newer".
+    const fetchFn = jest.fn().mockResolvedValue(okJsonResponse([{ tag_name: 'kanban-plugin-not-a-semver', assets: [SAMPLE_ASSET] }]));
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
@@ -372,7 +373,7 @@ describe('checkPluginUpdate', () => {
         expect.stringContaining('fictionlab-kanban')
       );
       const warnedMessage = warnSpy.mock.calls[0]?.[0] as string;
-      expect(warnedMessage).toContain('totally-unparseable-garbage');
+      expect(warnedMessage).toContain('kanban-plugin-not-a-semver');
       expect(warnedMessage).toContain('1.0.0');
     } finally {
       warnSpy.mockRestore();

--- a/src/main/plugin-github-updater.ts
+++ b/src/main/plugin-github-updater.ts
@@ -122,15 +122,25 @@ export function resolveUpdateSource(
   manifest: MinimalPluginManifest | null
 ): PluginUpdateSource | null {
   const declared = (manifest as any)?.updateSource;
+  const known = KNOWN_PLUGIN_UPDATE_SOURCES[pluginId];
+
   if (declared && typeof declared.repo === 'string' && typeof declared.assetPattern === 'string') {
+    // Manifest values win for repo/assetPattern/private (unchanged
+    // precedence). tagPrefix is the one field that falls back to the
+    // known-plugin table when the manifest omits it -- the manifest on an
+    // already-installed plugin can predate bead mea-ecp, in which case the
+    // table is the only place the correct prefix is known. See mea-4w7:
+    // dropping straight to `undefined` here caused fetchLatestReleaseForPrefix
+    // to fall back to the repo-wide /releases/latest for a multi-plugin repo,
+    // and normalizeVersion to leave the raw tag name unstripped.
     return {
       repo: declared.repo,
       assetPattern: declared.assetPattern,
       private: !!declared.private,
-      tagPrefix: typeof declared.tagPrefix === 'string' ? declared.tagPrefix : undefined,
+      tagPrefix: typeof declared.tagPrefix === 'string' ? declared.tagPrefix : known?.tagPrefix,
     };
   }
-  return KNOWN_PLUGIN_UPDATE_SOURCES[pluginId] ?? null;
+  return known ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -292,11 +302,28 @@ export async function checkPluginUpdate(
   const release = result.release;
   const latestVersion = normalizeVersion(release.tagName, source.tagPrefix);
 
-  const isNewer = currentVersion
-    ? semver.valid(latestVersion) && semver.valid(currentVersion)
-      ? semver.gt(latestVersion, currentVersion)
-      : latestVersion !== currentVersion
-    : true;
+  let isNewer: boolean;
+  if (!currentVersion) {
+    // No installed version to compare against -- there is nothing installed
+    // yet, so any release counts as available.
+    isNewer = true;
+  } else if (semver.valid(latestVersion) && semver.valid(currentVersion)) {
+    isNewer = semver.gt(latestVersion, currentVersion);
+  } else {
+    // Fail safe: an unparseable version on either side must NOT be reported
+    // as an update. The previous `latestVersion !== currentVersion` fallback
+    // treated any unparseable tag (e.g. a raw "agent-factory-plugin-v0.1.1"
+    // left unstripped by a missing tagPrefix) as "newer", forever offering a
+    // phantom same-version update. A missed update is recoverable by
+    // reinstalling; a false positive destroys trust in the whole pane. See
+    // mea-4w7.
+    isNewer = false;
+    console.warn(
+      `[plugin-github-updater] Could not compare versions for plugin "${pluginId}": ` +
+        `raw tag "${release.tagName}" normalized to "${latestVersion}", installed version "${currentVersion}". ` +
+        'At least one side is not valid semver; treating as up-to-date to avoid a false-positive update prompt.'
+    );
+  }
 
   if (!isNewer) {
     return { status: 'up-to-date', pluginId, currentVersion, latestVersion, release, source };


### PR DESCRIPTION
## What changed and why

Two defects in `src/main/plugin-github-updater.ts` were compounding into a phantom "update available" for Agent Factory in the Plugins pane (installed `0.1.1`, offered the raw git tag name `agent-factory-plugin-v0.1.1` as if it were a newer version, and re-offering it after every reinstall).

**Defect 1 — `resolveUpdateSource` (L120-134) dropped a known-good `tagPrefix`.** If the *installed* plugin's `plugin.json` declares an `updateSource` with `repo`/`assetPattern` but no `tagPrefix`, the function returned immediately with `tagPrefix: undefined` and never fell through to `KNOWN_PLUGIN_UPDATE_SOURCES`, even though the table has the correct prefix (`agent-factory-plugin-`) for that plugin. This matters because the update-check path reads the manifest of the *already-installed* plugin, which can predate the manifest fix (bead mea-ecp) shipped in fictionlab-workflow — the app has to be robust against old installed manifests, since the update check is precisely the mechanism by which a user would get the new manifest.
  - Consequence: `fetchLatestReleaseForPrefix` saw a falsy `tagPrefix` and fell back to the repo-wide `/releases/latest`, which in a multi-plugin monorepo can resolve to an entirely different plugin's release.
  - Consequence: `normalizeVersion` only strips a leading `v`, so `"agent-factory-plugin-v0.1.1"` came back unchanged.

**Fix:** `resolveUpdateSource` now merges `tagPrefix` from `KNOWN_PLUGIN_UPDATE_SOURCES[pluginId]` when the manifest omits it. `repo`/`assetPattern`/`private` precedence is unchanged — the manifest still wins for those.

**Defect 2 — the `isNewer` comparison (L293-299) fell back to `!==`, treating any unparseable version as "newer".** `semver.valid("agent-factory-plugin-v0.1.1")` is `null`, so the old fallback (`latestVersion !== currentVersion`) evaluated to `true` — "update available" — forever, for any tag it couldn't parse as semver. Fixing only Defect 1 would have made today's symptom disappear while leaving this trap armed for the next unparseable tag.

**Fix:** if either side isn't valid semver after normalization, `isNewer` is now `false` (fail-safe — no update reported), and a `console.warn` names the plugin id, the raw tag, and the normalized value so a real parsing gap is diagnosable instead of silently swallowed.

## Handling of the two pre-existing tests (per the CASEY SPEC)

- **`normalizeVersion` "is a no-op when the tagPrefix does not match"` (was L150-152) — left UNCHANGED.** That assertion about `normalizeVersion` in isolation is still correct; the bug was never in the normalizer, it was upstream (resolution) and downstream (compare) of it. Deleting or altering this test would have hidden that the fix belongs elsewhere.
- **`resolveUpdateSource` "prefers a manifest-declared updateSource over the known-plugin map"` (was L76-84) — UPDATED deliberately.** This test asserted `tagPrefix: undefined` as the *expected* result of a manifest omitting `tagPrefix`, which is exactly Defect 1 encoded as intended behavior. It now expects the merged table value (`KNOWN_PLUGIN_UPDATE_SOURCES['fictionlab-kanban'].tagPrefix`) while still asserting `repo`/`assetPattern`/`private` come from the manifest, preserving the precedence the test was originally guarding.

## New tests added (`src/main/__tests__/plugin-github-updater.test.ts`)

- Manifest declares `updateSource` without `tagPrefix`, for a plugin present in `KNOWN_PLUGIN_UPDATE_SOURCES` → resolved `tagPrefix` comes from the table (the exact production case).
- Installed `0.1.1`, latest release tag `agent-factory-plugin-v0.1.1` → `up-to-date`, no update offered (Rebecca's literal reported symptom).
- Same shape, installed `0.1.1`, release tag `agent-factory-plugin-v0.2.0` → `update-available`, `latestVersion` renders as `0.2.0`, never the raw tag.
- Double-digit ordering: installed `0.1.9`, tag `...-v0.1.10` → `update-available` (guards against any regression to string comparison).
- Unparseable version remainder after a matching prefix strip → `up-to-date` (fail-safe) + a warning log naming the plugin, raw tag, and normalized value.

## Test / build results

- `npx jest src/main/__tests__/plugin-github-updater.test.ts` — **37/37 passed.**
- Full suite (`npx jest`): **818 passed, 15 failed, 3 skipped** across 61 suites. The 15 failures are in 4 suites (`tests/main/build-orchestrator.test.ts`, `tests/main/repository-manager.test.ts`, `src/main/llm/__tests__/provider-manager.test.ts`, `src/renderer/components/__tests__/ProviderSelector.a11y.test.tsx`) — verified pre-existing on unmodified `develop` (same failures, same counts, reproduced in a clean checkout before this branch's changes were applied). None touch `plugin-github-updater.ts` or its test file.
- `npm run build` (`tsc` renderer + main, then asset copy) — **succeeded, no errors.**

## Out of scope (untouched, per spec)

- Renderer display (`src/renderer/views/PluginsLauncher.ts` L689) — it already faithfully renders whatever the main process gives it; no UI change needed now that the values are correct.
- The app self-updater (`src/renderer/components/SetupTab.ts` L425) — unrelated code path.
- Plugin release tagging in fictionlab-workflow — Rebecca's call, tracked on mea-uhg.
- The dependency-gate semver use (L378-396).

## Sequencing

This must ship in the app release BEFORE workflow-plugin/kanban-plugin are tagged (see mea-uhg), otherwise every newly-tagged plugin will show a phantom update.

Closes bead: mea-4w7