### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fictionlab",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fictionlab",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fictionlab",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI-powered writing workspace for authors - your creative laboratory",
   "main": "dist/main/index.js",
   "author": "FictionLab",


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json`, matching the v0.4.0 convention (555ac0e). **No tag is pushed by this PR.**

## Why this is prepped but not cut

`release.yml` triggers only on a `v*.*.*` tag push. Merging this PR is therefore safe and publishes nothing. Cutting the release — pushing the `v0.5.0` tag, which builds real Win/Mac/Linux installers and publishes a public GitHub Release — is Rebecca's call (bead `mea-uhg`).

## Version choice

0.5.0, not 0.4.1. Two new features (plugin dashboard-widget contribution API, embedded terminal PTY), so MINOR per `RELEASE.md`.

## ⚠️ Install order is load-bearing

This release couples app and plugin versions in a way normal releases do not.

- #242 (`mea-cjl.4`) **removes the workflow columns from core** and expects the workflow plugin's dashboard widget to fill that space.
- The contribution API that mounts that widget landed in #240 — also in this release.

**Required order:**
1. **Install app v0.5.0 first.** It carries the `mea-4w7` updater fix.
2. **Then** tag `workflow-plugin-v1.2.0` and `kanban-plugin-v1.1.3` in `fictionlab-workflow`.

Reversing this re-creates the exact bug #247 just fixed: the pre-0.5.0 updater compares raw git tag names against versions, so every newly-tagged plugin advertises a phantom same-version update. The fixed app must be installed *before* those tags exist.

Note both plugins already carry correct `tagPrefix`/`updateSource` in their manifests (PRs #48/#49 in fictionlab-workflow) — they have simply never been tagged under the new scheme. Only `agent-factory-plugin-v0.1.1` exists today.

## Contents (8 commits since v0.4.0, tagged 2026-07-17)

| PR | Bead | Change |
|---|---|---|
| #247 | mea-4w7 | fix(plugins): stop phantom same-version update |
| #246 | mea-bkr | feat(terminal): host-side PTY spawn + IPC surface |
| #245 | mea-qpg | fix(spellcheck): suggested corrections in context menu |
| #244 | — | fix(workflows): always offer general-purpose in Agent dropdown |
| #243 | — | feat(workflows): wire ContextVariablesTab into NodeConfigDialog |
| #242 | mea-cjl.4 | feat(dashboard): drop workflow columns from core |
| #241 | — | fix(dashboard): top-bar aggregate status from live SystemStrip |
| #240 | — | feat(dashboard): plugin dashboard-widget contribution API |

## Still open after this

`mea-cjl.3` and `mea-cjl.5` remain unshipped slices of the workflow-UI extraction epic — the next release will need the same app/plugin sequencing treatment.

Relates to bead: mea-uhg