### PR TITLE
fix(dashboard): remove Export Report from top bar (mea-ctr)

### DIFF
--- a/src/renderer/dashboard-handlers.ts
+++ b/src/renderer/dashboard-handlers.ts
@@ -455,23 +455,3 @@ function showClaudeDesktopDialog(isConfigured: boolean, config: any): void {
     });
   }
 }
-
-/**
- * Export a diagnostic report for the Dashboard's top-bar "Export Report"
- * action. Reuses the same `logger.exportDiagnosticReport` IPC call the
- * Setup/Logs views use.
- */
-export async function exportDashboardDiagnosticReport(): Promise<void> {
-  try {
-    const result = await window.electronAPI.logger.exportDiagnosticReport();
-
-    if (result.success) {
-      showNotification(`Diagnostic report exported to: ${result.path}`, 'success');
-    } else {
-      showNotification(`Failed to export report: ${result.error}`, 'error');
-    }
-  } catch (error) {
-    console.error('Error exporting diagnostic report:', error);
-    showNotification('Failed to export diagnostic report', 'error');
-  }
-}

--- a/src/renderer/views/DashboardView.ts
+++ b/src/renderer/views/DashboardView.ts
@@ -14,6 +14,12 @@
  * handlers are gone -- DashboardApp owns its own polling/subscriptions, and
  * SystemStrip.tsx re-implements Start/Stop/Restart System directly against
  * the same mcpSystem IPC dashboard-handlers.ts used to call.
+ *
+ * The top bar's "Export Report" action was removed (mea-ctr): exporting a
+ * diagnostic report is a rare action, not a primary-toolbar one. It remains
+ * reachable from the Diagnostics menu ("Export Diagnostic Report") and the
+ * Settings > Logs page, both of which already called the same
+ * `logger.exportDiagnosticReport` IPC handler this view used to call too.
  */
 
 import * as React from 'react';
@@ -21,7 +27,6 @@ import * as ReactDOM from 'react-dom/client';
 import type { View } from '../components/ViewRouter.js';
 import type { TopBarConfig } from '../components/TopBar.js';
 import { DashboardApp } from './DashboardViewReact.js';
-import { exportDashboardDiagnosticReport } from '../dashboard-handlers.js';
 
 export class DashboardView implements View {
   private container: HTMLElement | null = null;
@@ -53,11 +58,6 @@ export class DashboardView implements View {
         // listeners), same as the top-bar action always did.
         window.dispatchEvent(new CustomEvent('dashboard-refresh'));
         break;
-      case 'export':
-        exportDashboardDiagnosticReport().catch((error) => {
-          console.error('[DashboardView] Export failed:', error);
-        });
-        break;
       default:
         console.warn('[DashboardView] Unknown action:', actionId);
     }
@@ -68,7 +68,6 @@ export class DashboardView implements View {
       title: 'Dashboard',
       actions: [
         { id: 'refresh', label: 'Refresh', icon: '🔄' },
-        { id: 'export', label: 'Export Report', icon: '📊' },
       ],
       global: {
         projectSelector: true,

--- a/src/renderer/views/__tests__/DashboardView.test.ts
+++ b/src/renderer/views/__tests__/DashboardView.test.ts
@@ -10,10 +10,12 @@
  * the .tsx file the way WorkflowsViewReact does. It creates a ReactDOM
  * root in mount() and tears it down in unmount(), and forwards top-bar
  * actions: 'refresh' dispatches a 'dashboard-refresh' CustomEvent that
- * DashboardApp's panels + SystemStrip subscribe to, 'export' calls
- * dashboard-handlers.ts's exportDashboardDiagnosticReport() (the one piece
- * of the old dashboard-handlers.ts surface DashboardView itself still
- * depends on).
+ * DashboardApp's panels + SystemStrip subscribe to.
+ *
+ * The top-bar 'export' action (and its dashboard-handlers.ts
+ * exportDashboardDiagnosticReport() handler) was removed in mea-ctr -- the
+ * same diagnostic report is already reachable from the Diagnostics menu and
+ * the Settings > Logs page.
  *
  * DashboardViewReact.js is mocked wholesale (real DashboardApp render
  * behavior is covered by its own panel/strip component tests under
@@ -26,12 +28,7 @@ jest.mock('../DashboardViewReact.js', () => ({
   DashboardApp: () => null,
 }));
 
-jest.mock('../../dashboard-handlers.js', () => ({
-  exportDashboardDiagnosticReport: jest.fn().mockResolvedValue(undefined),
-}));
-
 import { DashboardView } from '../DashboardView';
-import * as dashboardHandlers from '../../dashboard-handlers.js';
 
 describe('DashboardView', () => {
   let container: HTMLElement;
@@ -73,17 +70,10 @@ describe('DashboardView', () => {
     window.removeEventListener('dashboard-refresh', listener);
   });
 
-  it('triggers a real diagnostic export on the "export" top-bar action', async () => {
-    await view.mount(container);
-    view.handleAction('export');
-
-    expect(dashboardHandlers.exportDashboardDiagnosticReport).toHaveBeenCalledTimes(1);
-  });
-
-  it('exposes the Dashboard title and Refresh/Export Report top-bar actions', () => {
+  it('exposes the Dashboard title and Refresh top-bar action', () => {
     const config = view.getTopBarConfig();
 
     expect(config.title).toBe('Dashboard');
-    expect(config.actions?.map((a) => a.id)).toEqual(['refresh', 'export']);
+    expect(config.actions?.map((a) => a.id)).toEqual(['refresh']);
   });
 });


### PR DESCRIPTION
## Summary
- Removes the "Export Report" action from the Dashboard top bar (`DashboardView.ts`) -- exporting a diagnostic report is a rare action that doesn't belong in the primary toolbar.
- The same report is already reachable from **Diagnostics > Export Diagnostic Report** (menu) and **Settings > Logs page** -- both already call the identical `logger.exportDiagnosticReport` IPC handler the top-bar button used, so the exported report is unchanged.
- Removes the now-dead `exportDashboardDiagnosticReport()` handler from `dashboard-handlers.ts` and updates `DashboardView.test.ts` accordingly.

## Test plan
- [x] `npm run build` passes
- [x] `npx jest DashboardView.test` passes (4/4)
- [x] Confirmed unrelated pre-existing failures (`build-orchestrator.test.ts`, `repository-manager.test.ts`) exist on origin/develop baseline too (verified via `git stash`), unaffected by this change
- [x] Verified Diagnostics menu's "Export Diagnostic Report" and the Logs page's export button call the same `logger.exportDiagnosticReport` IPC path the removed top-bar button used

Closes bead: mea-ctr