### PR TITLE
fix(test): eliminate focus race in NodeConfigDialog arrow-key nav tests (mea-3en)

### DIFF
--- a/src/renderer/components/dialogs/__tests__/NodeConfigDialog.a11y.test.tsx
+++ b/src/renderer/components/dialogs/__tests__/NodeConfigDialog.a11y.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { NodeConfigDialog, NodeConfigDialogProps } from '../NodeConfigDialog';
@@ -341,6 +341,10 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const basicTab = screen.getByRole('tab', { name: /Basic Info/i });
       basicTab.focus();
+      // Windows CI runners can be slow enough that the keydown fires before
+      // jsdom has committed the imperative .focus() call, so the ArrowRight
+      // handler reads the wrong tabId (mea-3en). Wait for focus to settle.
+      await waitFor(() => expect(basicTab).toHaveFocus());
 
       await user.keyboard('{ArrowRight}');
 
@@ -356,6 +360,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
       const configTab = screen.getByRole('tab', { name: /Configuration/i });
       await user.click(configTab);
       configTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(configTab).toHaveFocus());
 
       await user.keyboard('{ArrowLeft}');
 
@@ -371,6 +378,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
       const advancedTab = screen.getByRole('tab', { name: /Advanced/i });
       await user.click(advancedTab);
       advancedTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(advancedTab).toHaveFocus());
 
       await user.keyboard('{ArrowRight}');
 
@@ -384,6 +394,10 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const basicTab = screen.getByRole('tab', { name: /Basic Info/i });
       basicTab.focus();
+      // Windows CI runners can be slow enough that the keydown fires before
+      // jsdom has committed the imperative .focus() call, so the ArrowLeft
+      // handler reads the wrong tabId (mea-3en, the primary flaky case).
+      await waitFor(() => expect(basicTab).toHaveFocus());
 
       await user.keyboard('{ArrowLeft}');
 
@@ -397,6 +411,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const basicTab = screen.getByRole('tab', { name: /Basic Info/i });
       basicTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(basicTab).toHaveFocus());
 
       await user.keyboard('{ArrowDown}');
 
@@ -411,6 +428,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
       const configTab = screen.getByRole('tab', { name: /Configuration/i });
       await user.click(configTab);
       configTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(configTab).toHaveFocus());
 
       await user.keyboard('{ArrowUp}');
 
@@ -425,6 +445,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
       const advancedTab = screen.getByRole('tab', { name: /Advanced/i });
       await user.click(advancedTab);
       advancedTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(advancedTab).toHaveFocus());
 
       await user.keyboard('{Home}');
 
@@ -438,6 +461,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const basicTab = screen.getByRole('tab', { name: /Basic Info/i });
       basicTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(basicTab).toHaveFocus());
 
       await user.keyboard('{End}');
 
@@ -451,6 +477,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const configTab = screen.getByRole('tab', { name: /Configuration/i });
       configTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(configTab).toHaveFocus());
 
       await user.keyboard('{Enter}');
 
@@ -463,6 +492,9 @@ describe('NodeConfigDialog - Keyboard Navigation', () => {
 
       const configTab = screen.getByRole('tab', { name: /Configuration/i });
       configTab.focus();
+      // See mea-3en: wait for focus to settle before dispatching the key so
+      // the keydown lands on the tab we expect, not a stale activeElement.
+      await waitFor(() => expect(configTab).toHaveFocus());
 
       await user.keyboard(' ');
 


### PR DESCRIPTION
## What changed

`NodeConfigDialog.a11y.test.tsx`'s "Tab Navigation with Arrow Keys" describe block (10 tests) called `tab.focus()` imperatively and immediately sent `await user.keyboard(...)` with nothing awaited in between. Added `await waitFor(() => expect(tab).toHaveFocus())` right after every imperative `.focus()` call (10 sites, all 10 tests in that block) so each test proves focus has actually settled in jsdom before the key event fires.

## Why it was racy

`handleTabKeyDown` (NodeConfigDialog.tsx L312-346) computes the target tab index from `visibleTabs.findIndex(tab => tab.id === tabId)`, where `tabId` is bound to whichever tab element the keydown event landed on. If the imperative `.focus()` call hasn't been committed by jsdom yet when `user.keyboard(...)` fires, the keydown lands on the wrong (or no) activeElement, so the wrong tab's handler runs — or none at all — and the test's `aria-selected` assertion fails.

This was Windows-only because Windows CI runners are the slowest of the three OSes, and #243 (ContextVariablesTab) added a 5th tab, lengthening the render and widening the race window — consistent with the failures starting after #243 merged.

No assertions weakened, no tests skipped/retried, nothing removed from `test:ci`. Tab order in `NodeConfigDialog.tsx` (L153-162, Advanced last) is unchanged — verified correct as-is.

## Verification

**Loop test** (a11y suite alone, 20 consecutive runs, `jest --config jest.config.cjs .../NodeConfigDialog.a11y.test.tsx`):
```
TOTAL: 20 passed, 0 failed out of 20
```

**`npm run test:ci`** (the blocking release gate):
```
Test Suites: 57 passed, 57 total
Tests:       711 passed, 711 total
Time:        10.739 s
```

**`npm run build`**: exit 0, `tsc -p tsconfig.renderer.json && tsc -p tsconfig.main.json && node scripts/copy-assets.js` completed cleanly, asset copy finished with no errors.

This gates cutting v0.5.0 (see mea-uhg and PR #248).

Closes bead: mea-3en