### PR TITLE
feat(workflows): wire sub-workflow node canvas links (mea-0uq)

### DIFF
--- a/src/renderer/components/WorkflowCanvas.tsx
+++ b/src/renderer/components/WorkflowCanvas.tsx
@@ -782,6 +782,8 @@ export const WorkflowCanvas: React.FC<WorkflowCanvasProps> = React.memo(({
   const nodesWithStatus = useMemo(() => {
     return baseNodes.map(node => {
       const statusInfo = executionStatus?.get(node.id);
+      const subWorkflowId = node.baseData.phase.subWorkflowId;
+      const subWorkflowMissing = !!subWorkflowId && !availableWorkflows.some((wf) => wf.id === subWorkflowId);
       return {
         ...node,
         data: {
@@ -790,13 +792,14 @@ export const WorkflowCanvas: React.FC<WorkflowCanvasProps> = React.memo(({
           loopIteration: statusInfo?.loopIteration,
           isActiveNode: activeNodeId === node.id, // Highlight the currently executing node
           onEdit: () => handleEditNode(node.id), // Use new NodeConfigDialog
-          onOpenSubWorkflow: node.baseData.phase.subWorkflowId
-            ? () => handleOpenSubWorkflow(node.baseData.phase.subWorkflowId!)
+          subWorkflowMissing,
+          onOpenSubWorkflow: subWorkflowId && !subWorkflowMissing
+            ? () => handleOpenSubWorkflow(subWorkflowId)
             : undefined,
         },
       };
     });
-  }, [baseNodes, executionStatus, activeNodeId, handleEditNode, handleOpenSubWorkflow]);
+  }, [baseNodes, executionStatus, activeNodeId, handleEditNode, handleOpenSubWorkflow, availableWorkflows]);
 
   // Update React Flow state when memoized values change
   useEffect(() => {

--- a/src/renderer/components/dialogs/config-panels/SubWorkflowNodeConfig.tsx
+++ b/src/renderer/components/dialogs/config-panels/SubWorkflowNodeConfig.tsx
@@ -199,6 +199,16 @@ export const SubWorkflowNodeConfig: React.FC<SubWorkflowNodeConfigProps> = ({
         </div>
       )}
 
+      {node.subWorkflowId && !selectedWorkflow && (
+        <div style={styles.warningBox}>
+          <span style={styles.warningIcon}>⚠</span>
+          <div style={styles.warningContent}>
+            <strong>Referenced workflow not found:</strong> "{node.subWorkflowId}" no longer
+            exists (it may have been deleted or renamed). Select a different workflow.
+          </div>
+        </div>
+      )}
+
       {/* Execution Settings */}
       <div style={styles.field}>
         <label style={styles.checkboxLabel}>

--- a/src/renderer/components/nodes/PhaseNode.tsx
+++ b/src/renderer/components/nodes/PhaseNode.tsx
@@ -49,6 +49,8 @@ export interface PhaseNodeData extends Record<string, unknown> {
   loopIteration?: number;
   /** True if this node is the currently executing node in an active workflow */
   isActiveNode?: boolean;
+  /** True if phase.subWorkflowId is set but doesn't resolve to a known workflow */
+  subWorkflowMissing?: boolean;
   onEdit?: () => void;
   onOpenSubWorkflow?: () => void;
 }
@@ -235,14 +237,24 @@ export const PhaseNode = ({ data }: NodeProps) => {
 
       {/* Sub-workflow indicator with click-to-open */}
       {nodeData.phase.type === 'subworkflow' && nodeData.phase.subWorkflowId && (
-        <div
-          className="sub-workflow-link"
-          style={subWorkflowLinkStyle}
-          onClick={handleSubWorkflowClick}
-          title="Click to open sub-workflow"
-        >
-          🔗 {nodeData.phase.subWorkflowId}
-        </div>
+        nodeData.subWorkflowMissing ? (
+          <div
+            className="sub-workflow-link sub-workflow-link-missing"
+            style={subWorkflowLinkMissingStyle}
+            title={`Referenced workflow "${nodeData.phase.subWorkflowId}" not found`}
+          >
+            🔗 {nodeData.phase.subWorkflowId} (not found)
+          </div>
+        ) : (
+          <div
+            className="sub-workflow-link"
+            style={subWorkflowLinkStyle}
+            onClick={handleSubWorkflowClick}
+            title="Click to open sub-workflow"
+          >
+            🔗 {nodeData.phase.subWorkflowId}
+          </div>
+        )
       )}
 
       {nodeData.phase.gate && (
@@ -313,4 +325,13 @@ const subWorkflowLinkStyle: React.CSSProperties = {
   cursor: 'pointer',
   textDecoration: 'underline',
   transition: 'color 0.2s',
+};
+
+const subWorkflowLinkMissingStyle: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#9ca3af',
+  marginBottom: '4px',
+  cursor: 'not-allowed',
+  textDecoration: 'line-through',
+  fontStyle: 'italic',
 };

--- a/src/renderer/components/nodes/__tests__/PhaseNode.test.tsx
+++ b/src/renderer/components/nodes/__tests__/PhaseNode.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Render tests for PhaseNode's sub-workflow link affordance (mea-0uq):
+ * clicking a subworkflow-type node's link should invoke
+ * `data.onOpenSubWorkflow`, and a reference that doesn't resolve to a known
+ * workflow (`data.subWorkflowMissing`) should render as a disabled,
+ * non-clickable indicator with an explanatory tooltip instead of crashing.
+ */
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactFlowProvider } from '@xyflow/react';
+import { PhaseNode, PhaseNodeData } from '../PhaseNode';
+
+function makeData(overrides: Partial<PhaseNodeData> = {}): PhaseNodeData {
+  return {
+    label: 'Dramatica Pipeline',
+    phase: {
+      id: 1,
+      name: 'Dramatica Pipeline',
+      type: 'subworkflow',
+      agent: 'unused',
+      description: '',
+      gate: false,
+      requiresApproval: false,
+      subWorkflowId: 'dramatica-pipeline',
+    },
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+function renderNode(data: PhaseNodeData) {
+  return render(
+    <ReactFlowProvider>
+      <PhaseNode
+        id="node-1"
+        data={data}
+        type="subworkflow"
+        selected={false}
+        isConnectable
+        zIndex={0}
+        dragging={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+      />
+    </ReactFlowProvider>
+  );
+}
+
+describe('PhaseNode sub-workflow link', () => {
+  it('renders a clickable link that calls onOpenSubWorkflow when the reference resolves', async () => {
+    const user = userEvent.setup();
+    const onOpenSubWorkflow = jest.fn();
+    renderNode(makeData({ onOpenSubWorkflow }));
+
+    const link = screen.getByTitle('Click to open sub-workflow');
+    expect(link).toHaveTextContent('dramatica-pipeline');
+
+    await user.click(link);
+    expect(onOpenSubWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a disabled indicator with a not-found tooltip when the reference is missing, and does not crash on click', async () => {
+    const user = userEvent.setup();
+    const onOpenSubWorkflow = jest.fn();
+    // Missing reference: WorkflowCanvas never wires onOpenSubWorkflow for this case.
+    renderNode(makeData({ subWorkflowMissing: true, onOpenSubWorkflow: undefined }));
+
+    const link = screen.getByTitle('Referenced workflow "dramatica-pipeline" not found');
+    expect(link).toHaveTextContent('dramatica-pipeline (not found)');
+
+    await user.click(link);
+    expect(onOpenSubWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('renders no sub-workflow link for non-subworkflow node types', () => {
+    renderNode({
+      ...makeData(),
+      phase: { ...makeData().phase, type: 'planning', subWorkflowId: undefined },
+    });
+
+    expect(screen.queryByText(/dramatica-pipeline/)).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/WorkflowsViewReact.tsx
+++ b/src/renderer/views/WorkflowsViewReact.tsx
@@ -430,8 +430,11 @@ const WorkflowsApp: React.FC = () => {
       setExecutionStatus(new Map());
       setActiveNodeId(null);
       setActiveRegistryId(null);
-    } catch (error) {
+    } catch (error: any) {
       console.error('[WorkflowsViewReact] Failed to get workflow:', error);
+      if (typeof (window as any).showNotification === 'function') {
+        (window as any).showNotification(`Failed to open workflow: ${error?.message || error}`, 'error');
+      }
     }
   };
 
@@ -865,6 +868,7 @@ const WorkflowsApp: React.FC = () => {
                       onNodeClick={(nodeId: string, phase: any) => {
                         console.log('[WorkflowsViewReact] Node clicked:', nodeId, phase);
                       }}
+                      onOpenSubWorkflow={handleSelectWorkflow}
                       onWorkflowChange={(updatedWorkflow: any) => {
                         console.log('[WorkflowsViewReact] Workflow changed:', updatedWorkflow);
                         // Update the selected workflow with the new data


### PR DESCRIPTION
## Summary
- Sub-workflow canvas nodes already rendered a "🔗 subWorkflowId" link affordance (`PhaseNode.tsx`) and `WorkflowCanvas` already threaded an `onOpenSubWorkflow` callback + `availableWorkflows` prop down to it, but `WorkflowsViewReact.tsx` never passed a handler into `<WorkflowCanvas>` -- clicking was a dead end. Wires it to `handleSelectWorkflow`, the exact same navigation the "Available Workflows" sidebar list already uses to switch the canvas to a different workflow.
- Failures opening the referenced workflow now surface via the existing `window.showNotification` pattern instead of only `console.error`.
- Broken-reference handling: `WorkflowCanvas` now flags a node whose `subWorkflowId` doesn't resolve to any entry in `availableWorkflows`; `PhaseNode` renders that case as a disabled, non-clickable indicator styled distinctly (strikethrough, muted color) with a `Referenced workflow "X" not found` tooltip instead of a live link. The `SubWorkflowNodeConfig` inspector panel shows the same warning for a stale/deleted reference.

## Test plan
- [x] `npm run build` passes
- [x] Added `src/renderer/components/nodes/__tests__/PhaseNode.test.tsx` covering: clicking a resolvable sub-workflow link calls `onOpenSubWorkflow`; a missing reference renders the disabled/tooltip state and does not call the handler or crash on click; non-subworkflow node types render no link
- [x] `npm test` -- new suite passes (3/3); pre-existing unrelated failures in `build-orchestrator.test.ts`/`repository-manager.test.ts` (timeouts) confirmed present on the `origin/develop` baseline too, unaffected by this change

Closes bead: mea-0uq