### PR TITLE
fix(release): upgrade action-gh-release to v2 to fix false-failure on asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,7 +439,7 @@ jobs:
           cat release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- `softprops/action-gh-release@v1` reports a 404 and fails the Create Release step even when the asset upload succeeds, because GitHub normalizes spaces in asset filenames (our `artifactName` produces `FictionLab Setup X.Y.Z x64.exe`) and v1's upload-confirmation logic doesn't account for that.
- This reddened both v0.4.0 (run 29606320295) and v0.5.0 (run 29712291883) even though all 11 assets landed on the release correctly.
- Upgrades the action to `@v2`, which reworked asset upload/confirmation. No change to installer filenames or any other user-visible behavior.

## Notes
- Preferred fix per the bead — invisible, no filename changes. The belt-and-braces `artifactName` change (removing spaces) is intentionally NOT included; only apply it if a real tagged release proves v2 alone doesn't fix the false failure.
- The failure-path gate in `release-complete` is unchanged — it still hard-fails when `create-release` genuinely fails.

## Test plan
- [x] YAML syntax validated (`python3 -c "yaml.safe_load(...)"`)
- [ ] Verify on the next real tagged release: run completes GREEN end to end, all 11 assets present with sane sizes, Create Release step succeeds
- [ ] Confirm the failure gate still fires if a real upload failure occurs (no regression from this change — logic untouched)

Closes bead: mea-422