### PR TITLE
fix(plugins): dedupe duplicate-id plugin folders, broaden .bak/.staging skip

### DIFF
--- a/src/main/__tests__/plugin-loader-backup-dir-skip.test.ts
+++ b/src/main/__tests__/plugin-loader-backup-dir-skip.test.ts
@@ -98,6 +98,42 @@ describe('PluginLoader.discoverPlugins skips update-swap bookkeeping directories
     expect(results[0].manifest.version).toBe('2.0.0');
   });
 
+  it('ignores a human-renamed `.bak-<version>` rollback folder (mea-4yh concrete incident)', async () => {
+    // Exact reported layout: updating fictionlab-agent-factory to v0.2.0 left
+    // a rollback folder named `fictionlab-agent-factory.bak-0.1.1` (the old
+    // `.bak` renamed with the version for clarity) beside the canonical
+    // install. The pre-mea-4yh filter only matched an EXACT `.bak` suffix,
+    // so this versioned variant slipped through and got discovered as a
+    // duplicate-id plugin, which then won the id-keyed dependency sort.
+    writeManifest(
+      path.join(pluginsDir, 'fictionlab-agent-factory'),
+      'fictionlab-agent-factory',
+      '0.2.0'
+    );
+    writeManifest(
+      path.join(pluginsDir, 'fictionlab-agent-factory.bak-0.1.1'),
+      'fictionlab-agent-factory',
+      '0.1.1'
+    );
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].manifest.version).toBe('0.2.0');
+  });
+
+  it('does not discover a dot-prefixed sibling folder even with a valid plugin.json', async () => {
+    writeManifest(path.join(pluginsDir, 'fictionlab-kanban'), 'fictionlab-kanban', '2.0.0');
+    writeManifest(path.join(pluginsDir, '.fictionlab-kanban.staging-tmp'), 'fictionlab-kanban', '2.1.0');
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].manifest.version).toBe('2.0.0');
+  });
+
   it('does not discover a plugin at all when only a backup copy exists (no phantom fallback)', async () => {
     writeManifest(
       path.join(pluginsDir, 'fictionlab-workflow.backup-1769903090229'),

--- a/src/main/__tests__/plugin-loader-duplicate-id-dedup.test.ts
+++ b/src/main/__tests__/plugin-loader-duplicate-id-dedup.test.ts
@@ -1,0 +1,100 @@
+/**
+ * mea-4yh: belt-and-suspenders coverage for PluginLoader.discoverPlugins()'s
+ * duplicate-id dedup pass. The name-based `.bak`/`.staging`/dot-prefix skip
+ * (see plugin-loader-backup-dir-skip.test.ts) is the first line of defense,
+ * but any two folders that both declare the same plugin id -- regardless of
+ * naming -- must never both come back `valid`, or sortByDependencies' id-
+ * keyed map will silently pick whichever happened to be discovered last.
+ */
+
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => (global as any).__testUserDataDir),
+    getVersion: jest.fn(() => '1.0.0'),
+  },
+}));
+
+import { PluginLoader } from '../plugin-loader';
+
+function writeManifest(dir: string, id: string, version: string): void {
+  fs.ensureDirSync(dir);
+  fs.writeJsonSync(path.join(dir, 'plugin.json'), {
+    id,
+    name: id,
+    version,
+    description: 'test fixture',
+    author: 'test',
+    fictionLabVersion: '^1.0.0',
+    pluginType: 'feature',
+    entry: { main: 'index.js' },
+    permissions: [],
+  });
+  fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = {};');
+}
+
+describe('PluginLoader.discoverPlugins duplicate-id dedup', () => {
+  let tmpRoot: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fictionlab-plugin-dedup-'));
+    (global as any).__testUserDataDir = tmpRoot;
+    pluginsDir = path.join(tmpRoot, 'plugins');
+    fs.ensureDirSync(pluginsDir);
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpRoot);
+    delete (global as any).__testUserDataDir;
+  });
+
+  it('prefers the folder whose name exactly matches the plugin id over a differently-named sibling', async () => {
+    writeManifest(path.join(pluginsDir, 'fictionlab-agent-factory'), 'fictionlab-agent-factory', '0.2.0');
+    // Named differently enough to dodge the .bak/.staging/dot-prefix name filter,
+    // but still declares the same id in its own plugin.json.
+    writeManifest(path.join(pluginsDir, 'fictionlab-agent-factory-old-copy'), 'fictionlab-agent-factory', '0.1.1');
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(2);
+
+    const valid = results.filter(r => r.valid);
+    expect(valid).toHaveLength(1);
+    expect(path.basename(valid[0].path)).toBe('fictionlab-agent-factory');
+    expect(valid[0].manifest.version).toBe('0.2.0');
+
+    const ignored = results.find(r => !r.valid);
+    expect(ignored).toBeDefined();
+    expect(path.basename(ignored!.path)).toBe('fictionlab-agent-factory-old-copy');
+    expect(ignored!.errors?.some(e => e.includes('duplicate plugin id'))).toBe(true);
+  });
+
+  it('breaks ties by higher semver version when neither folder name equals the id', async () => {
+    writeManifest(path.join(pluginsDir, 'copy-a'), 'fictionlab-kanban', '1.5.0');
+    writeManifest(path.join(pluginsDir, 'copy-b'), 'fictionlab-kanban', '2.0.0');
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    const valid = results.filter(r => r.valid);
+    expect(valid).toHaveLength(1);
+    expect(valid[0].manifest.version).toBe('2.0.0');
+    expect(path.basename(valid[0].path)).toBe('copy-b');
+  });
+
+  it('leaves non-colliding plugins untouched', async () => {
+    writeManifest(path.join(pluginsDir, 'fictionlab-kanban'), 'fictionlab-kanban', '1.0.0');
+    writeManifest(path.join(pluginsDir, 'fictionlab-agent-factory'), 'fictionlab-agent-factory', '1.0.0');
+
+    const loader = new PluginLoader();
+    const results = await loader.discoverPlugins();
+
+    expect(results).toHaveLength(2);
+    expect(results.every(r => r.valid)).toBe(true);
+  });
+});

--- a/src/main/handlers/plugin-update-handlers.ts
+++ b/src/main/handlers/plugin-update-handlers.ts
@@ -93,9 +93,13 @@ export function registerPluginUpdateHandlers() {
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         // Skip update-swap bookkeeping directories (see plugin-update-swap.ts).
+        // `.includes(...)` (not `.endsWith(...)`) so a human-renamed rollback
+        // copy like `<id>.bak-0.1.1` is still recognized as a `.bak` sibling
+        // (mea-4yh); dot-prefixed folders are skipped too.
         if (
-          entry.name.endsWith('.bak') ||
-          entry.name.endsWith('.staging') ||
+          entry.name.startsWith('.') ||
+          entry.name.includes('.bak') ||
+          entry.name.includes('.staging') ||
           entry.name.includes('.backup-')
         ) {
           continue;

--- a/src/main/plugin-loader.ts
+++ b/src/main/plugin-loader.ts
@@ -69,14 +69,20 @@ export class PluginLoader {
         // for crash rollback, and `.staging` is a not-yet-swapped-in update.
         // Both are full copies of a real plugin (same id, own plugin.json),
         // so without this guard they'd be "discovered" as duplicate plugins.
-        // Also skip the older ad-hoc `.backup-<timestamp>` naming in case any
-        // are still on disk from before this change.
+        // Matched with `.includes(...)` rather than `.endsWith(...)` because
+        // a human-renamed rollback copy (e.g. `<id>.bak-0.1.1`, keeping the
+        // old version in the name for clarity) is still a `.bak` sibling and
+        // must not slip through (mea-4yh: this exact naming pinned a stale
+        // plugin renderer bundle after an update). Also skip the older
+        // ad-hoc `.backup-<timestamp>` naming, and any dot-prefixed folder
+        // (hidden/staging scratch dirs are never real plugins).
         if (
-          entry.name.endsWith('.bak') ||
-          entry.name.endsWith('.staging') ||
+          entry.name.startsWith('.') ||
+          entry.name.includes('.bak') ||
+          entry.name.includes('.staging') ||
           entry.name.includes('.backup-')
         ) {
-          logWithCategory('debug', LogCategory.SYSTEM, `Skipping update-swap directory: ${entry.name}`);
+          logWithCategory('debug', LogCategory.SYSTEM, `Skipping update-swap/hidden directory: ${entry.name}`);
           continue;
         }
 
@@ -102,11 +108,77 @@ export class PluginLoader {
 
       logWithCategory('info', LogCategory.SYSTEM, `Discovered ${results.length} plugins (${results.filter(r => r.valid).length} valid)`);
 
-      return results;
+      return this.dedupeById(results);
     } catch (error: any) {
       logWithCategory('error', LogCategory.SYSTEM, 'Error discovering plugins:', error);
       return [];
     }
+  }
+
+  /**
+   * Belt-and-suspenders guard against two discovered folders declaring the
+   * same plugin id (e.g. a `.bak`/`.staging` sibling that slipped past the
+   * name filter above, or any other stray copy). Without this, whichever
+   * folder happened to sort last would silently win in sortByDependencies'
+   * id-keyed map -- the exact "loads the wrong copy" failure mode this
+   * dedup exists to prevent (mea-4yh).
+   *
+   * Preference order: folder name exactly equal to the plugin id, then
+   * higher semver version. Losers are marked invalid (with a WARN naming
+   * the ignored folder and why) rather than dropped, so callers still see
+   * every discovered path.
+   */
+  private dedupeById(results: PluginDiscoveryResult[]): PluginDiscoveryResult[] {
+    const byId = new Map<string, PluginDiscoveryResult[]>();
+
+    for (const result of results) {
+      if (!result.valid) continue;
+      const group = byId.get(result.manifest.id) ?? [];
+      group.push(result);
+      byId.set(result.manifest.id, group);
+    }
+
+    const losers = new Set<PluginDiscoveryResult>();
+
+    for (const [id, group] of byId) {
+      if (group.length <= 1) continue;
+
+      const winner = group.reduce((best, candidate) => {
+        const bestIsExactId = path.basename(best.path) === id;
+        const candidateIsExactId = path.basename(candidate.path) === id;
+
+        if (candidateIsExactId && !bestIsExactId) return candidate;
+        if (bestIsExactId && !candidateIsExactId) return best;
+
+        return semver.gt(candidate.manifest.version, best.manifest.version) ? candidate : best;
+      });
+
+      for (const candidate of group) {
+        if (candidate === winner) continue;
+        losers.add(candidate);
+        logWithCategory(
+          'warn',
+          LogCategory.SYSTEM,
+          `Duplicate plugin id '${id}': ignoring folder '${path.basename(candidate.path)}' (v${candidate.manifest.version}) in favor of '${path.basename(winner.path)}' (v${winner.manifest.version})`
+        );
+      }
+    }
+
+    if (losers.size === 0) {
+      return results;
+    }
+
+    return results.map(result => {
+      if (!losers.has(result)) return result;
+      return {
+        ...result,
+        valid: false,
+        errors: [
+          ...(result.errors ?? []),
+          `Ignored: duplicate plugin id '${result.manifest.id}' -- another folder for this id was preferred`,
+        ],
+      };
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- The plugin loader's `.bak`/`.staging` skip only matched an exact suffix (`endsWith`), so a human-renamed rollback folder like `fictionlab-agent-factory.bak-0.1.1` slipped through discovery as a second valid plugin with the same id.
- `sortByDependencies` keys its result map by plugin id, so whichever duplicate-id folder was iterated last silently won — pinning the app to a stale renderer bundle with zero warning to the user. Confirmed as the live incident: v0.2.0 installed correctly, but `.bak-0.1.1` sorted after it and overwrote the winner.
- Broadened the name filter (`.includes` instead of `endsWith`, plus dot-prefixed folders) in both `plugin-loader.ts` discovery and the `plugin:list-installed` scan.
- Added a belt-and-suspenders dedup pass in `discoverPlugins()`: if two folders still declare the same id, prefer the folder named exactly after the id, then higher semver version, and log a WARN naming the ignored folder + reason.

## Test plan
- [x] New test: exact incident layout (`<id>` v0.2.0 + `<id>.bak-0.1.1` v0.1.1) discovers only the canonical version.
- [x] New test: dot-prefixed sibling with a valid `plugin.json` is never discovered.
- [x] New test suite for the id-dedup fallback: folder-name-equals-id wins over a differently-named duplicate; ties break by higher semver; non-colliding plugins are untouched.
- [x] `npx jest src/main` — 391/392 passing (1 pre-existing, unrelated failure in `provider-manager.test.ts`, confirmed present on `develop` before this change).
- [x] `tsc --noEmit` error count unchanged vs `develop` (98 pre-existing renderer-test errors, none in touched files).

Closes bead: mea-4yh