### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fictionlab",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fictionlab",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fictionlab",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI-powered writing workspace for authors - your creative laboratory",
   "main": "dist/main/index.js",
   "author": "FictionLab",


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json`, matching the v0.5.0 convention (#248). **No tag is pushed by this PR.**

## Why this is prepped but not cut

`release.yml` triggers only on a `v*.*.*` tag push. Merging this PR is therefore safe and publishes nothing. Cutting the release — pushing the `v0.5.1` tag, which builds real Win/Mac/Linux installers and publishes a public GitHub Release — needs operator/Rebecca authorization per repo convention (same gate as `mea-uhg`/v0.5.0).

**Requesting that authorization here.** Once this PR is merged and develop CI is green on the merge commit (all 3 required OS legs), the remaining steps are: push annotated tag `v0.5.1`, verify `release.yml` publishes with full assets. Please merge + give the go-ahead to tag, or let me know if you'd rather tag it yourself.

## Version choice

0.5.1, not 0.6.0 — three fixes (CSP `data:` img-src restoring the Agent Factory 0.6.7 topo backdrop, plugin-folder dedupe, `action-gh-release` v2 fixing the recurring false-red release run) plus one scaffold (`chapter-editor-plugin`, not yet user-facing), per `RELEASE.md` SemVer guidance.

## Contents (4 commits since v0.5.0)

| PR | Bead | Change |
|---|---|---|
| #255 | mea-i38 | fix(renderer): add `data:` to img-src CSP for plugin data-URL images |
| #254 | mea-jyn | feat(chapter-editor-plugin): scaffold + Tiptap Core editing/comments |
| #253 | mea-4yh | fix(plugins): dedupe duplicate-id plugin folders, broaden .bak/.staging skip |
| #252 | — | fix(release): upgrade action-gh-release to v2 (fixes recurring false-red release run, mea-uhg/mea-422) |

## Testing

`npm run test:ci` run locally on this commit: 58 suites / 717 tests passed. develop HEAD (71f79d1) is already CI-green on all required OS legs (windows-latest, macos-latest, ubuntu-latest) per the existing "Build Electron App" workflow run.

## After tagging

Rebecca: once v0.5.1 installs, the Agent Factory topo backdrop (agent-factory 0.6.7, already installed) should render correctly again — that's the mea-i38 fix. No plugin-contract skew this window; no install-order hazard.

Closes bead: mea-d8o