### PR TITLE
fix(renderer): migrate workflows view onto universal plugin-view path

### DIFF
--- a/src/renderer/components/ViewRouter.ts
+++ b/src/renderer/components/ViewRouter.ts
@@ -47,19 +47,13 @@ export class ViewRouter {
   private initPromise: Promise<void> | null = null;
 
   // Plugin-dependent views: view id -> plugin id that provides it.
-  // 'workflows' is still host-bundled (WorkflowsViewReact) so it stays
-  // hardcoded; plugin-shipped views (renderer bundles, e.g. the kanban
-  // board from fictionlab-kanban) are added dynamically from their
-  // manifests via registerPluginViewRequirement().
-  private pluginRequiredViews: Map<string, string> = new Map([
-    ['workflows', 'fictionlab-workflow']
-  ]);
+  // Populated dynamically from every active plugin's manifest (entry.renderer
+  // + ui.mainView) via registerPluginViewRequirement() — see pluginViewLoader.
+  private pluginRequiredViews: Map<string, string> = new Map();
 
   // Human-readable labels for plugin-provided views (from ui.mainViewLabel),
   // used by the "plugin required" screen and top-bar title fallback.
-  private pluginViewLabels: Map<string, string> = new Map([
-    ['workflows', 'Workflows']
-  ]);
+  private pluginViewLabels: Map<string, string> = new Map();
 
   constructor(options: ViewRouterOptions) {
     this.container = options.container;
@@ -113,8 +107,6 @@ export class ViewRouter {
 
       // New views
       await register('plugins', () => import('../views/PluginsLauncher.js'), 'PluginsLauncher');
-
-      // Note: WorkflowsViewReact is registered manually in renderer.ts (uses React via import map)
 
       await register('library', () => import('../views/LibraryView.js'), 'LibraryView');
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -10,7 +10,6 @@ import { loadClientOptions, setupClientSelectionListeners } from './client-selec
 import { Sidebar } from './components/Sidebar.js';
 import { TopBar } from './components/TopBar.js';
 import { ViewRouter } from './components/ViewRouter.js';
-import { WorkflowsViewReact } from './views/WorkflowsViewReact.js';
 import { syncPluginProvidedViews } from './services/pluginViewLoader.js';
 // Legacy imports (still used by view wrappers)
 import { initializeSetupTab } from './components/SetupTab.js';
@@ -1045,15 +1044,6 @@ async function init(): Promise<void> {
   // Initialize ViewRouter (async - registers all views)
   await viewRouter.initialize();
 
-  // Register React-based views manually only if their plugins are installed
-  // WorkflowsViewReact requires fictionlab-workflow plugin
-  if (sidebar.isPluginInstalled('fictionlab-workflow')) {
-    viewRouter.registerView('workflows', WorkflowsViewReact);
-    console.log('[Renderer] WorkflowsViewReact registered (plugin installed)');
-  } else {
-    console.log('[Renderer] WorkflowsViewReact not registered (plugin not installed)');
-  }
-
   // Plugin-provided views (universal path, fictionlab-workflow#8): any
   // active plugin whose manifest declares entry.renderer + ui.mainView gets
   // its renderer bundle imported and its view registered by id — the kanban
@@ -1075,27 +1065,6 @@ async function init(): Promise<void> {
 
       // Reload sidebar navigation
       await sidebar.updateNavigation();
-
-      // Re-register plugin-dependent views
-      if (sidebar.isPluginInstalled('fictionlab-workflow')) {
-        const wasRegistered = viewRouter['viewClasses'].has('workflows');
-        if (!wasRegistered) {
-          viewRouter.registerView('workflows', WorkflowsViewReact);
-          console.log('[Renderer] WorkflowsViewReact registered after plugin install');
-        }
-
-        // If we're currently trying to view workflows but it was showing "Plugin Required",
-        // re-navigate to actually load the view now that the plugin is ready
-        const currentViewId = viewRouter['currentViewId'];
-        const savedView = localStorage.getItem('fictionlab-active-view');
-        if (savedView === 'workflows' && (!currentViewId || currentViewId !== 'workflows' || !wasRegistered)) {
-          console.log('[Renderer] Re-navigating to workflows view after plugin activation');
-          await viewRouter.navigateTo('workflows');
-        }
-      } else {
-        // Remove workflows view if plugin was uninstalled
-        viewRouter.clearCache('workflows');
-      }
 
       // Re-sync plugin-provided views (imports newly-available renderer
       // bundles, unregisters ones whose plugin went away).
@@ -1234,12 +1203,6 @@ async function init(): Promise<void> {
     // Update sidebar navigation
     await sidebar.updateNavigation();
 
-    // Register workflow view if the workflow plugin was installed
-    if (pluginId === 'fictionlab-workflow' && sidebar.isPluginInstalled('fictionlab-workflow')) {
-      viewRouter.registerView('workflows', WorkflowsViewReact);
-      console.log('[Renderer] WorkflowsViewReact registered after plugin installation');
-    }
-
     // Load any renderer bundle the newly-installed plugin provides and
     // register its view + sidebar entry (universal path — see
     // pluginViewLoader).
@@ -1254,11 +1217,6 @@ async function init(): Promise<void> {
 
     // Update sidebar navigation
     await sidebar.updateNavigation();
-
-    // If workflow plugin was uninstalled and user is on workflows view, navigate away
-    if (pluginId === 'fictionlab-workflow' && viewRouter.getCurrentViewId() === 'workflows') {
-      await viewRouter.navigateTo('dashboard');
-    }
 
     // Unregister any plugin-provided views the uninstalled plugin was
     // serving, and don't strand the user on one of them.


### PR DESCRIPTION
## Summary
- Removes renderer.ts's four workflows-specific special cases (static import + initial registerView, the plugin-state-changed re-register/re-navigate block, the plugin-installed listener's registerView, and the plugin-uninstalled listener's manual navigate-away) — the workflow plugin already ships `entry.renderer` + `ui.mainView` (mea-cjl.2) and its `WorkflowsViewReact` default-export satisfies the same `View` contract the kanban board uses, so `syncPluginProvidedViews` already covers register/unregister/re-navigate generically.
- Drops ViewRouter's hardcoded `pluginRequiredViews`/`pluginViewLabels` 'workflows' entries — `registerPluginViewRequirement()` populates these dynamically before the first `navigateTo`, since `syncPluginViews()` runs before initial navigation.
- Does **not** delete core's `src/renderer/views/WorkflowsViewReact.tsx` (that file deletion is mea-cjl.5's scope) — only its usage from renderer.ts is removed, so it's currently dead/unimported code left for that follow-up bead to remove.

## Test plan
- [x] `npm run build` (tsc renderer + main + asset copy) succeeds
- [x] `npx jest --testPathPatterns=__tests__` — same 5 pre-existing failing suites as before this change (repository-manager/build-orchestrator/provider-manager/plugin-github-updater/ProviderSelector a11y — all unrelated to renderer.ts/ViewRouter, confirmed no reference to either file)
- [x] `npx playwright test e2e/pluginless.spec.ts` — all 5 pass (no dangling workflows nav entry, no plugin-required leakage)
- [x] `npx playwright test e2e/smoke.spec.ts` — all 4 pass

Closes bead: mea-8n0