### PR TITLE
feat: publish author/series/chapter/character/scene ports (3002-3005, 3009) to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,11 @@ services:
       - "${OUTLINE_PORT}:3013"  # Outline Server (host side remappable, container fixed at 3013)
       - "${KANBAN_PORT}:3015"  # Kanban Server (host side remappable, container fixed at 3015)
       - "${STORY_ANALYSIS_PORT}:3016"  # Story Analysis Server (host side remappable, container fixed at 3016)
+      - "${SERIES_PORT}:3002"  # Series Planning Server (host side remappable, container fixed at 3002)
+      - "${CHAPTER_PORT}:3003"  # Chapter Planning Server (host side remappable, container fixed at 3003)
+      - "${CHARACTER_PORT}:3004"  # Character Server (host side remappable, container fixed at 3004)
+      - "${SCENE_PORT}:3005"  # Scene Server (host side remappable, container fixed at 3005)
+      - "${AUTHOR_PORT}:3009"  # Author Server (host side remappable, container fixed at 3009)
     environment:
       # PRIMARY: Use PgBouncer for connection pooling (internal Docker network port)
       # CRITICAL: Use container name and INTERNAL port (6432), NOT the external ${PGBOUNCER_PORT} variable

--- a/src/main/env-config.ts
+++ b/src/main/env-config.ts
@@ -34,6 +34,11 @@ export interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   STORY_ANALYSIS_PORT: number;
+  SERIES_PORT: number;
+  CHAPTER_PORT: number;
+  CHARACTER_PORT: number;
+  SCENE_PORT: number;
+  AUTHOR_PORT: number;
   GITHUB_TOKEN?: string;
   /**
    * Fine-grained GitHub PAT scoped ONLY to RLRyals/fictionlab-workflow,
@@ -63,6 +68,11 @@ export const DEFAULT_CONFIG: EnvConfig = {
   OUTLINE_PORT: 3013,
   KANBAN_PORT: 3015,
   STORY_ANALYSIS_PORT: 3016,
+  SERIES_PORT: 3002,
+  CHAPTER_PORT: 3003,
+  CHARACTER_PORT: 3004,
+  SCENE_PORT: 3005,
+  AUTHOR_PORT: 3009,
   GITHUB_TOKEN: '',
   GITHUB_PLUGINS_TOKEN: '',
 };
@@ -475,6 +485,11 @@ export async function checkAllPortsAndSuggestAlternatives(
     { port: config.OUTLINE_PORT, name: 'Outline Server', key: 'OUTLINE_PORT' as const },
     { port: config.KANBAN_PORT, name: 'Kanban Server', key: 'KANBAN_PORT' as const },
     { port: config.STORY_ANALYSIS_PORT, name: 'Story Analysis Server', key: 'STORY_ANALYSIS_PORT' as const },
+    { port: config.SERIES_PORT, name: 'Series Planning Server', key: 'SERIES_PORT' as const },
+    { port: config.CHAPTER_PORT, name: 'Chapter Planning Server', key: 'CHAPTER_PORT' as const },
+    { port: config.CHARACTER_PORT, name: 'Character Server', key: 'CHARACTER_PORT' as const },
+    { port: config.SCENE_PORT, name: 'Scene Server', key: 'SCENE_PORT' as const },
+    { port: config.AUTHOR_PORT, name: 'Author Server', key: 'AUTHOR_PORT' as const },
   ];
 
   // Check configurable ports
@@ -657,6 +672,21 @@ export function parseEnvFile(content: string): Partial<EnvConfig> {
         case 'STORY_ANALYSIS_PORT':
           config.STORY_ANALYSIS_PORT = parseInt(unquotedValue, 10);
           break;
+        case 'SERIES_PORT':
+          config.SERIES_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'CHAPTER_PORT':
+          config.CHAPTER_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'CHARACTER_PORT':
+          config.CHARACTER_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'SCENE_PORT':
+          config.SCENE_PORT = parseInt(unquotedValue, 10);
+          break;
+        case 'AUTHOR_PORT':
+          config.AUTHOR_PORT = parseInt(unquotedValue, 10);
+          break;
         case 'GITHUB_TOKEN':
           config.GITHUB_TOKEN = unquotedValue;
           break;
@@ -765,6 +795,11 @@ export function formatEnvFile(config: EnvConfig): string {
     `OUTLINE_PORT=${config.OUTLINE_PORT}`,
     `KANBAN_PORT=${config.KANBAN_PORT}`,
     `STORY_ANALYSIS_PORT=${config.STORY_ANALYSIS_PORT}`,
+    `SERIES_PORT=${config.SERIES_PORT}`,
+    `CHAPTER_PORT=${config.CHAPTER_PORT}`,
+    `CHARACTER_PORT=${config.CHARACTER_PORT}`,
+    `SCENE_PORT=${config.SCENE_PORT}`,
+    `AUTHOR_PORT=${config.AUTHOR_PORT}`,
   ];
 
   // Only include GITHUB_TOKEN if it's set
@@ -884,6 +919,31 @@ export function validateConfig(config: EnvConfig): { valid: boolean; errors: str
   const storyAnalysisPortValidation = validatePort(config.STORY_ANALYSIS_PORT);
   if (!storyAnalysisPortValidation.valid) {
     errors.push(`Story Analysis port: ${storyAnalysisPortValidation.error}`);
+  }
+
+  const seriesPortValidation = validatePort(config.SERIES_PORT);
+  if (!seriesPortValidation.valid) {
+    errors.push(`Series Planning port: ${seriesPortValidation.error}`);
+  }
+
+  const chapterPortValidation = validatePort(config.CHAPTER_PORT);
+  if (!chapterPortValidation.valid) {
+    errors.push(`Chapter Planning port: ${chapterPortValidation.error}`);
+  }
+
+  const characterPortValidation = validatePort(config.CHARACTER_PORT);
+  if (!characterPortValidation.valid) {
+    errors.push(`Character port: ${characterPortValidation.error}`);
+  }
+
+  const scenePortValidation = validatePort(config.SCENE_PORT);
+  if (!scenePortValidation.valid) {
+    errors.push(`Scene port: ${scenePortValidation.error}`);
+  }
+
+  const authorPortValidation = validatePort(config.AUTHOR_PORT);
+  if (!authorPortValidation.valid) {
+    errors.push(`Author port: ${authorPortValidation.error}`);
   }
 
   // Validate auth token

--- a/src/main/mcp-system.ts
+++ b/src/main/mcp-system.ts
@@ -679,6 +679,11 @@ async function execDockerCompose(
         OUTLINE_PORT: String(config.OUTLINE_PORT),
         KANBAN_PORT: String(config.KANBAN_PORT),
         STORY_ANALYSIS_PORT: String(config.STORY_ANALYSIS_PORT),
+        SERIES_PORT: String(config.SERIES_PORT),
+        CHAPTER_PORT: String(config.CHAPTER_PORT),
+        CHARACTER_PORT: String(config.CHARACTER_PORT),
+        SCENE_PORT: String(config.SCENE_PORT),
+        AUTHOR_PORT: String(config.AUTHOR_PORT),
         MCP_AUTH_TOKEN: config.MCP_AUTH_TOKEN,
         // Path to MCP config file for Docker volume mounting
         MCP_CONFIG_FILE_PATH: mcpConfigPath,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -81,6 +81,11 @@ interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   STORY_ANALYSIS_PORT: number;
+  SERIES_PORT: number;
+  CHAPTER_PORT: number;
+  CHARACTER_PORT: number;
+  SCENE_PORT: number;
+  AUTHOR_PORT: number;
   GITHUB_TOKEN?: string;
   /** Fine-grained PAT for the private plugin repo (bead mea-6tt). */
   GITHUB_PLUGINS_TOKEN?: string;

--- a/src/renderer/components/ServicesTab.ts
+++ b/src/renderer/components/ServicesTab.ts
@@ -41,6 +41,11 @@ interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   STORY_ANALYSIS_PORT: number;
+  SERIES_PORT: number;
+  CHAPTER_PORT: number;
+  CHARACTER_PORT: number;
+  SCENE_PORT: number;
+  AUTHOR_PORT: number;
 }
 
 /**
@@ -110,7 +115,7 @@ const MCP_SERVERS: Array<{
  * A single row in the Ports settings table
  */
 interface PortRowDefinition {
-  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT' | 'OUTLINE_PORT' | 'KANBAN_PORT' | 'STORY_ANALYSIS_PORT';
+  key: 'POSTGRES_PORT' | 'PGBOUNCER_PORT' | 'MCP_CONNECTOR_PORT' | 'HTTP_SSE_PORT' | 'DB_ADMIN_PORT' | 'NPE_PORT' | 'WORKFLOW_MANAGER_PORT' | 'OUTLINE_PORT' | 'KANBAN_PORT' | 'STORY_ANALYSIS_PORT' | 'SERIES_PORT' | 'CHAPTER_PORT' | 'CHARACTER_PORT' | 'SCENE_PORT' | 'AUTHOR_PORT';
   name: string;
 }
 
@@ -128,6 +133,11 @@ const PORT_ROWS: PortRowDefinition[] = [
   { key: 'OUTLINE_PORT', name: 'Outline Server' },
   { key: 'KANBAN_PORT', name: 'Kanban Server' },
   { key: 'STORY_ANALYSIS_PORT', name: 'Story Analysis Server' },
+  { key: 'SERIES_PORT', name: 'Series Planning Server' },
+  { key: 'CHAPTER_PORT', name: 'Chapter Planning Server' },
+  { key: 'CHARACTER_PORT', name: 'Character Server' },
+  { key: 'SCENE_PORT', name: 'Scene Server' },
+  { key: 'AUTHOR_PORT', name: 'Author Server' },
 ];
 
 export class ServicesTab {

--- a/src/renderer/components/__tests__/ServicesTab.test.ts
+++ b/src/renderer/components/__tests__/ServicesTab.test.ts
@@ -61,6 +61,11 @@ const CONFIG_FIXTURE = {
   OUTLINE_PORT: 8767,
   KANBAN_PORT: 8768,
   STORY_ANALYSIS_PORT: 8769,
+  SERIES_PORT: 8770,
+  CHAPTER_PORT: 8771,
+  CHARACTER_PORT: 8772,
+  SCENE_PORT: 8773,
+  AUTHOR_PORT: 8774,
 };
 
 /**
@@ -196,7 +201,7 @@ describe('Services tab (issue #124)', () => {
     expect(container.textContent).toContain('Docker Desktop');
 
     const portRows = document.querySelectorAll('#ports-table-body tr');
-    expect(portRows.length).toBe(10);
+    expect(portRows.length).toBe(15);
   });
 
   it('shows PostgreSQL connection info (host, port, database) from the env config', async () => {

--- a/src/renderer/env-config-handlers.ts
+++ b/src/renderer/env-config-handlers.ts
@@ -19,6 +19,11 @@ interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   STORY_ANALYSIS_PORT: number;
+  SERIES_PORT: number;
+  CHAPTER_PORT: number;
+  CHARACTER_PORT: number;
+  SCENE_PORT: number;
+  AUTHOR_PORT: number;
   GITHUB_TOKEN?: string;
   GITHUB_PLUGINS_TOKEN?: string;
 }
@@ -239,6 +244,11 @@ export async function saveEnvConfig(event: Event): Promise<void> {
       OUTLINE_PORT: currentEnvConfig?.OUTLINE_PORT || 3013,
       KANBAN_PORT: currentEnvConfig?.KANBAN_PORT || 3015,
       STORY_ANALYSIS_PORT: currentEnvConfig?.STORY_ANALYSIS_PORT || 3016,
+      SERIES_PORT: currentEnvConfig?.SERIES_PORT || 3002,
+      CHAPTER_PORT: currentEnvConfig?.CHAPTER_PORT || 3003,
+      CHARACTER_PORT: currentEnvConfig?.CHARACTER_PORT || 3004,
+      SCENE_PORT: currentEnvConfig?.SCENE_PORT || 3005,
+      AUTHOR_PORT: currentEnvConfig?.AUTHOR_PORT || 3009,
       // Not exposed as a form field on this form - preserve existing value so a
       // re-save doesn't silently erase a stored GitHub token
       GITHUB_TOKEN: currentEnvConfig?.GITHUB_TOKEN,

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -76,6 +76,11 @@ interface EnvConfig {
   OUTLINE_PORT: number;
   KANBAN_PORT: number;
   STORY_ANALYSIS_PORT: number;
+  SERIES_PORT: number;
+  CHAPTER_PORT: number;
+  CHARACTER_PORT: number;
+  SCENE_PORT: number;
+  AUTHOR_PORT: number;
 }
 
 interface PortConflictDetail {

--- a/src/renderer/setup-wizard-handlers.ts
+++ b/src/renderer/setup-wizard-handlers.ts
@@ -732,6 +732,11 @@ async function saveEnvironmentConfig(): Promise<boolean> {
             OUTLINE_PORT: currentConfig?.OUTLINE_PORT || 3013,
             KANBAN_PORT: currentConfig?.KANBAN_PORT || 3015,
             STORY_ANALYSIS_PORT: currentConfig?.STORY_ANALYSIS_PORT || 3016,
+            SERIES_PORT: currentConfig?.SERIES_PORT || 3002,
+            CHAPTER_PORT: currentConfig?.CHAPTER_PORT || 3003,
+            CHARACTER_PORT: currentConfig?.CHARACTER_PORT || 3004,
+            SCENE_PORT: currentConfig?.SCENE_PORT || 3005,
+            AUTHOR_PORT: currentConfig?.AUTHOR_PORT || 3009,
             // Not exposed in this wizard step - preserve existing value so a re-save
             // doesn't silently erase a stored GitHub token
             GITHUB_TOKEN: currentConfig?.GITHUB_TOKEN,


### PR DESCRIPTION
## Problem (found 2026-07-28, PR FictionLab-Downloads#34 verification)

The app-generated compose (template = docker-compose.yml at this repo's root,
copied to %APPDATA%\fictionlab\docker) publishes only 3001, 3010-3013,
3015-3016. But FictionLab-Online's fiction module (modules/fiction.js SERVERS
block) targets host ports author 3009 / series-planning 3002 /
chapter-planning 3003 / scene 3005, and the manuscript-import workflow
(fld-bpe) calls the same servers -- all unreachable from the host, so those
lanes have been silently down. Same class of gap mea-0zq/mea-g5z fixed for
kanban 3015 + outline 3013 + story-analysis 3016.

## Fix

Mirrors the existing OUTLINE_PORT/KANBAN_PORT/STORY_ANALYSIS_PORT pattern
across every file it touches:

- `docker-compose.yml` -- new `${VAR}:port` mappings for SERIES_PORT (3002),
  CHAPTER_PORT (3003), CHARACTER_PORT (3004), SCENE_PORT (3005), AUTHOR_PORT
  (3009)
- `src/main/env-config.ts` -- interface, DEFAULT_CONFIG, port-conflict check
  list, parse/format, validation
- `src/main/mcp-system.ts` -- env passthrough to docker compose
- `src/preload/preload.ts`, `src/renderer/renderer.ts`,
  `src/renderer/env-config-handlers.ts`, `src/renderer/setup-wizard-handlers.ts`
  -- interface + preserved-field defaults
- `src/renderer/components/ServicesTab.ts` -- PortRowDefinition + PORT_ROWS
  (Ports settings table)
- `src/renderer/components/__tests__/ServicesTab.test.ts` -- fixture + row
  count (10 -> 15)

## Cleanup rider

A temporary override file `casey-ports.override.yml` sits in
`%APPDATA%\fictionlab\docker\` (Casey, 2026-07-28) publishing these ports
until this ships -- Rebecca can delete it once an app release with this fix
has recreated the stack.

## Test plan
- [x] `npm run build` (tsc renderer + main) passes
- [x] `npx jest src/renderer/components/__tests__/ServicesTab.test.ts` -- 10/10 pass
- [x] Full `npx jest` run: same 4 pre-existing failing suites as baseline
      (build-orchestrator/repository-manager timeouts, unrelated to ports/env
      config -- verified no PORT/EnvConfig references in those test files)
- [ ] Fresh app-managed stack recreate publishes 3002-3005 + 3009; curl each
      /health from host returns 200 (requires a real app recreate -- not run
      in this sandboxed session)

Closes bead: mea-8f3